### PR TITLE
Fixed #958: Drag-and-drop not working on IE

### DIFF
--- a/js/src/utils/utils.js
+++ b/js/src/utils/utils.js
@@ -64,6 +64,9 @@
     var assoc  = {};
     var decode = function (s) { return decodeURIComponent(s.replace(/\+/g, " ")); };
     var queryString = url.split('?')[1];
+    if (typeof queryString === "undefined") {
+      return {};
+    }
     var keyValues = queryString.split('&');
 
     for(var i in keyValues) {

--- a/js/src/workspaces/slot.js
+++ b/js/src/workspaces/slot.js
@@ -148,7 +148,7 @@
         var _this = this;
 
         url = url || text_url;
-        var manifestUrl = $.getQueryParams(url).manifest,
+        var manifestUrl = $.getQueryParams(url).manifest || url,
             canvasId = $.getQueryParams(url).canvas,
             imageInfoUrl = $.getQueryParams(url).image,
             windowConfig;

--- a/js/src/workspaces/slot.js
+++ b/js/src/workspaces/slot.js
@@ -134,7 +134,7 @@
       var _this = this;
 
       e.preventDefault();
-      var text_url = e.originalEvent.dataTransfer.getData("text/plain");
+      var text_url = e.originalEvent.dataTransfer.getData("text");
       if (text_url) {
         _this.handleDrop(text_url);
       } else {

--- a/spec/utils/utils.test.js
+++ b/spec/utils/utils.test.js
@@ -127,5 +127,9 @@ describe('Utils', function() {
       expect(queryParams.manifest).toBe("http://www.e-codices.unifr.ch/metadata/iiif/kba-0003/manifest.json");
       expect(queryParams.canvas).toBe("http://www.e-codices.unifr.ch/metadata/iiif/kba-0003/canvas/kba-0003_002r.json");
     });
+    it('should properly parse a url without query parameters', function() {
+      var queryParams = this.utils.getQueryParams('http://www.google.com');
+      expect(queryParams).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
Drag-and-drop no longer crashes on IE.

See: #958 
