### PR TITLE
Modify JsonLd.getTextValue to match algorithm outlined in spec

### DIFF
--- a/js/src/utils/jsonLd.js
+++ b/js/src/utils/jsonLd.js
@@ -1,20 +1,66 @@
 (function($) {
-  
+  /** Get the language to use for displaying the given propertyValue.
+   *
+   * Uses the algorithm described in
+   * http://iiif.io/api/presentation/2.1/#language-of-property-values
+   */
+  function getDisplayLanguage(languages, items) {
+    var itemLanguages = items.map(function(itm) {
+      if (typeof itm === 'string') {
+        return null;
+      } else {
+        return itm['@language'];
+      }
+    });
+
+    var bestLanguageMatch = null;
+    jQuery.each(languages, function(idx, lang) {
+      if (bestLanguageMatch !== null) {
+        return false;
+      } else {
+        if (itemLanguages.indexOf(lang) !== -1) {
+          bestLanguageMatch = lang;
+        }
+      }
+    });
+
+    // Only pick the first available language if **all** property values
+    // have an associated language
+    if (bestLanguageMatch === null && itemLanguages.indexOf(null) === -1) {
+      bestLanguageMatch = itemLanguages[0];
+    }
+    return bestLanguageMatch;
+  }
+
   $.JsonLd = {
     getTextValue: function(propertyValue, language) {
-      if (typeof language === 'undefined') { language = "en"; }
-      if (typeof propertyValue === 'undefined' || propertyValue === null) {return ''; }
-      else if (typeof propertyValue === 'string') { return propertyValue; }
+      var languages = window.navigator.languages || ['en'];
+      if (typeof language === 'string') {
+        languages = [language].concat(languages);
+      } else if (Array.isArray(language)) {
+        languages = language.concat(languages);
+      }
+
+      if (typeof propertyValue === 'undefined' || propertyValue === null) {
+        return '';
+      }
+      else if (typeof propertyValue === 'string') {
+        return propertyValue;
+      }
       else if (Array.isArray(propertyValue)) {
+        var displayLanguage = getDisplayLanguage(languages, propertyValue);
         var text = '';
-        jQuery.each(propertyValue, function(index, item) {
-          if (typeof item === "string") {
-            text += item;
-            text += "<br/>";
-          } else if (!text || item['@language'] === language) {
-            // {@value: ..., @language: ...}
-              text = item['@value'];
+        jQuery.each(propertyValue, function(idx, item) {
+          var textToAdd = '';
+          if (typeof item === 'string' && displayLanguage === null) {
+            textToAdd = item;
+          } else if (item['@language'] === displayLanguage) {
+            textToAdd = item['@value'];
           }
+          if (textToAdd !== '' && text !== '') {
+            text += '<br/>';
+          }
+          text += textToAdd;
         });
         return text;
       } else {

--- a/spec/utils/jsonLd.test.js
+++ b/spec/utils/jsonLd.test.js
@@ -38,8 +38,55 @@ describe('JsonLd', function () {
         "@value": "Super waahoo",
         "@language": "en"
       };
+      debugger;
       expect(Mirador.JsonLd.getTextValue(sample, 'en')).toEqual("Super waahoo");
       expect(Mirador.JsonLd.getTextValue(sample)).toEqual("Super waahoo");
     });
+
+    it('should return all values when no value has a langue associated', function() {
+      var sample = ['First value',
+                    'Second value'];
+      expect(Mirador.JsonLd.getTextValue(sample)).toEqual('First value<br/>Second value');
+    });
+
+    it('should return all values that best match the language preference', function() {
+      var sample = [
+        'This is a value without a language.',
+        {'@value': "This is an American value.",
+         '@language': "en-US"},
+        {'@value': "This ia a British value.",
+         '@language': "en-UK"},
+        'This is another value without a language.',
+        {'@value': "C'est une valeur française.",
+         '@language': "fr"}];
+      window.navigator.languages = ['en-US', 'en']
+      expect(Mirador.JsonLd.getTextValue(sample)).toEqual("This is an American value.");
+    });
+
+    it('should pick a language if all values have a language but none match the preference', function() {
+      var sample = [
+        {'@value': "This is an American value.",
+         '@language': "en-US"},
+        {'@value': "This is another American value.",
+         '@language': "en-US"},
+        {'@value': "C'est une valeur française.",
+         '@language': "fr"}];
+      window.navigator.languages = ['de-DE', 'de'];
+      expect(Mirador.JsonLd.getTextValue(sample))
+        .toEqual('This is an American value.<br/>' +
+                 'This is another American value.');
+    });
+
+    it('should return all values without an associated language if some have one, but none match the preference', function() {
+      var sample = [
+        {'@value': "C'est une valeur française.",
+         '@language': "fr"},
+        'This is a value without a language.',
+        'This is another value without a language.'];
+      window.navigator.languages = ['en-US', 'en'];
+      expect(Mirador.JsonLd.getTextValue(sample))
+        .toEqual('This is a value without a language.<br/>' +
+                 'This is another value without a language.');
+    })
   });
 });

--- a/spec/utils/jsonLd.test.js
+++ b/spec/utils/jsonLd.test.js
@@ -38,7 +38,6 @@ describe('JsonLd', function () {
         "@value": "Super waahoo",
         "@language": "en"
       };
-      debugger;
       expect(Mirador.JsonLd.getTextValue(sample, 'en')).toEqual("Super waahoo");
       expect(Mirador.JsonLd.getTextValue(sample)).toEqual("Super waahoo");
     });


### PR DESCRIPTION
This PR implements the algorithm outlined in ["4.3. Language of Property Values"](http://iiif.io/api/presentation/2.1/#language-of-property-values) in the Presentation API 2.1 specification.

It maintains complete backwards compatibility with existing code (as far as I could tell from the unit tests).

In the present implementation the browser's language preferences (as available from `window.navigator.languages`) are used, although the language(s) passed to `Mirador.JsonLd.getTextValue` always take precedence over these.