### PR TITLE
Migrate annotation loading fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![mirador banner](http://projectmirador.github.io/mirador/img/banner.jpg)
 **Mirador is a multi-repository, configurable, extensible, and easy-to-integrate viewer and annotation creation and comparison environment for IIIF resources, ranging from deep-zooming artwork, to complex manuscript objects. It provides a tiling windowed environment for comparing multiple image-based resources, synchronised structural and visual navigation of content using openSeadragon, Open Annotation compliant annotation creation and viewing on deep-zoomable canvases, metadata display, bookreading, and bookmarking.**
 ###[See a Demo](http://projectmirador.org/demo/)
-###[Getting Started](http://projectmirador.org/docs/getting-started.html)
+###[Getting Started](http://projectmirador.org/docs/docs/getting-started.html)
 
 ### Run in Development
 Mirador uses [node.js](http://nodejs.org/) and a build system to assemble, test, and manage the development resources. If you have never used these tools before, you may need to install them.
@@ -19,7 +19,7 @@ Mirador uses [node.js](http://nodejs.org/) and a build system to assemble, test,
 ### Run Tests
 `grunt test`
 
-For more information, see the [Docs](http://projectmirador.org/docs/getting-started.html), submit an [issue](https://github.com/projectmirador/mirador/issues), or ask on [slack](http://bit.ly/iiif-slack).
+For more information, see the [Docs](http://projectmirador.org/docs/docs/getting-started.html), submit an [issue](https://github.com/projectmirador/mirador/issues), or ask on [slack](http://bit.ly/iiif-slack).
 
 ### Project Diagnostics
  [![Coverage Status](https://coveralls.io/repos/github/ProjectMirador/mirador/badge.svg?branch=master&upToDate=true)](https://coveralls.io/github/ProjectMirador/mirador?branch=master&upToDate=true)

--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -153,19 +153,19 @@
           event: false
         },
         events: {
-          show: function(event, api) {
+          shown: function(event, api) {
             if (params.onTooltipShown) { params.onTooltipShown(event, api); }
           },
           hidden: function(event, api) {
             if (params.onTooltipHidden) { params.onTooltipHidden(event, api); }
+            _this.removeAllEvents(api, params);
           },
           visible: function (event, api) {
-            _this.removeAllEvents(api, params);
             _this.addViewerEvents(api, params);
           },
           move: function (event, api) {
-            _this.removeAllEvents(api, params);
-            _this.addViewerEvents(api, params);
+           // _this.removeAllEvents(api, params);
+           // _this.addViewerEvents(api, params);
           }
         }
       });
@@ -232,6 +232,8 @@
            _this.addEditorEvents(api, viewerParams);
         } else {
           _this.eventEmitter.publish('annotationInEditMode.' + _this.windowId,[oaAnno]);
+          api.destroy();
+          jQuery(api.tooltip).remove();
         }
 
         _this.eventEmitter.publish('SET_ANNOTATION_EDITING.' + _this.windowId, {

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -414,6 +414,13 @@
         _this.annoTooltip = null;
         _this.annoEditorVisible = false;
       }));
+
+      this.eventsSubscriptions.push(this.eventEmitter.subscribe("ANNOTATIONS_LIST_UPDATED",function(event,options){
+        if(options.windowId) {
+          _this.eventEmitter.publish("refreshOverlay." + _this.windowId);
+        }
+      }));
+
     },
 
     deleteShape:function(shape){

--- a/js/src/widgets/annotationsLayer.js
+++ b/js/src/widgets/annotationsLayer.js
@@ -17,6 +17,8 @@
     this.init();
   };
 
+  $.AnnotationsLayer.DISPLAY_ANNOTATIONS = 'displayAnnotations';
+
   $.AnnotationsLayer.prototype = {
 
     init: function() {

--- a/js/src/widgets/imageView.js
+++ b/js/src/widgets/imageView.js
@@ -270,8 +270,7 @@
 
       this.element.find('.mirador-osd-refresh-mode').on('click', function() {
         //update annotation list from endpoint
-        _this.eventEmitter.publish('updateAnnotationList.'+_this.windowId);
-       // _this.eventEmitter.publish('refreshOverlay.'+_this.windowId, '');
+        _this.eventEmitter.publish('updateAnnotationList.' + _this.windowId);
       });
       //Annotation specific controls
 

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -385,10 +385,10 @@
 
       _this.eventEmitter.subscribe('annotationUpdated.'+_this.id, function(event, oaAnno) {
         //first function is success callback, second is error callback
-        _this.endpoint.update(oaAnno, function() {
+        _this.endpoint.update(oaAnno, function(data) {
           jQuery.each(_this.annotationsList, function(index, value) {
-            if (value['@id'] === oaAnno['@id']) {
-              _this.annotationsList[index] = oaAnno;
+            if (value['@id'] === data['@id']) {
+              _this.annotationsList[index] = data;
               return false;
             }
           });


### PR DESCRIPTION
@aeschylus  Those are the fixes that re-renders the annotations when new annotations list has been loaded

@rsinghal  I have included the fix for https://github.com/ProjectMirador/mirador/issues/1151 inside since it is not much code