### PR TITLE
Sidepanel visibility on canvas focus

### DIFF
--- a/js/src/widgets/sidePanel.js
+++ b/js/src/widgets/sidePanel.js
@@ -187,17 +187,10 @@
 
     render: function(renderingData) {
       var _this = this;
-
       if (!this.element) {
         this.element = this.appendTo;
         jQuery(_this.template(renderingData)).appendTo(_this.appendTo);
         return;
-      }
-
-      if (renderingData.open) {
-        this.appendTo.removeClass('minimized');
-      } else {
-        this.appendTo.addClass('minimized');
       }
     },
 

--- a/spec/widgets/sidePanel.test.js
+++ b/spec/widgets/sidePanel.test.js
@@ -1,16 +1,46 @@
 describe('SidePanel', function() {
+  
+  function createSidePanel(sidePanelOptions) {
+    sidePanelOptions = sidePanelOptions || {};	
+
+    var eventEmitter = new Mirador.EventEmitter();
+    var state = new Mirador.SaveController(jQuery.extend(
+      true, {}, Mirador.DEFAULT_SETTINGS, {eventEmitter: eventEmitter}
+    ));
+    var fixture = getJSONFixture('BNF-condorcet-florus-dispersus-manifest.json');
+    var manifest = new Mirador.Manifest(fixture['@id'], 'IIIF', fixture);
+    var canvasID = manifest.getCanvases()[0]['@id'];
+    var appendTo = jQuery('<div class="sidePanel"></div>');
+
+    var config = jQuery.extend(true, {
+      windowId: '380c9e54-7561-4010-a99f-f132f5dc13fd',
+      state: state,
+      eventEmitter: eventEmitter,
+      appendTo: appendTo,
+      manifest: manifest,
+      canvasID: canvasID,
+      layersTabAvailable: false,
+      tocTabAvailable: false,
+      annotationsTabAvailable: false,
+      hasStructures: false
+    }, sidePanelOptions);
+
+    return new Mirador.SidePanel(config);
+  }
 
   beforeEach(function() {
-
+    jasmine.getJSONFixtures().fixturesPath = 'spec/fixtures';
+    this.sidePanel = createSidePanel();
   });
 
   afterEach(function() {
 
   });
 
-  xdescribe('Initialization', function() {
+  describe('Initialization', function() {
     it('should initialize', function() {
-
+      expect(this.sidePanel instanceof Mirador.SidePanel).toBeTruthy();
+      expect(this.sidePanel.appendTo).toBeTruthy();
     });
   });
 
@@ -34,8 +64,10 @@ describe('SidePanel', function() {
 
   });
 
-  xdescribe('render', function() {
-
+  describe('render', function() {
+    it('should render on initialization', function() {
+      expect(this.sidePanel.appendTo.html()).toBeTruthy();
+    });
   });
 
   xdescribe('toggle', function() {


### PR DESCRIPTION
When a canvas is focused, it takes 3 clicks on the TOC icon to open the side panel. This PR fixes that so that one click toggles the side panel open or closed.

**Steps to reproduce:**

1. Go to [http://projectmirador.org/demo/](http://projectmirador.org/demo/).
2. In the first window on the left, click on the first canvas displayed in the bottom panel to focus it.
3. Click the TOC icon to toggle the side panel. Expected result is that nothing will happen.
4. Click again. Nothing should happen.
5. Click again. Finally, the side panel should open.

**Discussion:**

The issue seems to be that most of the visibility logic is in `Mirador.Window.sidePanelVisibility()` but there's also a little bit in `Mirador.SidePanel.render()`, and those two can and do get out of sync. Based on how the code is currently written, it seemed to make the most sense to just get rid of the visibility logic in `Mirador.SidePanel` and simply let `Mirador.Window` handle that (at least for now -- maybe a later refactor will change that).

This change shouldn't impact the logic around rendering the panel open/closed initially, since `sidePanelVisibility()` is determined by `settings.sidePanelVisible` the first time it is called. The tab objects contained in the side panel appear to override that setting if they detect no content. Subsequent changes to visibility are carried through window updates as the value of `window.sidePanelVisible` is toggled. 

@rsinghal @aeschylus Do you see any problems with this change?