### PR TITLE
Don't wrap existing <a>s in metadata with another one (fixes #571)

### DIFF
--- a/js/src/widgets/metadataView.js
+++ b/js/src/widgets/metadataView.js
@@ -205,7 +205,7 @@
           textWithLinks = text,
           matches;
 
-      if (typeof text === 'string') {
+      if (typeof text === 'string' && textWithLinks.indexOf('<a ') == -1) {
         matches = text.match(regexUrl);
 
         if (matches) {

--- a/spec/fixtures/metadataFixture.json
+++ b/spec/fixtures/metadataFixture.json
@@ -23,6 +23,14 @@
     {
       "label":"Single HTML with valid elements",
       "value":"<span><b>bold</b><i>italic</i><br/><a href='http://iiif.io/'><img src='http://iiif.io/img/logo-iiif-34x30.png'></a></span>"
-	  }
+	  },
+    {
+      "label": "Single text with single URL",
+      "value": "There's an URL: http://example.com"
+    },
+    {
+      "label": "Single text with multiple URLs",
+      "value": "There's an URL: http://example.com and here's another: http://foobar.org"
+    }
   ]
 }

--- a/spec/widgets/metadataView.test.js
+++ b/spec/widgets/metadataView.test.js
@@ -63,7 +63,21 @@ describe('MetadataView', function() {
 
   });
 
-  xdescribe('addLinksToUris', function() {
+  describe('addLinksToUris', function() {
+    it('should properly wrap a single URL in an anchor tag', function() {
+      var withLinksAdded = Mirador.MetadataView.prototype.addLinksToUris(this.fixture.metadata[5].value);
+      expect(withLinksAdded).toBe("There's an URL: <a href=\"http://example.com\" target=\"_blank\">http://example.com</a>");
+    });
+    it('should properly wrap multiple URLs in anchor tags', function() {
+      var withLinksAdded = Mirador.MetadataView.prototype.addLinksToUris(this.fixture.metadata[6].value);
+      expect(withLinksAdded).toBe(
+        "There's an URL: <a href=\"http://example.com\" target=\"_blank\">http://example.com</a> and here's another: " +
+        "<a href=\"http://foobar.org\" target=\"_blank\">http://foobar.org</a>");
+    });
+    it('should not wrap links in pre-existing anchor tags with an anchor tag', function() {
+      var withLinksAdded = Mirador.MetadataView.prototype.addLinksToUris(this.fixture.metadata[4].value);
+      expect(withLinksAdded).toBe(this.fixture.metadata[4].value);
+    });
 
   });
 });


### PR DESCRIPTION
Currently, when a metadata field contains HTML with an anchor tag that targets an absolute URL, Mirador's logic for wrapping HTTP-URLs will trigger and wrap an additional anchor-tag around it.

Example: `This is a <a href="http://example.com">link</a>` will become `This is <a href="<a href="http://example.com target="_blank">http://example.com</a>">link</a>`

This fix adds a check to `Mirador.MetadataView.addLinkstoUris` that prevents this behavior.