### PR TITLE
Update travis build packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '5'
 before_install:
 - npm install
 - npm install -g bower

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.3.5",
     "karma-json-fixtures-preprocessor": "0.0.6",
-    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-phantomjs-launcher": "^1.0",
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
     "karma-spec-reporter": "^0.0.16"


### PR DESCRIPTION
This fixes the build for our integrations tests. The problem seems to have been an outdated node and karma-phantomjs-launcher dependency.

It looks like there are many outdated pinned dependencies in the Mirador repo. Potential for some investigative work down the line to update those.