### PR TITLE
Fix (partial) 1143 - Disabling annotation layer mouse mouse handlers in default mode

### DIFF
--- a/js/src/annotations/osd-region-draw-tool.js
+++ b/js/src/annotations/osd-region-draw-tool.js
@@ -25,6 +25,8 @@
     },
 
     enterDisplayAnnotations: function() {
+      this.svgOverlay.setMouseTool();
+      
       // if a user selected the pointer mode but is still actively
       // working on an annotation, don't re-render
       if (!this.svgOverlay.inEditOrCreateMode) {
@@ -65,6 +67,10 @@
     },
 
     enterDefault: function() {
+      // Removing the Tool explicitly because otherwise mouse events keep
+      // firing in default mode where they shouldn't.
+      this.svgOverlay.removeMouseTool();
+
       this.exitEditMode(false);
     },
 

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -102,21 +102,44 @@
           }
         }
       };
-      var mouseTool = jQuery.data(document.body, 'draw_canvas_' + _this.windowId);
+      
+      // Key for saving mouse tool as data attribute
+      // TODO: It seems its main use is for destroy the old paperjs mouse tool
+      // when a new Overlay is instantiated. Maybe a better scheme can be
+      // devised in the future?
+      this.mouseToolKey = 'draw_canvas_' + _this.windowId;
+      
+      this.setMouseTool();
+      this.listenForActions();
+    },
+    
+    /**
+     * Adds a Tool that handles mouse events for the paperjs scope.
+     */
+    setMouseTool: function() {
+      this.removeMouseTool();
+
+      var mouseTool = new this.paperScope.Tool();
+      mouseTool.overlay = this;
+      mouseTool.onMouseUp = this.onMouseUp;
+      mouseTool.onMouseDrag = this.onMouseDrag;
+      mouseTool.onMouseMove = this.onMouseMove;
+      mouseTool.onMouseDown = this.onMouseDown;
+      mouseTool.onDoubleClick = this.onDoubleClick;
+      mouseTool.onKeyDown = function(event){};
+
+      jQuery.data(document.body, this.mouseToolKey, mouseTool);
+    },
+    
+    /**
+     * Removes the mouse Tool from the paperjs scope.
+     */
+    removeMouseTool: function() {
+      var mouseTool = jQuery.data(document.body, this.mouseToolKey);
       if (mouseTool) {
         mouseTool.remove();
+        jQuery.removeData(document.body, this.mouseToolKey);
       }
-      mouseTool = new this.paperScope.Tool();
-      mouseTool.overlay = this;
-      mouseTool.onMouseUp = _this.onMouseUp;
-      mouseTool.onMouseDrag = _this.onMouseDrag;
-      mouseTool.onMouseMove = _this.onMouseMove;
-      mouseTool.onMouseDown = _this.onMouseDown;
-      mouseTool.onDoubleClick = _this.onDoubleClick;
-      mouseTool.onKeyDown = function(event){};
-      jQuery.data(document.body, 'draw_canvas_' + _this.windowId, mouseTool);
-
-      this.listenForActions();
     },
 
     handleDeleteShapeEvent: function (event, shape) {

--- a/js/src/viewer/manifestListItem.js
+++ b/js/src/viewer/manifestListItem.js
@@ -189,10 +189,15 @@
         if (newMaxPreviewWidth < _this.maxPreviewImagesWidth ) {
           while (_this.imagesTotalWidth >= newMaxPreviewWidth) {
             image = _this.tplData.images.pop();
-            _this.imagesTotalWidth -= (image.width + _this.margin);
+            
+            if (image) {
+              _this.imagesTotalWidth -= (image.width + _this.margin);
 
-            //remove image from dom
-            _this.element.find('img[data-image-id="'+image.id+'"]').remove();
+              //remove image from dom
+              _this.element.find('img[data-image-id="'+image.id+'"]').remove();
+            } else {
+              break;
+            }
           }
           //check if need to add ellipsis
           if (_this.remaining === 0 && _this.allImages.length - _this.tplData.images.length > 0) {

--- a/spec/annotations/annotation-utils.stub.js
+++ b/spec/annotations/annotation-utils.stub.js
@@ -5,7 +5,7 @@
   };
 
   MockItem.prototype = {
-    getItem: jasmine.createSpy().and.callFake(function() { return this }),
+    getItem: jasmine.createSpy().and.callFake(function() { return this; }),
     translateByXY: jasmine.createSpy(),
     translateByPoint: jasmine.createSpy(),
     click: jasmine.createSpy(),
@@ -22,7 +22,7 @@
       if (key === 'pivot') {
         return {
           add: jasmine.createSpy()
-        }
+        };
       }
     },
     getMask:function () {

--- a/spec/annotations/annotation-utils.test.js
+++ b/spec/annotations/annotation-utils.test.js
@@ -30,7 +30,7 @@ describe('Annotation utils', function () {
       this.y = y;
       this.add = function (point) {
         return new position(this.x + point.x, this.y + point.y);
-      }
+      };
     };
 
     describe('Icon', function () {

--- a/spec/annotations/osd-svg-overlay.test.js
+++ b/spec/annotations/osd-svg-overlay.test.js
@@ -528,6 +528,17 @@ describe('Overlay', function() {
    }
   });
 
-
+  it('set and remove mouse tool', function() {
+    var key = this.overlay.mouseToolKey;
+    var paperScope = this.overlay.paperScope;
+    
+    this.overlay.setMouseTool();
+    expect(paperScope.tools.length).toEqual(1);
+    expect(jQuery.data(document.body, key)).toBe(paperScope.tools[0]);
+    
+    this.overlay.removeMouseTool();
+    expect(paperScope.tools.length).toEqual(0);
+    expect(jQuery.data(document.body, key)).toBeUndefined();
+  });
 
 });


### PR DESCRIPTION
This PR includes a partial fix to https://github.com/ProjectMirador/mirador/issues/1143

Mouse tool for the paperScope was still triggering mouse handlers when the canvas is hidden, making "drag and select" of texts unresponsive. This change explicitly deletes the mouseTool when entering the "default" mode and creates one when entering "pointer" mode.

This is not a complete fix in that
(1) While you can drag and select in default mode, you still cannot in pointer and edit modes. It is probably  impossible to fix because of the way paper.js manages events
(2) It is could possibly a Chrome bug rather, because the problem is not occurring in FireFox or Safari. 