### PR TITLE
Catch annotation fixes

### DIFF
--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -68,7 +68,6 @@
         },
         events: {
           render: function(event, api) {
-            _this.eventEmitter.publish('annotationEditorAvailable.' + _this.windowId);
             _this.eventEmitter.publish('disableTooltips.' + _this.windowId);
 
             api.elements.tooltip.draggable();
@@ -103,6 +102,7 @@
             });
 
             _this.activeEditor.show(selector);
+            _this.eventEmitter.publish('annotationEditorAvailable.' + _this.windowId);
           }
 
         }
@@ -405,7 +405,6 @@
         'content.text': editorContainer,
         'hide.event': false
       });
-      _this.eventEmitter.publish('annotationEditorAvailable.' + this.windowId);
       //add rich text editor
       this.activeEditor = new this.editor(
         jQuery.extend({}, this.editorOptions, {
@@ -413,6 +412,7 @@
           windowId: this.windowId
         }));
       this.activeEditor.show('form#annotation-editor-'+this.windowId);
+      _this.eventEmitter.publish('annotationEditorAvailable.' + this.windowId);
       jQuery(api.elements.tooltip).removeClass("qtip-viewer");
       api.elements.tooltip.draggable();
       if (viewerParams.onEnterEditMode) {

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -247,32 +247,45 @@
         on = annotation.parent;  //need to make URI
       } else {
         var value;
-        if (typeof annotation.rangePosition === 'object') {
-          value = "xywh="+annotation.rangePosition.x+","+annotation.rangePosition.y+","+annotation.rangePosition.width+","+annotation.rangePosition.height;
-        } else {
-          value = annotation.rangePosition;
-        }
         motivation.push("oa:commenting");
-        on = { "@type" : "oa:SpecificResource",
-          "full" : annotation.uri,
-          "selector": {
-            "@type": "oa:Choice",
-            "default": {
-              "@type": "oa:FragmentSelector",
-              "value": "xywh=" + annotation.bounds.x + "," + annotation.bounds.y + "," + annotation.bounds.width + "," + annotation.bounds.height
-            },
-            "item": {
+        if (typeof annotation.rangePosition === 'object') {
+          //legacy strategy
+          value = "xywh="+annotation.rangePosition.x+","+annotation.rangePosition.y+","+annotation.rangePosition.width+","+annotation.rangePosition.height;
+          on = { "@type" : "oa:SpecificResource",
+            "full" : annotation.uri,
+            "selector": {
+                "@type": "oa:FragmentSelector",
+                "value": value
+            }
+          };
+        } else if (annotation.bounds) {
+          //dual strategy
+          value = annotation.rangePosition;
+          on = { "@type" : "oa:SpecificResource",
+            "full" : annotation.uri,
+            "selector": {
+              "@type": "oa:Choice",
+              "default": {
+                "@type": "oa:FragmentSelector",
+                "value": "xywh=" + annotation.bounds.x + "," + annotation.bounds.y + "," + annotation.bounds.width + "," + annotation.bounds.height
+              },
+              "item": {
+                "@type": "oa:SvgSelector",
+                "value": value
+              }
+            }
+          };
+        } else {
+          //2.1 strategy
+          value = annotation.rangePosition;
+          on = { "@type" : "oa:SpecificResource",
+            "full" : annotation.uri,
+            "selector": {
               "@type": "oa:SvgSelector",
               "value": value
             }
-          }
-          // ,
-          // "scope": {
-          //   "@context" : "http://www.harvard.edu/catch/oa.json",
-          //   "@type" : "catch:Viewport",
-          //   "value" : "xywh="+annotation.bounds.x+","+annotation.bounds.y+","+annotation.bounds.width+","+annotation.bounds.height
-          // }
-        };
+          };
+        }
       }
       resource.push( {
         "@type" : "dctypes:Text",
@@ -326,6 +339,7 @@
 
       var region = oaAnnotation.on.selector.item.value;
       var regionArray;
+      //always assume dual strategy
       if (region.indexOf('<svg') !== -1) {
         //this is an svg string, so don't do anything special
         annotation.rangePosition = region;
@@ -333,8 +347,8 @@
       var coords = oaAnnotation.on.selector.default.value;
       regionArray = coords.split('=')[1].split(',');
 
-      var imageUrl = $.Iiif.getImageUrl(this.imagesList[$.getImageIndexById(this.imagesList, oaAnnotation.on.full)]);
-      imageUrl = imageUrl + "/" + regionArray.join(',') + "/full/0/native.jpg";
+      var canvas = this.imagesList[$.getImageIndexById(this.imagesList, oaAnnotation.on.full)];
+      var imageUrl = $.getThumbnailForCanvas(canvas, 300);
       annotation.thumb = imageUrl;
       annotation.bounds = {"x":regionArray[0], "y":regionArray[1], "width":regionArray[2], "height":regionArray[3]};
 

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -303,7 +303,8 @@
 
     // Converts OA Annotation to endpoint format
     getAnnotationInEndpoint: function(oaAnnotation) {
-      var uris = [];
+      var _this = this,
+      uris = [];
       oaAnnotation.on.forEach(function(value) {
         if (jQuery.inArray(value.full, uris) === -1) {
           uris.push(value.full);
@@ -352,7 +353,7 @@
           "height" : Math.max.apply(null, bottom) - Math.min.apply(null, top)
         };
 
-        var canvas = this.imagesList[$.getImageIndexById(this.imagesList, uri)];
+        var canvas = _this.imagesList[$.getImageIndexById(_this.imagesList, uri)];
         var imageUrl = $.getThumbnailForCanvas(canvas, 300);
         imageUrl = imageUrl.replace('full', newRect.x+','+newRect.y+','+newRect.width+','+newRect.height);
         annotation.thumb = imageUrl;

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -40,7 +40,7 @@
     init: function() {
       this.catchOptions = {
         user: {
-          id: this.userid, 
+          id: this.userid,
           name: this.username
         },
         permissions: {
@@ -82,7 +82,7 @@
           contextId: _this.context_id,
           collectionId: _this.collection_id,
           media: options.media ? options.media : "image",
-          limit: options.limit ? options.limit : -1 
+          limit: options.limit ? options.limit : -1
         },
 
         contentType: "application/json; charset=utf-8",
@@ -109,9 +109,9 @@
 
       });
     },
-    
+
     deleteAnnotation: function(annotationID, successCallback, errorCallback) {
-      var _this = this;        
+      var _this = this;
       jQuery.ajax({
        url: this.prefix+"/destroy/"+annotationID,
        type: 'DELETE',
@@ -134,12 +134,12 @@
 
     });
     },
-    
+
     update: function(oaAnnotation, successCallback, errorCallback) {
       var annotation = this.getAnnotationInEndpoint(oaAnnotation),
       _this = this,
       annotationID = annotation.id;
-      
+
       jQuery.ajax({
         url: this.prefix+"/update/"+annotationID,
         type: 'POST',
@@ -172,7 +172,7 @@
 
     createCatchAnnotation: function(catchAnnotation, successCallback, errorCallback) {
       var _this = this;
-      
+
       jQuery.ajax({
         url: this.prefix+"/create",
         type: 'POST',
@@ -198,7 +198,7 @@
 
     userAuthorize: function(action, annotation) {
       var token, tokens, _i, _len;
-      //if this is an instructor, they have access to student annotations      
+      //if this is an instructor, they have access to student annotations
       if (this.roles && (this.roles.indexOf('Instructor') !== -1 || this.roles.indexOf('Administrator') !== -1)){
           return true;
       }
@@ -224,7 +224,7 @@
 
     //Convert Endpoint annotation to OA
     getAnnotationInOA: function(annotation) {
-      var id, 
+      var id,
       motivation = [],
       resource = [],
       on,
@@ -236,7 +236,7 @@
       if (annotation.tags.length > 0) {
         motivation.push("oa:tagging");
         jQuery.each(annotation.tags, function(index, value) {
-          resource.push({      
+          resource.push({
             "@type":"oa:Tag",
             "chars":value
           });
@@ -297,7 +297,7 @@
       var annotation = {},
       tags = [],
       text;
-      
+
       if (oaAnnotation["@id"]) {
         annotation.id = oaAnnotation["@id"];
       }
@@ -305,7 +305,7 @@
       annotation.media = "image";
       jQuery.each(oaAnnotation.resource, function(index, value) {
         if (value['@type'] === 'oa:Tag') {
-          tags.push(value.chars); 
+          tags.push(value.chars);
         } else if (value['@type'] === 'dctypes:Text') {
           text = value.chars;
         }
@@ -317,27 +317,26 @@
       annotation.contextId = this.context_id;
       annotation.collectionId = this.collection_id;
 
-      var region = oaAnnotation.on.selector.value;
+      var region = oaAnnotation.on.selector.item.value;
       var regionArray;
       if (region.indexOf('<svg') !== -1) {
         //this is an svg string, so don't do anything special
         annotation.rangePosition = region;
-      } else {
-        regionArray = region.split('=')[1].split(',');
-        annotation.rangePosition = {"x":regionArray[0], "y":regionArray[1], "width":regionArray[2], "height":regionArray[3]};
       }
+      var coords = oaAnnotation.on.selector.default.value;
+      regionArray = coords.split('=')[1].split(',');
 
-      // var imageUrl = $.Iiif.getImageUrl(this.parent.imagesList[$.getImageIndexById(this.parent.imagesList, oaAnnotation.on.full)]);
-      // imageUrl = imageUrl + "/" + regionArray.join(',') + "/full/0/native.jpg";
-      // annotation.thumb = imageUrl;
+      var imageUrl = $.Iiif.getImageUrl(this.parent.imagesList[$.getImageIndexById(this.parent.imagesList, oaAnnotation.on.full)]);
+      imageUrl = imageUrl + "/" + regionArray.join(',') + "/full/0/native.jpg";
+      annotation.thumb = imageUrl;
 
       // region = oaAnnotation.on.scope.value;
       // regionArray = region.split('=')[1].split(',');
       // annotation.bounds = {"x":regionArray[0], "y":regionArray[1], "width":regionArray[2], "height":regionArray[3]};
 
       annotation.updated = new Date().toISOString();
-      if (oaAnnotation.annotatedAt) { 
-        annotation.created = oaAnnotation.annotatedAt; 
+      if (oaAnnotation.annotatedAt) {
+        annotation.created = oaAnnotation.annotatedAt;
       } else {
         annotation.created = annotation.updated;
       }

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -167,8 +167,10 @@
     //takes OA Annotation, gets Endpoint Annotation, and saves
     //if successful, MUST return the OA rendering of the annotation
     create: function(oaAnnotation, successCallback, errorCallback) {
-      var annotation = this.getAnnotationInEndpoint(oaAnnotation);
-      this.createCatchAnnotation(annotation, successCallback, errorCallback);
+      var annotations = this.getAnnotationInEndpoint(oaAnnotation);
+      annotations.forEach(function(annotation) {
+        this.createCatchAnnotation(annotation, successCallback, errorCallback);
+      });
     },
 
     createCatchAnnotation: function(catchAnnotation, successCallback, errorCallback) {
@@ -249,7 +251,10 @@
       } else {
         var value;
         motivation.push("oa:commenting");
-        if (typeof annotation.rangePosition === 'object') {
+        if (jQuery.isArray(annotation.rangePosition)) {
+          //dual strategy
+          on  = annotation.rangePosition;
+        } else if (typeof annotation.rangePosition === 'object') {
           //legacy strategy
           value = "xywh="+annotation.rangePosition.x+","+annotation.rangePosition.y+","+annotation.rangePosition.width+","+annotation.rangePosition.height;
           on = { "@type" : "oa:SpecificResource",
@@ -257,23 +262,6 @@
             "selector": {
                 "@type": "oa:FragmentSelector",
                 "value": value
-            }
-          };
-        } else if (annotation.bounds) {
-          //dual strategy
-          value = annotation.rangePosition;
-          on = { "@type" : "oa:SpecificResource",
-            "full" : annotation.uri,
-            "selector": {
-              "@type": "oa:Choice",
-              "default": {
-                "@type": "oa:FragmentSelector",
-                "value": "xywh=" + annotation.bounds.x + "," + annotation.bounds.y + "," + annotation.bounds.width + "," + annotation.bounds.height
-              },
-              "item": {
-                "@type": "oa:SvgSelector",
-                "value": value
-              }
             }
           };
         } else {
@@ -315,64 +303,82 @@
 
     // Converts OA Annotation to endpoint format
     getAnnotationInEndpoint: function(oaAnnotation) {
-      var annotation = {},
-      tags = [],
-      text;
-
-      if (oaAnnotation["@id"]) {
-        annotation.id = oaAnnotation["@id"];
-      }
-
-      annotation.media = "image";
-      jQuery.each(oaAnnotation.resource, function(index, value) {
-        if (value['@type'] === 'oa:Tag') {
-          tags.push(value.chars);
-        } else if (value['@type'] === 'dctypes:Text') {
-          text = value.chars;
+      var uris = [];
+      oaAnnotation.on.forEach(function(value) {
+        if (jQuery.inArray(value.full, uris) === -1) {
+          uris.push(value.full);
         }
       });
-      annotation.tags = tags;
-      annotation.text = text;
+      var annotations = [];
 
-      annotation.uri = oaAnnotation.on.full;
-      annotation.contextId = this.context_id;
-      annotation.collectionId = this.collection_id;
+      uris.forEach(function(uri) {
+        var annotation = {},
+        tags = [],
+        text;
 
-      var region = oaAnnotation.on.selector.item.value;
-      var regionArray;
-      //always assume dual strategy
-      if (region.indexOf('<svg') !== -1) {
-        //this is an svg string, so don't do anything special
-        annotation.rangePosition = region;
-      }
-      var coords = oaAnnotation.on.selector.default.value;
-      regionArray = coords.split('=')[1].split(',');
+        if (oaAnnotation["@id"]) {
+          annotation.id = oaAnnotation["@id"];
+        }
 
-      var canvas = this.imagesList[$.getImageIndexById(this.imagesList, oaAnnotation.on.full)];
-      var imageUrl = $.getThumbnailForCanvas(canvas, 300);
-      imageUrl = imageUrl.replace('full', regionArray.join(','));
-      annotation.thumb = imageUrl;
-      annotation.bounds = {"x":regionArray[0], "y":regionArray[1], "width":regionArray[2], "height":regionArray[3]};
+        annotation.media = "image";
+        jQuery.each(oaAnnotation.resource, function(index, value) {
+          if (value['@type'] === 'oa:Tag') {
+            tags.push(value.chars);
+          } else if (value['@type'] === 'dctypes:Text') {
+            text = value.chars;
+          }
+        });
+        annotation.tags = tags;
+        annotation.text = text;
 
-      annotation.updated = new Date().toISOString();
-      if (oaAnnotation.annotatedAt) {
-        annotation.created = oaAnnotation.annotatedAt;
-      } else {
-        annotation.created = annotation.updated;
-      }
-      // this needs to come from LTI annotation.user.id, annotation.user.name
-      annotation.user = {};
-      if (oaAnnotation.annotatedBy) {
-        annotation.user.name = oaAnnotation.annotatedBy.name;
-        annotation.user.id = oaAnnotation.annotatedBy['@id'];
-      } else {
-        annotation.user = this.catchOptions.user;
-      }
-      annotation.permissions = this.catchOptions.permissions;
-      annotation.archived = false;
-      annotation.ranges = [];
-      annotation.parent = "0";
-      return annotation;
+        annotation.uri = uri;
+        annotation.contextId = this.context_id;
+        annotation.collectionId = this.collection_id;
+        annotation.rangePosition = oaAnnotation.on;
+
+        var coordsArray = [];
+        oaAnnotation.on.forEach(function(value) {
+          coordsArray.push(value.selector.default.value.split('=')[1].split(','));
+        });
+        var left = coordsArray.map(function(i) {return i[0];});
+        var top = coordsArray.map(function(i) {return i[1];});
+        var right = coordsArray.map(function(i) {return i[0] + i[2];});
+        var bottom = coordsArray.map(function(i) {return i[1] + i[3];});
+
+        var newRect = {
+          "x" : Math.min.apply(null, left),
+          "y" : Math.min.apply(null, top),
+          "width" : Math.max.apply(null, right) - Math.min.apply(null, left),
+          "height" : Math.max.apply(null, bottom) - Math.min.apply(null, top)
+        };
+
+        var canvas = this.imagesList[$.getImageIndexById(this.imagesList, uri)];
+        var imageUrl = $.getThumbnailForCanvas(canvas, 300);
+        imageUrl = imageUrl.replace('full', newRect.x+','+newRect.y+','+newRect.width+','+newRect.height);
+        annotation.thumb = imageUrl;
+        annotation.bounds = {"x":newRect.x, "y":newRect.y, "width":newRect.width, "height":newRect.height};
+
+        annotation.updated = new Date().toISOString();
+        if (oaAnnotation.annotatedAt) {
+          annotation.created = oaAnnotation.annotatedAt;
+        } else {
+          annotation.created = annotation.updated;
+        }
+        // this needs to come from LTI annotation.user.id, annotation.user.name
+        annotation.user = {};
+        if (oaAnnotation.annotatedBy) {
+          annotation.user.name = oaAnnotation.annotatedBy.name;
+          annotation.user.id = oaAnnotation.annotatedBy['@id'];
+        } else {
+          annotation.user = this.catchOptions.user;
+        }
+        annotation.permissions = this.catchOptions.permissions;
+        annotation.archived = false;
+        annotation.ranges = [];
+        annotation.parent = "0";
+        annotations.push(annotation);
+      });
+      return annotations;
     }
   };
 

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -326,13 +326,10 @@
       var coords = oaAnnotation.on.selector.default.value;
       regionArray = coords.split('=')[1].split(',');
 
-      var imageUrl = $.Iiif.getImageUrl(this.parent.imagesList[$.getImageIndexById(this.parent.imagesList, oaAnnotation.on.full)]);
+      var imageUrl = $.Iiif.getImageUrl(this.imagesList[$.getImageIndexById(this.imagesList, oaAnnotation.on.full)]);
       imageUrl = imageUrl + "/" + regionArray.join(',') + "/full/0/native.jpg";
       annotation.thumb = imageUrl;
-
-      // region = oaAnnotation.on.scope.value;
-      // regionArray = region.split('=')[1].split(',');
-      // annotation.bounds = {"x":regionArray[0], "y":regionArray[1], "width":regionArray[2], "height":regionArray[3]};
+      annotation.bounds = {"x":regionArray[0], "y":regionArray[1], "width":regionArray[2], "height":regionArray[3]};
 
       annotation.updated = new Date().toISOString();
       if (oaAnnotation.annotatedAt) {

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -21,6 +21,7 @@
     jQuery.extend(this, {
       token:     null,
       prefix:    null,
+      params:    "",
       dfd:       null,
       context_id: "None",
       collection_id: "None",
@@ -66,7 +67,7 @@
       this.annotationsList = []; //clear out current list
 
       jQuery.ajax({
-        url: this.prefix+"/search",
+        url: this.prefix+"/search" + params,
         type: 'GET',
         dataType: 'json',
         headers: {
@@ -113,7 +114,7 @@
     deleteAnnotation: function(annotationID, successCallback, errorCallback) {
       var _this = this;
       jQuery.ajax({
-       url: this.prefix+"/destroy/"+annotationID,
+       url: this.prefix+"/destroy/"+annotationID + params,
        type: 'DELETE',
        dataType: 'json',
        headers: {
@@ -141,7 +142,7 @@
       annotationID = annotation.id;
 
       jQuery.ajax({
-        url: this.prefix+"/update/"+annotationID,
+        url: this.prefix+"/update/"+annotationID + params,
         type: 'POST',
         dataType: 'json',
         headers: {
@@ -174,7 +175,7 @@
       var _this = this;
 
       jQuery.ajax({
-        url: this.prefix+"/create",
+        url: this.prefix+"/create" + params,
         type: 'POST',
         dataType: 'json',
         headers: {

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -167,9 +167,10 @@
     //takes OA Annotation, gets Endpoint Annotation, and saves
     //if successful, MUST return the OA rendering of the annotation
     create: function(oaAnnotation, successCallback, errorCallback) {
-      var annotations = this.getAnnotationInEndpoint(oaAnnotation);
+      var _this = this,
+      annotations = this.getAnnotationInEndpoint(oaAnnotation);
       annotations.forEach(function(annotation) {
-        this.createCatchAnnotation(annotation, successCallback, errorCallback);
+        _this.createCatchAnnotation(annotation, successCallback, errorCallback);
       });
     },
 

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -151,7 +151,7 @@
         contentType: "application/json; charset=utf-8",
         success: function(data) {
           if (typeof successCallback === "function") {
-            successCallback();
+            successCallback(_this.getAnnotationInOA(data));
           }
           _this.eventEmitter.publish('catchAnnotationUpdated.'+_this.windowID, annotation);
         },

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -340,7 +340,8 @@
 
         var coordsArray = [];
         oaAnnotation.on.forEach(function(value) {
-          coordsArray.push(value.selector.default.value.split('=')[1].split(','));
+          var xywh = value.selector.default.value.split('=')[1].split(',');
+          coordsArray.push(xywh.map(function(i) {return parseInt(i);}));
         });
         var left = coordsArray.map(function(i) {return i[0];});
         var top = coordsArray.map(function(i) {return i[1];});

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -333,8 +333,8 @@
         annotation.text = text;
 
         annotation.uri = uri;
-        annotation.contextId = this.context_id;
-        annotation.collectionId = this.collection_id;
+        annotation.contextId = _this.context_id;
+        annotation.collectionId = _this.collection_id;
         annotation.rangePosition = oaAnnotation.on;
 
         var coordsArray = [];
@@ -371,9 +371,9 @@
           annotation.user.name = oaAnnotation.annotatedBy.name;
           annotation.user.id = oaAnnotation.annotatedBy['@id'];
         } else {
-          annotation.user = this.catchOptions.user;
+          annotation.user = _this.catchOptions.user;
         }
-        annotation.permissions = this.catchOptions.permissions;
+        annotation.permissions = _this.catchOptions.permissions;
         annotation.archived = false;
         annotation.ranges = [];
         annotation.parent = "0";

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -349,6 +349,7 @@
 
       var canvas = this.imagesList[$.getImageIndexById(this.imagesList, oaAnnotation.on.full)];
       var imageUrl = $.getThumbnailForCanvas(canvas, 300);
+      imageUrl = imageUrl.replace('full', regionArray.join(','));
       annotation.thumb = imageUrl;
       annotation.bounds = {"x":regionArray[0], "y":regionArray[1], "width":regionArray[2], "height":regionArray[3]};
 

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -67,7 +67,7 @@
       this.annotationsList = []; //clear out current list
 
       jQuery.ajax({
-        url: this.prefix+"/search" + params,
+        url: this.prefix+"/search" + this.params,
         type: 'GET',
         dataType: 'json',
         headers: {
@@ -114,7 +114,7 @@
     deleteAnnotation: function(annotationID, successCallback, errorCallback) {
       var _this = this;
       jQuery.ajax({
-       url: this.prefix+"/destroy/"+annotationID + params,
+       url: this.prefix+"/destroy/"+annotationID + this.params,
        type: 'DELETE',
        dataType: 'json',
        headers: {
@@ -142,7 +142,7 @@
       annotationID = annotation.id;
 
       jQuery.ajax({
-        url: this.prefix+"/update/"+annotationID + params,
+        url: this.prefix+"/update/"+annotationID + this.params,
         type: 'POST',
         dataType: 'json',
         headers: {
@@ -175,7 +175,7 @@
       var _this = this;
 
       jQuery.ajax({
-        url: this.prefix+"/create" + params,
+        url: this.prefix+"/create" + this.params,
         type: 'POST',
         dataType: 'json',
         headers: {

--- a/js/src/annotations/catchEndpoint.js
+++ b/js/src/annotations/catchEndpoint.js
@@ -255,9 +255,16 @@
         motivation.push("oa:commenting");
         on = { "@type" : "oa:SpecificResource",
           "full" : annotation.uri,
-          "selector" : {
-            "@type" : "oa:FragmentSelector",
-            "value" : value
+          "selector": {
+            "@type": "oa:Choice",
+            "default": {
+              "@type": "oa:FragmentSelector",
+              "value": "xywh=" + annotation.bounds.x + "," + annotation.bounds.y + "," + annotation.bounds.width + "," + annotation.bounds.height
+            },
+            "item": {
+              "@type": "oa:SvgSelector",
+              "value": value
+            }
           }
           // ,
           // "scope": {

--- a/js/src/annotations/localStorageEndpoint.js
+++ b/js/src/annotations/localStorageEndpoint.js
@@ -22,7 +22,7 @@
       token:     null,
       prefix:    null,
       dfd:       null,
-      annotationsList: [],        
+      annotationsList: [],
       windowID: null,
       eventEmitter: null
     }, options);
@@ -66,111 +66,147 @@
         }
       }
     },
-    
+
     deleteAnnotation: function(annotationID, successCallback, errorCallback) {
       var _this = this,
-      key = _this.annotationsList[0].on.full;
-      
-      try {
-        //find the matching annotation in the array and update it
-        _this.annotationsList = jQuery.grep(_this.annotationsList, function(value, index) {
-          return value['@id'] !== annotationID;
-        });
+      keys = [];
+      jQuery.each(_this.annotationsList[0].on, function(index, value) {
+        if (jQuery.inArray(value.full, keys) === -1) {
+          keys.push(value.full);
+        }
+      });
 
-        //remove endpoint reference before JSON.stringify
-        jQuery.each(_this.annotationsList, function(index, value) {
-          delete value.endpoint;
-        });
-
-        localStorage.setItem(key, JSON.stringify(_this.annotationsList));
-
-        //add endpoint reference after JSON.stringify
-        jQuery.each(_this.annotationsList, function(index, value) {
-          value.endpoint = _this;
-        });
-
-        if (typeof successCallback === "function") {
-          successCallback();
-        } 
-      } catch (e) {
+      if (keys.length === 0) {
         if (typeof errorCallback === "function") {
           errorCallback();
-        } 
+        }
       }
+      jQuery.each(keys, function(index, key) {
+        try {
+          //find the matching annotation in the array and update it
+          _this.annotationsList = jQuery.grep(_this.annotationsList, function(value, index) {
+            return value['@id'] !== annotationID;
+          });
+
+          //remove endpoint reference before JSON.stringify
+          jQuery.each(_this.annotationsList, function(index, value) {
+            delete value.endpoint;
+          });
+
+          localStorage.setItem(key, JSON.stringify(_this.annotationsList));
+
+          //add endpoint reference after JSON.stringify
+          jQuery.each(_this.annotationsList, function(index, value) {
+            value.endpoint = _this;
+          });
+
+          if (typeof successCallback === "function") {
+            successCallback();
+          }
+        } catch (e) {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
     },
-    
+
     update: function(oaAnnotation, successCallback, errorCallback) {
       var _this = this,
-      key = oaAnnotation.on.full,
-      annotationID = oaAnnotation['@id'];
-      
-      try {
-        if (_this.annotationsList.length === 0) {
-          _this.annotationsList = _this.getAnnotationList(key);          
+      annotationID = oaAnnotation['@id'],
+      keys = [];
+      jQuery.each(oaAnnotation.on, function(index, value) {
+        if (jQuery.inArray(value.full, keys) === -1) {
+          keys.push(value.full);
         }
-        //find the matching annotation in the array and update it
-        jQuery.each(_this.annotationsList, function(index, value) {
-          if (value['@id'] === annotationID) {
-            _this.annotationsList[index] = oaAnnotation;
-            return false;
-          }
-        });
+      });
 
-        //remove endpoint reference before JSON.stringify
-        jQuery.each(_this.annotationsList, function(index, value) {
-          delete value.endpoint;
-        });
-
-        localStorage.setItem(key, JSON.stringify(_this.annotationsList));
-
-        //add endpoint reference after JSON.stringify
-        jQuery.each(_this.annotationsList, function(index, value) {
-          value.endpoint = _this;
-        });
-
-        if (typeof successCallback === "function") {
-          successCallback(oaAnnotation);
-        } 
-      } catch (e) {
+      if (keys.length === 0) {
         if (typeof errorCallback === "function") {
           errorCallback();
-        } 
+        }
       }
+      jQuery.each(keys, function(index, key) {
+        try {
+          if (_this.annotationsList.length === 0) {
+            _this.annotationsList = _this.getAnnotationList(key);
+          }
+          //find the matching annotation in the array and update it
+          jQuery.each(_this.annotationsList, function(index, value) {
+            if (value['@id'] === annotationID) {
+              _this.annotationsList[index] = oaAnnotation;
+              return false;
+            }
+          });
+
+          //remove endpoint reference before JSON.stringify
+          jQuery.each(_this.annotationsList, function(index, value) {
+            delete value.endpoint;
+          });
+
+          localStorage.setItem(key, JSON.stringify(_this.annotationsList));
+
+          //add endpoint reference after JSON.stringify
+          jQuery.each(_this.annotationsList, function(index, value) {
+            value.endpoint = _this;
+          });
+
+          if (typeof successCallback === "function") {
+            successCallback(oaAnnotation);
+          }
+        } catch (e) {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
     },
 
     //takes OA Annotation, gets Endpoint Annotation, and saves
     //if successful, MUST return the OA rendering of the annotation
     create: function(oaAnnotation, successCallback, errorCallback) {
       var _this = this,
-      key = oaAnnotation.on.full;
-
-      try {
-        if (_this.annotationsList.length === 0) {
-          _this.annotationsList = _this.getAnnotationList(key);          
+      keys = [];
+      jQuery.each(oaAnnotation.on, function(index, value) {
+        if (jQuery.inArray(value.full, keys) === -1) {
+          keys.push(value.full);
         }
-        oaAnnotation["@id"] = $.genUUID();
-        _this.annotationsList.push(oaAnnotation);
+      });
 
-        //remove endpoint reference before JSON.stringify
-        jQuery.each(_this.annotationsList, function(index, value) {
-          delete value.endpoint;
-        });
-
-        localStorage.setItem(key, JSON.stringify(_this.annotationsList));
-
-        //add endpoint reference after JSON.stringify
-        jQuery.each(_this.annotationsList, function(index, value) {
-          value.endpoint = _this;
-        });
-
-        if (typeof successCallback === "function") {
-          successCallback(oaAnnotation);
-        } 
-      } catch (e) {
+      if (keys.length === 0) {
         if (typeof errorCallback === "function") {
           errorCallback();
-        } 
+        }
       }
+      jQuery.each(keys, function(index, key) {
+        try {
+          if (_this.annotationsList.length === 0) {
+            _this.annotationsList = _this.getAnnotationList(key);
+          }
+          oaAnnotation["@id"] = $.genUUID();
+          _this.annotationsList.push(oaAnnotation);
+
+          //remove endpoint reference before JSON.stringify
+          jQuery.each(_this.annotationsList, function(index, value) {
+            delete value.endpoint;
+          });
+
+          localStorage.setItem(key, JSON.stringify(_this.annotationsList));
+
+          //add endpoint reference after JSON.stringify
+          jQuery.each(_this.annotationsList, function(index, value) {
+            value.endpoint = _this;
+          });
+
+          if (typeof successCallback === "function") {
+            successCallback(oaAnnotation);
+          }
+        } catch (e) {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
     },
 
     getAnnotationList: function(key) {

--- a/js/src/annotations/miradorDualStrategy.js
+++ b/js/src/annotations/miradorDualStrategy.js
@@ -2,66 +2,74 @@
 
   $.MiradorDualStrategy = function(options) {
     jQuery.extend(this, {
-      
+
     }, options);
     this.init();
   };
-  
+
   $.MiradorDualStrategy.prototype = {
     init: function() {
-      
+
     },
-    
+
     // Check whether an annotation is supported under this formatting strategy
     isThisType: function(annotation) {
-      if (annotation.on && typeof annotation.on === 'object' &&
-          annotation.on.selector && typeof annotation.on.selector === 'object' &&
-          annotation.on.selector['@type'] === 'oa:Choice' &&
-          annotation.on.selector.default && typeof annotation.on.selector.default === 'object' &&
-          annotation.on.selector.default.value && typeof annotation.on.selector.default.value === 'string' &&
-          annotation.on.selector.item && typeof annotation.on.selector.item === 'object' &&
-          annotation.on.selector.item.value && typeof annotation.on.selector.item.value === 'string'
+      if (annotation.on && jQuery.isArray(annotation.on) && annotation.on.length > 0 && typeof annotation.on[0] === 'object' &&
+          annotation.on[0].selector && typeof annotation.on[0].selector === 'object' &&
+          annotation.on[0].selector['@type'] === 'oa:Choice' &&
+          annotation.on[0].selector.default && typeof annotation.on[0].selector.default === 'object' &&
+          annotation.on[0].selector.default.value && typeof annotation.on[0].selector.default.value === 'string' &&
+          annotation.on[0].selector.item && typeof annotation.on[0].selector.item === 'object' &&
+          annotation.on[0].selector.item.value && typeof annotation.on[0].selector.item.value === 'string'
         ) {
-        return annotation.on.selector.default.value.indexOf('xywh=') === 0 && annotation.on.selector.item.value.indexOf('<svg') === 0;
+        return annotation.on[0].selector.default.value.indexOf('xywh=') === 0 && annotation.on[0].selector.item.value.indexOf('<svg') === 0;
       }
       return false;
     },
-    
+
     // Build the selector into a bare annotation, given a Window and an OsdSvgOverlay
     buildAnnotation: function(options) {
       var oaAnno = options.annotation,
           win = options.window,
-          overlay = options.overlay,
-          svg = overlay.getSVGString(overlay.draftPaths),
-          bounds = overlay.draftPaths[0].bounds;
-      oaAnno.on = {
-        "@type": "oa:SpecificResource",
-        "full": win.canvasID,
-        "selector": {
-          "@type": "oa:Choice",
-          "default": {
-            "@type": "oa:FragmentSelector",
-            "value": "xywh=" + Math.round(bounds.x) + "," + Math.round(bounds.y) + "," + Math.round(bounds.width) + "," + Math.round(bounds.height)
+          overlay = options.overlay;
+      oaAnno.on = [];
+      jQuery.each(overlay.draftPaths, function(index, path) {
+        // getSVGString expects an array, so insert each path into a new array
+        var svg = overlay.getSVGString([path]),
+        bounds = path.bounds;
+        oaAnno.on.push({
+          "@type": "oa:SpecificResource",
+          "full": win.canvasID,
+          "selector": {
+            "@type": "oa:Choice",
+            "default": {
+              "@type": "oa:FragmentSelector",
+              "value": "xywh=" + Math.round(bounds.x) + "," + Math.round(bounds.y) + "," + Math.round(bounds.width) + "," + Math.round(bounds.height)
+            },
+            "item": {
+              "@type": "oa:SvgSelector",
+              "value": svg
+            }
           },
-          "item": {
-            "@type": "oa:SvgSelector",
-            "value": svg
+          "within": {
+            "@id": win.loadedManifest,
+            "@type": "sc:Manifest"
           }
-        },
-        "within": {
-          "@id": win.loadedManifest,
-          "@type": "sc:Manifest"
-        }
-      };
+        });
+      });
       return oaAnno;
     },
-    
+
     // Parse the annotation into the OsdRegionDrawTool instance (only if its format is supported by this strategy)
     parseRegion: function(annotation, osdRegionDrawTool) {
       if (this.isThisType(annotation)) {
-        return osdRegionDrawTool.svgOverlay.parseSVG(annotation.on.selector.item.value, annotation);
+        var regionArray = [];
+        jQuery.each(annotation.on, function(index, target) {
+          regionArray = regionArray.concat(osdRegionDrawTool.svgOverlay.parseSVG(target.selector.item.value, annotation));
+        });
+        return regionArray;
       }
     },
   };
-  
+
 }(Mirador));

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -167,7 +167,6 @@
           }
         }
       });
-      _this.eventEmitter.publish('DIALOG_CREATED.' + _this.windowId, ['mirador-dialog']);
     },
 
     listenForActions: function() {
@@ -292,7 +291,6 @@
                 }
               }
             });
-            _this.eventEmitter.publish('DIALOG_CREATED.' + _this.windowId, ['mirador-dialog']);
         } else {
           var writeStrategy = new $.MiradorDualStrategy();
           writeStrategy.buildAnnotation({
@@ -407,7 +405,6 @@
               }
             }
           });
-          _this.eventEmitter.publish('DIALOG_CREATED.' + _this.windowId, ['mirador-dialog']);
         } else {
           cancel();
         }

--- a/js/src/annotations/osd-svg-overlay.js
+++ b/js/src/annotations/osd-svg-overlay.js
@@ -104,17 +104,17 @@
           }
         }
       };
-      
+
       // Key for saving mouse tool as data attribute
       // TODO: It seems its main use is for destroy the old paperjs mouse tool
       // when a new Overlay is instantiated. Maybe a better scheme can be
       // devised in the future?
       this.mouseToolKey = 'draw_canvas_' + _this.windowId;
-      
+
       this.setMouseTool();
       this.listenForActions();
     },
-    
+
     /**
      * Adds a Tool that handles mouse events for the paperjs scope.
      */
@@ -132,7 +132,7 @@
 
       jQuery.data(document.body, this.mouseToolKey, mouseTool);
     },
-    
+
     /**
      * Removes the mouse Tool from the paperjs scope.
      */
@@ -149,6 +149,7 @@
       new $.DialogBuilder(this.slotWindowElement).dialog({
         message: i18n.t('deleteShape'),
         closeButton: false,
+        className: 'mirador-dialog',
         buttons: {
           'no': {
             label: i18n.t('no'),
@@ -166,6 +167,7 @@
           }
         }
       });
+      _this.eventEmitter.publish('DIALOG_CREATED.' + _this.windowId, ['mirador-dialog']);
     },
 
     listenForActions: function() {
@@ -258,6 +260,7 @@
             new $.DialogBuilder(_this.slotWindowElement).dialog({
               message: i18n.t('editModalSaveAnnotationWithNoShapesMsg'),
               closeButton: false,
+              className: 'mirador-dialog',
               buttons: {
                 success: {
                   label: i18n.t('editModalBtnSaveWithoutShapes'),
@@ -289,6 +292,7 @@
                 }
               }
             });
+            _this.eventEmitter.publish('DIALOG_CREATED.' + _this.windowId, ['mirador-dialog']);
         } else {
           var writeStrategy = new $.MiradorDualStrategy();
           writeStrategy.buildAnnotation({
@@ -346,7 +350,7 @@
             delete _this.draftPaths[i].data.newlyCreatedStrokeFactor;
           }
         }
-        
+
         var writeStrategy = new $.MiradorDualStrategy();
         writeStrategy.buildAnnotation({
           annotation: oaAnno,
@@ -382,6 +386,7 @@
           new $.DialogBuilder(_this.slotWindowElement).dialog({
             message: i18n.t('cancelAnnotation'),
             closeButton: false,
+            className: 'mirador-dialog',
             buttons: {
               'no': {
                 label: i18n.t('no'),
@@ -402,6 +407,7 @@
               }
             }
           });
+          _this.eventEmitter.publish('DIALOG_CREATED.' + _this.windowId, ['mirador-dialog']);
         } else {
           cancel();
         }

--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -39,7 +39,37 @@
         jQuery.extend(true, config, object);
       }
     });
-    this.init(jQuery.extend(true, {}, $.DEFAULT_SETTINGS, config));
+
+    /*
+    We want to deep copy/merge nested objects in the config, but array values should be overwritten
+    So, stringify arrays so extend overwrites them and then convert them back to arrays
+    */
+    function iterateStringify(object) {
+      for (var property in object) {
+        if (object.hasOwnProperty(property)) {
+          if (object[property] instanceof Array) {
+            object[property] = JSON.stringify(object[property]);
+          } else if (typeof object[property] === "object") {
+            iterateStringify(object[property]);
+          } else {}
+        }
+      }
+    }
+    function iterateParse(object) {
+      for (var property in object) {
+        if (object.hasOwnProperty(property)) {
+          if (typeof object[property] === "string" && object[property][0] === '[') {
+            object[property] = JSON.parse(object[property]);
+          } else if (typeof object[property] === "object") {
+            iterateParse(object[property]);
+          } else {}
+        }
+      }
+    }
+    iterateStringify(config);
+    var newConfig = jQuery.extend(true, {}, $.DEFAULT_SETTINGS, config);
+    iterateParse(newConfig);
+    this.init(newConfig);
   };
 
   $.SaveController.prototype = {

--- a/spec/fixtures/annotationMiradorDual.json
+++ b/spec/fixtures/annotationMiradorDual.json
@@ -11,7 +11,7 @@
       "chars": "<p>something</p>"
     }
   ],
-  "on": {
+  "on": [{
     "@type": "oa:SpecificResource",
     "full": "https://oculus-dev.harvardx.harvard.edu/manifests/huam:320567/canvas/canvas-10466656.json",
     "selector": {
@@ -29,6 +29,6 @@
       "@id": "https://oculus-dev.harvardx.harvard.edu/manifests/huam:320567",
       "@type": "sc:Manifest"
     }
-  },
+  }],
   "@id": "d2eda2e2-951a-4f88-b4ec-03a7b25a5d07"
 }


### PR DESCRIPTION
- Modified DualStrategy to handle multiple targets. Closes #1138
- A variety of fixes to handle the new Dual Strategy for annotations in CATCH and local storage endpoints.
- Array values in the config were not correctly overwriting the default value because of `jQuery.extend` treats them, so change arrays into strings before extending the configuration, and then convert them back to arrays
