### PR TITLE
Simplify install instructions by removing global grunt-cli ref

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,9 @@
 Mirador uses [node.js](http://nodejs.org/) and a build system to assemble, test, and manage the development resources. If you have never used these tools before, you may need to install them.
 
  1. Install Node, if you haven't already (available at the link above)  
- 2. Install the Grunt command line runner (if you haven't already); on the command line, run `npm install -g grunt-cli`  
- 3. Clone the mirador repository (if you haven't already done so above); `git clone https://github.com/ProjectMirador/mirador.git`
- 4. On the command line, go into the mirador folder
- 5. Install all dependencies with `npm install`. Run `npm start`
+ 1. Clone the mirador repository (if you haven't already done so above); `git clone https://github.com/ProjectMirador/mirador.git`
+ 1. On the command line, go into the mirador folder
+ 1. Install all dependencies with `npm install`. Run `npm start`
 
 `npm start` will run a local server that is available at `localhost:8000`.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@
 Mirador uses [node.js](http://nodejs.org/) and a build system to assemble, test, and manage the development resources. If you have never used these tools before, you may need to install them.
 
  1. Install Node, if you haven't already (available at the link above)  
- 2. Install the Grunt command line runner (if you haven't already); on the command line, run `npm install -g grunt-cli`  
- 3. Clone the mirador repository (if you haven't already done so above)
- 4. On the command line, go into the mirador folder
- 5. Install all dependencies with `npm install`. Run `npm start'.
+ 1. Clone the mirador repository (if you haven't already done so above)
+ 1. On the command line, go into the mirador folder
+ 1. Install all dependencies with `npm install`. Run `npm start'.
  
 ### Run Tests
 `npm test`

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "sinon": "^1.17.6"
   },
   "scripts": {
-    "start": "grunt serve",
+    "start": "./node_modules/.bin/grunt serve",
     "test": "./node_modules/.bin/karma start ./karma.conf.js",
-    "travis": "./node_modules/grunt-cli/bin/grunt ci --verbose --force & npm run test"
+    "travis": "./node_modules/.bin/grunt ci --verbose --force & npm run test"
   },
   "dependencies": {
     "bootbox": "^4.4.0",


### PR DESCRIPTION
Since we already include this as a dev dependency, let's just reference
our local version instead of requiring it global.

Verified successfully after doing a `npm uninstall grunt-cli -g`