### PR TITLE
Continue to next annotation when parsing of single annotation fails

### DIFF
--- a/spec/annotations/osd-region-draw-tool.test.js
+++ b/spec/annotations/osd-region-draw-tool.test.js
@@ -1,18 +1,16 @@
 describe('OsdRegionDrawTool', function() {
 
-  var config = {
-    osdViewer:{
-      svgOverlay:function(){
-        return MockOverlay.getOverlay();
-      },
-      addHandler:jasmine.createSpy(),
-      removeHandler:jasmine.createSpy()
-    },
-    eventEmitter: new MockEventEmitter(new Mirador.EventEmitter())
-  };
-
   beforeEach(function() {
-
+    var config = {
+      osdViewer:{
+        svgOverlay:function(){
+          return MockOverlay.getOverlay();
+        },
+        addHandler:jasmine.createSpy(),
+        removeHandler:jasmine.createSpy()
+      },
+      eventEmitter: new MockEventEmitter(new Mirador.EventEmitter())
+    };
     this.drawTool = new Mirador.OsdRegionDrawTool(config);
   });
 
@@ -42,8 +40,19 @@ describe('OsdRegionDrawTool', function() {
 
   });
 
-  xdescribe('render', function() {
-
+  describe('render', function() {
+    it('should still render the other annotations when SVG parsing fails for one or more', function() {
+      var annotations = [{
+        on: {
+          selector: {
+            '@type': 'oa:SvgSelector',
+            value: '<svg><path></path></sv' // invalid SVG
+          }
+        }
+      }];
+      var drawTool = createDrawToolForRenderingTest(annotations);
+      drawTool.render();
+    });
   });
 
   xdescribe('showTooltipsFromMousePosition', function() {
@@ -66,4 +75,47 @@ describe('OsdRegionDrawTool', function() {
     expect(this.drawTool.osdViewer.addHandler.callCount).toBe(this.drawTool.osdViewer.removeHandler.callCount);
   });
 
-}); 
+  function createDrawToolForRenderingTest(annotations) {
+    var windowId = 'window1';
+    jQuery('document.body').append(jQuery('<div>').attr('id', windowId));
+    var osdViewerElem = jQuery('<div/>');
+    var mockPaperScope = {
+      activate: jasmine.createSpy(),
+      project: {
+        clear: jasmine.createSpy()
+      },
+      view: {
+        draw: jasmine.createSpy()
+      }
+    };
+    var mockSvgOverlay = function() {
+      return MockOverlay.getOverlay(mockPaperScope);
+    };
+    var mockSaveController = {
+      currentConfig: {
+        annotationBodyEditor: {
+          module: function() { console.log('HHHHH'); }
+        }
+      },
+      getWindowElement: function() {
+        return jQuery('#' + windowId);
+      }
+    };
+    var mockAnnotationsLayer = {
+      mode: Mirador.AnnotationsLayer.DISPLAY_ANNOTATIONS
+    };
+    var mockOpenSeadragon = {
+      addHandler: jasmine.createSpy(),
+      svgOverlay: mockSvgOverlay,
+      element: osdViewerElem
+    };
+    return new Mirador.OsdRegionDrawTool({
+      eventEmitter: new MockEventEmitter(new Mirador.EventEmitter()),
+      list: annotations,
+      parent: mockAnnotationsLayer,
+      osdViewer: mockOpenSeadragon,
+      state: mockSaveController,
+      svgOverlay: mockSvgOverlay
+    });
+  }
+});

--- a/spec/annotations/osd-region-draw-tool.test.js
+++ b/spec/annotations/osd-region-draw-tool.test.js
@@ -1,21 +1,9 @@
 describe('OsdRegionDrawTool', function() {
 
   beforeEach(function() {
-    var config = {
-      osdViewer:{
-        svgOverlay:function(){
-          return MockOverlay.getOverlay();
-        },
-        addHandler:jasmine.createSpy(),
-        removeHandler:jasmine.createSpy()
-      },
-      eventEmitter: new MockEventEmitter(new Mirador.EventEmitter())
-    };
-    this.drawTool = new Mirador.OsdRegionDrawTool(config);
   });
 
   afterEach(function() {
-
   });
 
   xdescribe('Initialization', function() {
@@ -50,7 +38,7 @@ describe('OsdRegionDrawTool', function() {
           }
         }
       }];
-      var drawTool = createDrawToolForRenderingTest(annotations);
+      var drawTool = createDrawTool(annotations);
       drawTool.render();
     });
   });
@@ -68,14 +56,15 @@ describe('OsdRegionDrawTool', function() {
   });
 
   it('should unsubscibe from all events when destroying',function(){
-    this.drawTool.destroy();
-    for(var key in this.drawTool.eventEmitter.events){
-      expect(this.drawTool.eventEmitter.events[key]).toBe(0);
+    var drawTool = createDrawTool([]);
+    drawTool.destroy();
+    for(var key in drawTool.eventEmitter.events){
+      expect(drawTool.eventEmitter.events[key]).toBe(0);
     }
-    expect(this.drawTool.osdViewer.addHandler.callCount).toBe(this.drawTool.osdViewer.removeHandler.callCount);
+    expect(drawTool.osdViewer.addHandler.callCount).toBe(drawTool.osdViewer.removeHandler.callCount);
   });
 
-  function createDrawToolForRenderingTest(annotations) {
+  function createDrawTool(annotations) {
     var windowId = 'window1';
     jQuery('document.body').append(jQuery('<div>').attr('id', windowId));
     var osdViewerElem = jQuery('<div/>');
@@ -94,7 +83,7 @@ describe('OsdRegionDrawTool', function() {
     var mockSaveController = {
       currentConfig: {
         annotationBodyEditor: {
-          module: function() { console.log('HHHHH'); }
+          module: jasmine.createSpy()
         }
       },
       getWindowElement: function() {
@@ -107,7 +96,8 @@ describe('OsdRegionDrawTool', function() {
     var mockOpenSeadragon = {
       addHandler: jasmine.createSpy(),
       svgOverlay: mockSvgOverlay,
-      element: osdViewerElem
+      element: osdViewerElem,
+      removeHandler:jasmine.createSpy()
     };
     return new Mirador.OsdRegionDrawTool({
       eventEmitter: new MockEventEmitter(new Mirador.EventEmitter()),

--- a/spec/annotations/overlay.stub.js
+++ b/spec/annotations/overlay.stub.js
@@ -33,7 +33,8 @@
         show: jasmine.createSpy(),
         hide: jasmine.createSpy(),
         disable: jasmine.createSpy(),
-        destroy: jasmine.createSpy()
+        destroy: jasmine.createSpy(),
+        restoreEditedShapes: jasmine.createSpy()
       }
     }
   }


### PR DESCRIPTION
Placed parsing in try...catch do as not to let the whole rendering process fail when a single annotation contains invalid SVG as target.