### PR TITLE
Adds in Airbnb style via .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,5 +5,13 @@
     "jQuery": true
   },
   "rules": {
+    "no-param-reassign": [
+      2, {
+        "props": true,
+        "ignorePropertyModificationsFor": [
+          "$"
+        ]
+      }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "airbnb-base/legacy",
+  "globals": {
+    "Mirador": true,
+    "jQuery": true
+  },
+  "rules": {
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,9 @@ Some resources are managed with bower, but this is being phased out. It is recom
 #### Tasks
 ### Testing and Coverage
 ### Version Control
-### Editorconfig and jsHint
+### JavaScript Style
 Contributors use a variety of text editors according to circumstance and preference. This can introduce inconsistencies in the source text files, such as spaces being replaced with tabs, indentation spans being shortened, and whitespace being added or subtracted from the end of lines. Using your editor's [EditorConfig](http://editorconfig.org/) plugin resolves these inconsistencies while allowing each developer to use her own preferences while developing.
 
-[JSHint](http://jshint.com) will notify you of inconsistencies in the style of the code. Mirador uses the AirBnB [styleguide](https://github.com/airbnb/javascript/tree/es5-deprecated/es5) for ES5. 
+DEPRECATED [NON-FUNCTIONAL]. [JSHint](http://jshint.com) will notify you of inconsistencies in the style of the code. Mirador uses the AirBnB [styleguide](https://github.com/airbnb/javascript/tree/es5-deprecated/es5) for ES5.
+
+[eslint](http://eslint.org/). Mirador uses the AirBnb Javascript styleguide for ES5 as codified by AirBnb in [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base#eslint-config-airbnb-baselegacy). Make sure any changes you make conform to this style. You can check this by running the `npm run lint`. Error checking for this is not turned on in the continuous integration build at the moment, but will be in the future.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks("gruntify-eslint");
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -229,6 +230,13 @@ module.exports = function(grunt) {
       }
     },
 
+    eslint: {
+      options: {
+        silent: true
+      },
+      src: sources
+    },
+
     jshint: {
       options: {
         browser: true,
@@ -274,16 +282,19 @@ module.exports = function(grunt) {
       grunt.file.copy(abspath, dest);
     });
   });
+  // ----------
+  // Lint task
+  grunt.registerTask('lint', ['jshint', 'eslint'])
 
   // ----------
   // Build task.
   // Cleans out the build folder and builds the code and images into it, checking lint.
-  grunt.registerTask('build', [ 'clean:build', 'git-describe', 'jshint', 'less', 'concat:css', 'uglify', 'cssmin', 'copy']);
+  grunt.registerTask('build', [ 'clean:build', 'git-describe', 'lint', 'less', 'concat:css', 'uglify', 'cssmin', 'copy']);
 
   // ----------
   // Dev Build task.
   // Build, but skip the time-consuming and obscurantist minification and uglification.
-  grunt.registerTask('dev_build', [ 'clean:build', 'git-describe', 'jshint', 'less', 'concat', 'copy']);
+  grunt.registerTask('dev_build', [ 'clean:build', 'git-describe', 'lint', 'less', 'concat', 'copy']);
 
   // ----------
   // Package task.
@@ -308,6 +319,6 @@ module.exports = function(grunt) {
   // ----------
   // Runs this on travis.
   grunt.registerTask('ci', [
-                     'jshint'
+                     'lint'
   ]);
 };

--- a/js/src/widgets/statusBar.js
+++ b/js/src/widgets/statusBar.js
@@ -1,16 +1,7 @@
-(function($) {
+(function ($) {
+  $.WidgetStatusBar = function WidgetStatusBar(options) {
+    jQuery.extend(true, this, {
 
-  $.WidgetStatusBar = function(options) {
-
-     jQuery.extend(true, this, {
-
-     }, $.DEFAULT_SETTINGS, options);
-
+    }, $.DEFAULT_SETTINGS, options);
   };
-
-  $.WidgetStatusBar.prototype = {
-
-  };
-
 }(Mirador));
-

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "eslint": "^3.17.1",
+    "eslint-config-airbnb-base": "^11.1.1",
+    "eslint-plugin-import": "^2.2.0",
     "gitbook": "3.2.0",
     "gitbook-cli": "2.3.0",
     "gitbook-plugin-search": "2.2.1",
@@ -27,6 +30,7 @@
     "grunt-git-describe": "*",
     "grunt-githooks": "^0.3.1",
     "grunt-template-jasmine-istanbul": "^0.3.3",
+    "gruntify-eslint": "^3.1.0",
     "jasmine-core": "^2.1.3",
     "jasmine-jquery": "^2.0.5",
     "karma": "^1.5",
@@ -46,7 +50,8 @@
     "start": "./node_modules/.bin/grunt serve",
     "test": "./node_modules/.bin/karma start ./karma.conf.js",
     "travis": "./node_modules/.bin/grunt ci --verbose --force & npm run test",
-    "update_demo": "./bin/update_demo.sh"
+    "update_demo": "./bin/update_demo.sh",
+    "lint": "./node_modules/.bin/eslint js/src"
   },
   "dependencies": {
     "bootbox": "^4.4.0",


### PR DESCRIPTION
This PR starts to move towards Airbnb styleguide conformance without changing anything too drastic. Since the Airbnb styleguide is maintained via an eslint package, this PR adds that in.

It also updates the CONTRIBUTING.md to discuss what is going on currently and hopefully how we can get there.

Starts to address #1318 

Thoughts? @radpet @csbailey5t @sdellis @aeschylus @rsinghal ?

Our previous .jshintrc didn't really conform to AirBnb style, and the canonical expression of that style is now in eslint.