### PR TITLE
Update karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 node_js:
 - '5'
+- 'node'
 before_install:
 - npm install
 script:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-template-jasmine-istanbul": "^0.3.3",
     "jasmine-core": "^2.1.3",
     "jasmine-jquery": "^2.0.5",
-    "karma": "^0.12.16",
+    "karma": "^1.5",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.2.7",
     "karma-coveralls": "^1.1.2",


### PR DESCRIPTION
The 3 year old version of karma was preventing us from building Mirador on current versions of nodejs. This also allows us to test Mirador with legacy and current versions.