### PR TITLE
Fix path to watch less files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
 
   // source files
   sources = [
-    'js/src/mirador.js', 
+    'js/src/mirador.js',
     'js/src/utils/handlebars.js',
     'js/src/*.js',
     'js/src/viewer/*.js',
@@ -220,7 +220,7 @@ module.exports = function(grunt) {
           'locales/*/*.json',
           'images/*',
           'css/*.css',
-          'css/mirador/**/*.less',
+          'css/mirador.less/**/*.less',
           'index.html'
         ],
         tasks: 'dev_build'


### PR DESCRIPTION
Fixes path so that grunt watches less files and rebuilds on change.

Fixes #1353 