### PR TITLE
Fix rendering of within fields with an array value

### DIFF
--- a/js/src/widgets/metadataView.js
+++ b/js/src/widgets/metadataView.js
@@ -169,7 +169,7 @@
       var collectionLabel = within.label || collectionUrl;
       return '<a href="' + collectionUrl + '" target="_blank">' + collectionLabel + '</a>';
      } else if (within instanceof Array) {
-       return within.map(this.getWithin).join("<br/>");
+       return within.map(this.getWithin, this).join("<br/>");
      } else {
        return this.stringifyObject(within);
      }

--- a/spec/widgets/metadataView.test.js
+++ b/spec/widgets/metadataView.test.js
@@ -85,7 +85,7 @@ describe('MetadataView', function() {
   });
 
   describe('renderWithin', function() {
-    it('should render simple strings as-sis', function() {
+    it('should render simple strings as-is', function() {
       var within = "http://example.com";
       expect(Mirador.MetadataView.prototype.getWithin(within)).toBe(within);
     });
@@ -109,6 +109,12 @@ describe('MetadataView', function() {
       expect(Mirador.MetadataView.prototype.getWithin(within)).toBe(
         '<a href="http://example.com" target="_blank">foobar</a><br/>' +
         '<a href="http://foo.org" target="_blank">barfoo</a>');
+    });
+
+    it('should render a list of strings <br/>-concatenated', function() {
+      var within = ['http://example.com/foo', 'http://example.com/bar'];
+      expect(Mirador.MetadataView.prototype.getWithin(within)).toBe(
+        'http://example.com/foo<br/>http://example.com/bar');
     });
   });
 });


### PR DESCRIPTION
This PR fixes a bug I introduced in #1234 : When the `within` attribute of the Manifest contained an array of strings, the `getWithin` function would recursively call itself to render the individual entries.
However, I forgot to add the `this` parameter to the `map` call, resulting in an error when such a Manifest would be loaded.

An example of such a manifest can be found here: http://digi.ub.uni-heidelberg.de/diglit/iiif/cpg23/manifest.json