### PR TITLE
Fixes #1390. Modify karma.conf.js to allow passing in a KARMA_SPECS env var

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       'node_modules/sinon/pkg/sinon.js',
       'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
       // app
-      'js/src/mirador.js', 
+      'js/src/mirador.js',
       'js/src/utils/handlebars.js',
       'js/src/*.js',
       'js/src/viewer/*.js',
@@ -49,10 +49,9 @@ module.exports = function(config) {
       'js/src/utils/*.js',
       // spec
       'spec/**/*.stub.js',
-      'spec/**/*.js',
       {pattern: 'spec/data/*', watched: true, served: true, included: false},
-      {pattern: 'spec/fixtures/*json', watched: true, served: true, included: false},
-    ],
+      {pattern: 'spec/fixtures/*json', watched: true, served: true, included: false}
+    ].concat(!process.env.KARMA_SPECS ? ['spec/**/*.js'] : process.env.KARMA_SPECS.split(',')),
 
 
     // list of files to exclude


### PR DESCRIPTION
Fixes #1390. Modify `karma.conf.js` to allow passing in a `KARMA_SPECS` env var to only run those test specified

Now, things like this are allowed:
```
$ env KARMA_SPECS="spec/annotations/osd-svg-overlay.test.js,spec/mirador.test.js" npm test
```