### PR TITLE
Add identifiers to the rights and links metadata items

### DIFF
--- a/js/src/widgets/metadataView.js
+++ b/js/src/widgets/metadataView.js
@@ -38,6 +38,7 @@
 
           if (typeof itm.value === 'string' && itm.value !== '') {
             tplData[metadataKey].push({
+              identifier: itm.identifier || '',
               label: _this.extractLabelFromAttribute(itm.label),
               value: (metadataKey === 'links') ? itm.value : _this.addLinksToUris(itm.value)
             });
@@ -147,21 +148,38 @@
       return mdList;
     },
 
-   getMetadataRights: function(jsonLd) {
-       return [
-         {label: i18next.t('license'), value: jsonLd.license || ''},
-         {label: i18next.t('attribution'), value: $.JsonLd.getTextValue(jsonLd.attribution) || ''}
-        ];
-   },
+  getMetadataRights: function(jsonLd) {
+    return [
+      {
+        identifier: 'license',
+        label: i18next.t('license'),
+        value: jsonLd.license || ''
+      }, {
+        identifier: 'attribution',
+        label: i18next.t('attribution'),
+        value: $.JsonLd.getTextValue(jsonLd.attribution) || ''
+      }
+    ];
+  },
 
-   getMetadataLinks: function(jsonLd) {
-     // #414
-      return [
-        {label: i18next.t('related'), value: this.stringifyRelated(jsonLd.related || '')},
-        {label: i18next.t('seeAlso'), value: this.stringifyRelated(jsonLd.seeAlso || '')},
-        {label: i18next.t('within'),  value: this.getWithin(jsonLd.within || '')}
-      ];
-   },
+  getMetadataLinks: function(jsonLd) {
+    // #414
+    return [
+      {
+        identifier: 'related',
+        label: i18next.t('related'),
+        value: this.stringifyRelated(jsonLd.related || '')
+      }, {
+        identifier: 'seeAlso',
+        label: i18next.t('seeAlso'),
+        value: this.stringifyRelated(jsonLd.seeAlso || '')
+      }, {
+        identifier: 'within',
+        label: i18next.t('within'),
+        value: this.getWithin(jsonLd.within || '')
+      }
+    ];
+  },
 
    getWithin: function(within) {
      if (typeof within === 'object' && within['@type'] === 'sc:Collection') {
@@ -248,7 +266,7 @@
         '{{#if rights}}',
         '<div class="{{metadataListingCls}}">',
           '{{#each rights}}',
-            '<div class="metadata-item"><div class="metadata-label">{{label}}:</div><div class="metadata-value">{{{value}}}</div></div>',
+            '<div class="metadata-item {{identifier}}"><div class="metadata-label">{{label}}:</div><div class="metadata-value">{{{value}}}</div></div>',
           '{{/each}}',
           '{{#if logo}}',
             '<div class="metadata-item"><div class="metadata-label">{{t "logo"}}:</div><img class="metadata-logo" src="{{logo}}"/></div>',
@@ -263,7 +281,7 @@
         '<div class="sub-title">{{t "links"}}:</div>',
         '<div class="{{metadataListingCls}}">',
           '{{#each links}}',
-            '<div class="metadata-item"><div class="metadata-label">{{label}}:</div><div class="metadata-value">{{{value}}}</div></div>',
+            '<div class="metadata-item {{identifier}}"><div class="metadata-label">{{label}}:</div><div class="metadata-value">{{{value}}}</div></div>',
           '{{/each}}',
         // '{{#if relatedLinks}}',
         //   '<dt>{{label}}:</dt><dd>{{{value}}}</dd>',

--- a/spec/widgets/metadataView.test.js
+++ b/spec/widgets/metadataView.test.js
@@ -50,9 +50,9 @@ describe('MetadataView', function() {
   describe('stringifyRelated', function() {
     it('should handle arrays of strings', function() {
       expect(subject.stringifyRelated([
-        'http://projectmirador.org', 
-        '', 
-        'http://iiif.io', 
+        'http://projectmirador.org',
+        '',
+        'http://iiif.io',
         'http://github.com/iiif'
       ])).toEqual(
         '<a href="http://projectmirador.org" target="_blank">http://projectmirador.org</a>' +
@@ -102,14 +102,14 @@ describe('MetadataView', function() {
         license: 'CC-BY-ND 2.0',
         attribution: 'Oodlepods Fellowship International'
       })).toEqual([
-        { label: 'license', value: 'CC-BY-ND 2.0' },
-        { label: 'attribution', value: 'Oodlepods Fellowship International' }
+        { identifier: 'license', label: 'license', value: 'CC-BY-ND 2.0' },
+        { identifier: 'attribution', label: 'attribution', value: 'Oodlepods Fellowship International' }
       ]);
     });
     it('should default to blanks when not present', function() {
       expect(subject.getMetadataRights(this.manifest.jsonLd)).toEqual([
-        { label: 'license', value: '' },
-        { label: 'attribution', value: '' }
+        { identifier: 'license', label: 'license', value: '' },
+        { identifier: 'attribution', label: 'attribution', value: '' }
       ]);
     });
   });
@@ -121,16 +121,16 @@ describe('MetadataView', function() {
         seeAlso: "http://oodlepods.example.net",
         within: "Oodlepods Monthly Issue #6"
       })).toEqual([
-        { label: 'related', value: '<a href="http://news.example.net" target="_blank">http://news.example.net</a>' },
-        { label: 'seeAlso', value: '<a href="http://oodlepods.example.net" target="_blank">http://oodlepods.example.net</a>' },
-        { label: 'within', value: 'Oodlepods Monthly Issue #6' }
+        { identifier: 'related', label: 'related', value: '<a href="http://news.example.net" target="_blank">http://news.example.net</a>' },
+        { identifier: 'seeAlso', label: 'seeAlso', value: '<a href="http://oodlepods.example.net" target="_blank">http://oodlepods.example.net</a>' },
+        { identifier: 'within', label: 'within', value: 'Oodlepods Monthly Issue #6' }
       ]);
     });
     it('should default to blanks when not present', function() {
       expect(subject.getMetadataLinks(this.manifest.jsonLd)).toEqual([
-        { label: 'related', value: '' },
-        { label: 'seeAlso', value: '' },
-        { label: 'within', value: '' }
+        { identifier: 'related', label: 'related', value: '' },
+        { identifier: 'seeAlso', label: 'seeAlso', value: '' },
+        { identifier: 'within', label: 'within', value: '' }
       ]);
     });
   });


### PR DESCRIPTION
This PR adds static identifiers to the rights and links metadata items, that are used as classname in the rendering step. This can be useful for styling these sections in the metadata sidepanel via easy CSS rules:

```css
.metadata-item.within {
  color: red;
}
.metadata-item.license > .metadata-value {
  font-weight: bold;
}
```