### PR TITLE
Band-aid for hiding the gray line in #1320 from view

### DIFF
--- a/css/mirador.less/overrides/qtip.less
+++ b/css/mirador.less/overrides/qtip.less
@@ -1,5 +1,6 @@
 .mirador-container {
   .qtip {
+      border: none;
   }
 
   .qtip-bootstrap {


### PR DESCRIPTION
Since PR #1361 is now stagnant due to scope issues, I'm pushing up a small patch that hides the unwanted gray line in #1320 until the underlying cause is addressed. Some use cases such as manuscript studies are sensitive to visual noise and would benefit from the patch in the short term.