### PR TITLE
Show a manifest button in every window

### DIFF
--- a/css/less/global.less
+++ b/css/less/global.less
@@ -113,7 +113,8 @@
 
   .mirador-viewer a.mirador-icon-view-type,
   .mirador-viewer a.mirador-icon-metadata-view,
-  .mirador-viewer a.mirador-osd-fullscreen  {
+  .mirador-viewer a.mirador-osd-fullscreen,
+  .mirador-viewer a.mirador-icon-manifest-link {
     background: none;
     color: @gray-91;
     box-sizing: border-box;
@@ -142,13 +143,15 @@
   .mirador-viewer a.mirador-icon-empty-slot:hover,
   .mirador-viewer a.mirador-icon-window-menu:hover,
   .mirador-viewer a.mirador-icon-toc:hover,
-  .mirador-viewer a.mirador-osd-fullscreen:hover {
+  .mirador-viewer a.mirador-osd-fullscreen:hover,
+  .mirador-viewer a.mirador-icon-manifest-link:hover {
     color: @black;
   }
 
   .mirador-viewer a.mirador-icon-view-type.selected,
   .mirador-viewer a.mirador-icon-toc.selected,
-  .mirador-viewer a.mirador-icon-metadata-view.selected {
+  .mirador-viewer a.mirador-icon-metadata-view.selected,
+  .mirador-viewer a.mirador-icon-manifest-link:hover{
     color: @black;
   }
 

--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -54,7 +54,8 @@
         "ScrollView" : "fa fa-ellipsis-h fa-lg fa-fw",
         "ThumbnailsView" : "fa fa-th fa-lg fa-rotate-90 fa-fw"
       },
-      userButtons: null
+      userButtons: null,
+      showManifestButton: false
     }, options);
 
     this.init();
@@ -156,6 +157,10 @@
       templateData.currentFocusClass = _this.iconClasses[_this.viewType];
       templateData.showFullScreen = _this.fullScreen;
       templateData.userButtons = _this.userButtons;
+      templateData.showManifestButton = _this.showManifestButton;
+      if(_this.showManifestButton) {
+        templateData.manifestLink = manifest['@id'];
+      }
       _this.element = jQuery(this.template(templateData)).appendTo(_this.appendTo);
       this.element.find('.manifest-info .mirador-tooltip').each(function() {
         jQuery(this).qtip({
@@ -1010,6 +1015,11 @@
          '<div class="window-manifest-navigation">',
          '{{#if userButtons}}',
            '{{windowuserbtns userButtons}}',
+         '{{/if}}',
+         '{{#if showManifestButton}}',
+         '<a href="{{manifestLink}}" target="_blank" class="mirador-btn mirador-icon-manifest-link mirador-tooltip" role="button" title="{{t "manifestTooltip"}}" aria-label="{{t "manifestTooltip"}}">',
+         '<i class="fa fa-file-text-o fa-lg fa-fw"></i>',
+         '</a>',
          '{{/if}}',
          '<a href="javascript:;" class="mirador-btn mirador-icon-view-type" role="button" title="{{t "viewTypeTooltip"}}" aria-label="{{t "viewTypeTooltip"}}">',
          '<i class="{{currentFocusClass}}"></i>',

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -52,6 +52,7 @@
     "links": "Links",
     "load": "Laden",
     "logo": "Logo",
+    "manifestTooltip": "Manifest dieses Objekts anzeigen",
     "metadataTooltip": "Informationen/Metadaten über dieses Objekt anzeigen",
     "more": "mehr",
     "newObject": "Neues Objekt",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -57,6 +57,7 @@
   "links": "Links",
   "load": "Load",
   "logo": "Logo",
+  "manifestTooltip": "View manifest of this object",
   "metadataTooltip": "View information/metadata about this object",
   "mirrorTooltip": "Mirror image",
   "more": "more",

--- a/spec/workspaces/window.test.js
+++ b/spec/workspaces/window.test.js
@@ -77,7 +77,7 @@ describe('Window', function() {
               thumbnail: {
                 '@id': "https://ids.lib.harvard.edu/ids/iiif/5981098/full/,150/0/native.jpg",
                 '@type': "dctypes:Image"
-}
+              }
             }, {
               '@id': "https://purl.stanford.edu/qm670kv1873/iiif/canvas/image_1",
               '@type': "sc:Canvas",
@@ -122,7 +122,8 @@ describe('Window', function() {
               'href': 'http://example.com',
               'target': '_blank'
             }
-          }]
+          }],
+          showManifestButton: true
         }));
     });
 
@@ -145,6 +146,13 @@ describe('Window', function() {
         var calls = Mirador.ImageView.calls;
         expect(calls.count()).toBe(1);
         expect(calls.first().args[0].appendTo.is(this.appendTo.find('.view-container'))).toBe(true);
+      });
+
+      it('should place default buttons in DOM', function(){
+        expect(this.appendTo.find('.mirador-icon-manifest-link')).toExist();
+        expect(this.appendTo.find('.mirador-icon-view-type')).toExist();
+        expect(this.appendTo.find('.mirador-icon-metadata-view')).toExist();
+        expect(this.appendTo.find('.mirador-osd-fullscreen')).toExist();
       });
 
       it('should place user buttons in DOM', function(){


### PR DESCRIPTION
This PR adds the possibility to show a manifest button, that opens the manifest url in a new tab. Configuration is possible either in `windowObjects` or `windowSettings` with the key `showManifestButton`, default is false.