### PR TITLE
Fixes #1441 - remove recursions before saving config state

### DIFF
--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -72,6 +72,7 @@
     this.init(newConfig);
   };
 
+
   $.SaveController.prototype = {
 
     init: function(config) {
@@ -372,6 +373,37 @@
 
     },
 
+  cleanup: function(obj) {
+
+    /**
+     * Setup a Set to track the objects we have
+     * already cloned - this clean circular refs.
+     **/
+    var clonedSet = new Set();
+
+    function cloner(obj) {
+
+      if(obj === null || typeof(obj) != 'object') {
+        return obj;
+      }
+
+      if (!clonedSet.has(obj)) {
+        clonedSet.add(obj);
+        var temp = Array.isArray(obj) ? [] : {};
+        for(var key in obj) {
+          if (obj.hasOwnProperty(key)) {
+            temp[key] = cloner(obj[key]);
+          }
+        }
+        return temp;
+      }
+
+      return undefined;
+    }
+
+    return cloner(obj);
+  }
+
     save: function() {
       var _this = this;
 
@@ -379,7 +411,7 @@
       // localStorage is a key:value store that
       // only accepts strings.
 
-      localStorage.setItem(_this.sessionID, JSON.stringify(_this.currentConfig));
+      localStorage.setItem(_this.sessionID, JSON.stringify(_this.cleanup(_this.currentConfig)));
     }
 
   };

--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -373,36 +373,36 @@
 
     },
 
-  cleanup: function(obj) {
+    cleanup: function(obj) {
 
-    /**
-     * Setup a Set to track the objects we have
-     * already cloned - this clean circular refs.
-     **/
-    var clonedSet = new Set();
+      /**
+       * Setup a Set to track the objects we have
+       * already cloned - this clean circular refs.
+       **/
+      var clonedSet = new Set();
 
-    function cloner(obj) {
+      function cloner(obj) {
 
-      if(obj === null || typeof(obj) != 'object') {
-        return obj;
-      }
-
-      if (!clonedSet.has(obj)) {
-        clonedSet.add(obj);
-        var temp = Array.isArray(obj) ? [] : {};
-        for(var key in obj) {
-          if (obj.hasOwnProperty(key)) {
-            temp[key] = cloner(obj[key]);
-          }
+        if(obj === null || typeof(obj) != 'object') {
+          return obj;
         }
-        return temp;
+
+        if (!clonedSet.has(obj)) {
+          clonedSet.add(obj);
+          var temp = Array.isArray(obj) ? [] : {};
+          for(var key in obj) {
+            if (obj.hasOwnProperty(key)) {
+              temp[key] = cloner(obj[key]);
+            }
+          }
+          return temp;
+        }
+
+        return undefined;
       }
 
-      return undefined;
-    }
-
-    return cloner(obj);
-  }
+      return cloner(obj);
+    },
 
     save: function() {
       var _this = this;

--- a/js/src/viewer/bookmarkPanel.js
+++ b/js/src/viewer/bookmarkPanel.js
@@ -47,7 +47,7 @@
 
     onConfigUpdated: function() {
       var _this = this;
-      _this.storageModule.save(_this.state.currentConfig)
+      _this.storageModule.save(_this.state.cleanup(_this.state.currentConfig))
       .then(function(blobId) {
         var bookmarkURL = window.location.href.replace(window.location.hash, '') + "?json="+blobId;
         _this.element.find('#share-url').val(bookmarkURL).focus().select();

--- a/spec/utils/saveController.test.js
+++ b/spec/utils/saveController.test.js
@@ -123,6 +123,32 @@ describe('SaveController', function () {
     });
   });
   
+  describe('Test Cleaning Up Objects', function () {
+    it('should remove circular references', function () {
+
+      var saveController = new Mirador.SaveController(this.config);
+      
+      var object_a = { valid: 'This is a valid value' };
+      var object_b = { valid: 'This is a valid value', invalid: object_a };
+      object_a.object_b = object_b;
+
+      var cleaned = saveController.cleanup(object_a);
+
+      /**
+        * The original object should be untouched. 
+        */
+      expect(object_a.object_b.invalid).not.toBeUndefined();
+
+      /**
+        * object_a reference in cleaned should be the only 
+        * value missing.
+        */
+      expect(cleaned.valid).toBe('This is a valid value');
+      expect(cleaned.object_b.invalid).toBeUndefined();
+      expect(cleaned.object_b.valid).toBe('This is a valid value');
+    });
+  });
+
   describe('Event handling', function () {
     xit('should handle windowUpdated', function () {
     });


### PR DESCRIPTION
This PR has the following changes:

  * Added a cleanup function that will remove all the objects that are referenced more than once;
  * Use the cleanup function before saving to localStorage;
  * Cleanup configuration before sending to storage adapter - via the bookmarks controller.

 Not perfect, I admin - but resolves the issue while we find a better solution for it.
