### PR TITLE
Add manifest url in metadata view

### DIFF
--- a/js/src/widgets/metadataView.js
+++ b/js/src/widgets/metadataView.js
@@ -174,6 +174,10 @@
         label: i18next.t('seeAlso'),
         value: this.stringifyRelated(jsonLd.seeAlso || '')
       }, {
+        identifier: 'manifest',
+        label: i18next.t('manifest'),
+        value: this.stringifyRelated(jsonLd['@id'] || '')
+      }, {
         identifier: 'within',
         label: i18next.t('within'),
         value: this.getWithin(jsonLd.within || '')

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -57,6 +57,7 @@
   "links": "Links",
   "load": "Load",
   "logo": "Logo",
+  "manifest": "IIIF Manifest",
   "metadataTooltip": "View information/metadata about this object",
   "mirrorTooltip": "Mirror image",
   "more": "more",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -53,6 +53,7 @@
     "links": "Liens",
     "load": "Ajouter",
     "logo": "Logo",
+    "manifest": "Manifest IIIF",
     "metadataTooltip": "Afficher les informations/métadonnées",
     "mirrorTooltip": "Retourner l'image (axe horizontal)",
     "more": "restants",


### PR DESCRIPTION
Append manifest url to the "Links" section of the metadata panel (between `seeAlso` and `within`)
Add en/fr locales for the label