### PR TITLE
[WIP] sidebar annotations panel to display annotations

### DIFF
--- a/css/mirador.less/panels/side-panel.less
+++ b/css/mirador.less/panels/side-panel.less
@@ -43,6 +43,13 @@
       margin: 0 -2px;
     }
 
+    .annotationListItemAlt {
+      list-style-type: none;
+      border-left:0;
+      border-right:0;
+      padding:10px 10px 10px 10px;
+    }
+
     .annotationListItem {
       list-style-type: none;
       border-left:0;
@@ -122,9 +129,23 @@
     transition: all 0.3s ease;
   }
 
-  .annotationsPanel ul {
-    padding:0;
-    margin:0;
+  .annotationsPanel {
+    margin: 0;
+    overflow-y: scroll;
+    width: 280px;
+    padding-right: 10px;
+    position: absolute;
+    box-sizing: border-box;
+    left: 0;
+    top: 0px;
+    bottom: 0;
+    list-style-type: none;
+    font-size: 75%;
+
+    ul {
+      padding:0;
+      margin:0;
+    }
   }
 
   .toc {
@@ -153,6 +174,7 @@
         overflow:hidden;
       }
     }
+
 
     ul {
       margin:0;

--- a/index.html
+++ b/index.html
@@ -26,8 +26,9 @@
          "id": "viewer",
          "layout": "1x1",
          "data": [
-           { "manifestUri": "https://iiif.lib.harvard.edu/manifests/drs:48309543", "location": "Harvard University"},
-           { "manifestUri": "https://iiif.lib.harvard.edu/manifests/drs:5981093", "location": "Harvard University"},
+           { "manifestUri": "https://scta.info/iiif/codex/sorb/manifest"},
+           { "manifestUri": "https://scta.info/iiif/graciliscommentary/lon/manifest"}
+           /*{ "manifestUri": "https://iiif.lib.harvard.edu/manifests/drs:5981093", "location": "Harvard University"},
            { "manifestUri": "https://iiif.lib.harvard.edu/manifests/via:olvwork576793", "location": "Harvard University"},
            { "manifestUri": "https://iiif.lib.harvard.edu/manifests/drs:14033171", "location": "Harvard University"},
            { "manifestUri": "https://iiif.lib.harvard.edu/manifests/drs:46909368", "location": "Harvard University"},
@@ -68,10 +69,15 @@
            { "manifestUri": "http://dzkimgs.l.u-tokyo.ac.jp/iiif/zuzoubu/12b02/manifest.json", "location": "University of Tokyo"},
            { "manifestUri": "http://www2.dhii.jp/nijl/NIJL0018/099-0014/manifest_tags.json", "location": "NIJL"},
            { "manifestUri": "http://digi.vatlib.it/iiif/MSS_Vat.lat.3225/manifest.json", "location": "Vatican Library"},
-           { "manifestUri": "http://media.nga.gov/public/manifests/nga_highlights.json", "location": "National Gallery of Art"}
+           { "manifestUri": "http://media.nga.gov/public/manifests/nga_highlights.json", "location": "National Gallery of Art"} */
          ],
          "windowObjects": [],
-         "annotationEndpoint": { "name":"Local Storage", "module": "LocalStorageEndpoint" }
+         "annotationEndpoint": { "name":"Local Storage", "module": "LocalStorageEndpoint" },
+         'windowSettings' : {
+           "sidePanelOptions" : {
+             "annotations" : true
+           }
+         }
        });
      });
     </script>

--- a/js/src/widgets/annotationsTab.js
+++ b/js/src/widgets/annotationsTab.js
@@ -58,8 +58,10 @@
                 annotationSources = [],
                 localState = this.localState();
             jQuery.each(_this.state.getWindowAnnotationsList(_this.windowId), function(index, value) {
-                if(typeof value.endpoint === 'string') {
-                    annotationSources.push('manifest');
+                if(value.endpoint && typeof value.endpoint === 'string' ) {
+                    annotationSources.push(value.resource);
+                } else if(value.resource.endpoint && typeof value.resource.endpoint === 'string' ) {
+                    annotationSources.push(value.resource);
                 } else {
                     annotationSources.push(value.endpoint.name);
                 }
@@ -148,14 +150,15 @@
 
             listItems.on('click', function(event) {
                 //event.stopImmediatePropagation();
-                var listClicked = jQuery(this).data('id');
-                if(_this.localState().selectedList === listClicked){
-                    //_this.deselectList(listClicked);
-                    _this.eventEmitter.publish('listDeselected.' + _this.windowId, listClicked);
-                }else{
-                    //_this.selectList(listClicked);
-                    _this.eventEmitter.publish('listSelected.' + _this.windowId, listClicked);
-                }
+
+                // var listClicked = jQuery(this).data('id');
+                // if(_this.localState().selectedList === listClicked){
+                //     //_this.deselectList(listClicked);
+                //     _this.eventEmitter.publish('listDeselected.' + _this.windowId, listClicked);
+                // }else{
+                //     //_this.selectList(listClicked);
+                //     _this.eventEmitter.publish('listSelected.' + _this.windowId, listClicked);
+                // }
 
             });
 
@@ -184,8 +187,11 @@
             '<div class="annotationsPanel">',
             '<ul class="annotationSources">',
             '{{#each annotationSources}}',
-            '<li class="annotationListItem {{#if this.selected}}selected{{/if}} {{#if this.focused }}focused{{/if}}" data-id="{{this.annotationSource}}">',
-                    '<span>{{this.annotationSource}}</span>',
+            // '<li class="annotationListItem {{#if this.selected}}selected{{/if}} {{#if this.focused }}focused{{/if}}" data-id="{{this.annotationSource.label}}">',
+            '<li class="annotationListItemAlt">',
+                    '<span style="font-weight: bold">{{{this.annotationSource.label}}}</span>',
+                    '<br/>',
+                    '<span>{{{this.annotationSource.chars}}}</span>',
             '</li>',
             '{{/each}}',
             '</ul>',

--- a/js/src/widgets/sidePanel.js
+++ b/js/src/widgets/sidePanel.js
@@ -28,23 +28,23 @@
             name : 'toc',
             options : {
               available: _this.tocTabAvailable,
-              id:'tocTab', 
+              id:'tocTab',
               label:'Index'
             }
           },
-          /*{
+          {
            name : 'annotations',
            options : {
            available: _this.annotationsTabAvailable,
-           id:'annotationsTab', 
+           id:'annotationsTab',
            label:'Annotations'
            }
-           },*/
+          },
           {
             name : 'layers',
             options : {
               available: _this.layersTabAvailable,
-              id:'layersTab', 
+              id:'layersTab',
               label:'Layers'
             }
           },
@@ -52,7 +52,7 @@
            name : 'tools',
            options : {
            available: _this.toolsTabAvailable,
-           id:'toolsTab', 
+           id:'toolsTab',
            label:'Tools'
            }
            }*/
@@ -93,6 +93,7 @@
           manifest: _this.manifest,
           windowId: this.windowId,
           appendTo: _this.element.find('.tabContentArea'),
+          canvasID: this.canvasID,
           state: _this.state,
           eventEmitter: _this.eventEmitter
         });
@@ -206,11 +207,11 @@
       if (!enableSidePanel) {
         jQuery(this.appendTo).hide();
         _this.eventEmitter.publish('ADD_CLASS.'+this.windowId, 'focus-max-width');
-        _this.eventEmitter.publish('HIDE_ICON_TOC.'+this.windowId);                
+        _this.eventEmitter.publish('HIDE_ICON_TOC.'+this.windowId);
       } else {
         jQuery(this.appendTo).show({effect: "fade", duration: 300, easing: "easeInCubic"});
         _this.eventEmitter.publish('REMOVE_CLASS.'+this.windowId, 'focus-max-width');
-        _this.eventEmitter.publish('SHOW_ICON_TOC.'+this.windowId);                
+        _this.eventEmitter.publish('SHOW_ICON_TOC.'+this.windowId);
       }
     }
   };


### PR DESCRIPTION
I turned on primitive use of sidebar annotations panel to display annotations with and without coordinate; slide bug in tag selection event, but basic functionality seems to work; still needs tests

This was based off the 2.4 branch. 

While this doesn't work perfectly yet, it works well enough. I'm not able to test it with annotations coming from and storage endpoint, so I don't know yet if it works with these kinds of annotations.

Nevertheless, it is an improvement on what we have, and it touches on almost no other code. The only real change is the annotationsTab. Likewise, because it has to be turned on in the configuration settings, no one who doesn't want it will even know it is there.

Being able to turn it on might alert people to its existence and inspire them to help make it better as well

![mirador-annotation-side-panel](https://user-images.githubusercontent.com/1146685/29184385-fd5a2d5e-7dd3-11e7-87a9-35ffde148630.gif)

