### PR TITLE
Improvement for the annotation deletion confirm dialog

### DIFF
--- a/js/src/annotations/annotationTooltip.js
+++ b/js/src/annotations/annotationTooltip.js
@@ -193,7 +193,7 @@
       jQuery(selector + ' a.delete').on("click", function(event) {
         event.preventDefault();
         var elem = this;
-        new $.DialogBuilder(viewerParams.container).dialog({
+        new $.DialogBuilder(document.body).dialog({
           message: i18next.t('deleteAnnotation'),
           closeButton: false,
           buttons: {


### PR DESCRIPTION
This PR adds the confirm dialog, when deleting an annotation, to the document body instead of each window.