### PR TITLE
fixes #1485

### DIFF
--- a/css/less/workspace.less
+++ b/css/less/workspace.less
@@ -28,6 +28,9 @@
 
     .remove-slot-option {
       position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 1;
       margin: 10px;
       color: @gray;
       cursor: pointer;


### PR DESCRIPTION
#1485 is affecting more than just Safari. Other browsers where I have noticed it:
- Chrome Version 62.0.3202.62 (Official Build) (64-bit)
- Chromium Version 62.0.3202.94 (Official Build) Built on Ubuntu , running on Ubuntu 16.04 (64-bit)
- Firefox 57.0 (64-bit)

My fix works in each of those three environments and [should be supported in all of Mirador's target browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning). I undid a change made in `14dae3f` that changed the order of some DOM nodes, and therefore [changed their implicit stacking order](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index).

The `top` and `left` properties prevent the `remove-slot-option` link from moving if the DOM nodes are ever re-ordered again, or if any additional DOM nodes are added in front of it (as siblings).