### PR TITLE
Make i18nPath independent from buildPath

### DIFF
--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -172,7 +172,7 @@
 
     'buildPath' : 'build/mirador/',
 
-    'i18nPath' : 'locales/',
+    'i18nPath' : 'build/mirador/locales/',
 
     'imagesPath' : 'images/',
 
@@ -217,7 +217,7 @@
       'options': {
       }
     },
-    
+
     'sharingEndpoint': {
       'url': '',
       'storeId': 123,

--- a/js/src/viewer.js
+++ b/js/src/viewer.js
@@ -49,7 +49,7 @@
         load: 'unspecific',
         debug: false,
         backend: {
-          loadPath: _this.state.getStateProperty('buildPath') + _this.state.getStateProperty('i18nPath')+'{{lng}}/{{ns}}.json'
+          loadPath: _this.state.getStateProperty('i18nPath')+'{{lng}}/{{ns}}.json'
         }
       };
 
@@ -297,7 +297,7 @@
         });
       }
     },
-    
+
     addCollectionFromUrl: function(url, location, content) {
       var _this = this,
         collection;


### PR DESCRIPTION
This MR makes the i18nPath independent from the buildPath, so that one can host the locales anywhere.