### PR TITLE
Fix closing comment in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ To initialize Mirador, it needs to be attached to an existing HTML **div** throu
       $(function() {
         Mirador({
           id: "viewer",
-          data: [/* Manifests and collections here *]
+          data: [/* Manifests and collections here */]
         });
       });
     </script>


### PR DESCRIPTION
A small fix -- the closing slash was absent in a comment.