### PR TITLE
fix erroring NodeJS v5 builds on Travis CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-contrib-connect": "*",
     "grunt-contrib-copy": "*",
     "grunt-contrib-cssmin": "*",
-    "grunt-contrib-jasmine": "*",
+    "grunt-contrib-jasmine": "^1.2.0",
     "grunt-contrib-jshint": "*",
     "grunt-contrib-less": "^1.4.0",
     "grunt-contrib-uglify": "*",


### PR DESCRIPTION
As of 2.0.0, [`grunt-contrib-jasmine` depends on Puppeteer instead of PhantomJS](https://github.com/gruntjs/grunt-contrib-jasmine/blob/master/CHANGELOG). Puppeteer [requires Node 6.4.0 or greater](https://github.com/GoogleChrome/puppeteer#usage), which is why it has caused the Node 5 builds on Travis CI to error on all Mirador PRs that have been opened since the release of 2.0.0 on May 19, 2018 (e.g., the [latest as of this writing](https://travis-ci.org/ProjectMirador/mirador/jobs/436603809#L2596)).

`grunt-contrib-jasmine` was added as a dependency to Mirador before that dependency was at 2.0.0, so locking the version down to pre-2.0.0 should be fine.

inb4 all Travis builds for this PR succeed