### PR TITLE
Clear out window events on re-initialization

### DIFF
--- a/js/src/workspaces/window.js
+++ b/js/src/workspaces/window.js
@@ -69,6 +69,11 @@
           focusState = _this.viewType,
           templateData = {};
 
+      if (this.events) {
+        this.events.forEach(function(event){
+          _this.eventEmitter.unsubscribe(event.name,event.handler);
+        });
+      }
       this.events = [];
 
       //make sure annotations list is cleared out when changing objects within window


### PR DESCRIPTION
On window re-initialization, e.g. on layout change, unsubscribe any existing events to avoid duplicate event handling.  Not unsubscribing the `TOGGLE_BOTTOM_PANEL_VISIBILITY` event in particular causes the bottom panel toggling to stop working, since every click will toggle it twice, setting it back to its original state.