### PR TITLE
[WIP] Initialize Mirador windows from a config

### DIFF
--- a/__tests__/integration/mirador/configured.html
+++ b/__tests__/integration/mirador/configured.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+  </head>
+  <body>
+    <div id="mirador"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       miradorWindows: [
+         {
+           loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+         },
+         {
+           loadedManifest: 'https://media.nga.gov/public/manifests/nga_highlights.json'
+         }
+       ],
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -1,0 +1,43 @@
+import ReactDOM from 'react-dom';
+import MiradorViewer from '../../../src/lib/MiradorViewer';
+
+describe('MiradorViewer', () => {
+  let instance;
+  beforeAll(() => {
+    ReactDOM.render = jest.fn();
+    instance = new MiradorViewer({});
+  });
+  describe('constructor', () => {
+    it('returns viewer actions', () => {
+      expect(instance.actions.addWindow).toBeDefined();
+    });
+    it('returns viewer store', () => {
+      expect(instance.store.dispatch).toBeDefined();
+    });
+    it('renders via ReactDOM', () => {
+      expect(ReactDOM.render).toHaveBeenCalled();
+    });
+  });
+  describe('processPlugins', () => {
+    it('combines actionCreators and reducers', () => {
+      const fooPlugin = {
+        actions: {
+          fooAction: () => {},
+        },
+        reducers: {
+          fooReducer: null,
+        },
+      };
+      window.Mirador = {
+        plugins: {
+          fooPlugin,
+        },
+      };
+      instance = new MiradorViewer({
+        plugins: ['fooPlugin'],
+      });
+      expect(instance.actions.fooAction).toBeDefined();
+      expect(instance.store.pluginReducers).toBeDefined();
+    });
+  });
+});

--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -3,9 +3,14 @@ import MiradorViewer from '../../../src/lib/MiradorViewer';
 
 describe('MiradorViewer', () => {
   let instance;
+  let previousMirador;
   beforeAll(() => {
     ReactDOM.render = jest.fn();
     instance = new MiradorViewer({});
+    previousMirador = window;
+  });
+  afterAll(() => {
+    window.Mirador = previousMirador;
   });
   describe('constructor', () => {
     it('returns viewer actions', () => {
@@ -38,6 +43,25 @@ describe('MiradorViewer', () => {
       });
       expect(instance.actions.fooAction).toBeDefined();
       expect(instance.store.pluginReducers).toBeDefined();
+    });
+  });
+  describe('processWindows', () => {
+    it('fetches manifests and adds windows', () => {
+      instance = new MiradorViewer({
+        miradorWindows: [
+          {
+            loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+          },
+          {
+            loadedManifest: 'http://media.nga.gov/public/manifests/nga_highlights.json',
+          },
+        ],
+      });
+      expect(instance.store.getState().manifests).toEqual(expect.objectContaining({
+        'https://iiif.harvardartmuseums.org/manifests/object/299843': expect.anything(),
+        'http://media.nga.gov/public/manifests/nga_highlights.json': expect.anything(),
+      }));
+      expect(instance.store.getState().windows.length).toEqual(2);
     });
   });
 });

--- a/src/actions/window.js
+++ b/src/actions/window.js
@@ -20,7 +20,7 @@ export function addWindow(options) {
   const defaultOptions = {
     // TODO: Windows should be a hash with id's as keys for easy lookups
     // https://redux.js.org/faq/organizing-state#how-do-i-organize-nested-or-duplicate-data-in-my-state
-    id: `window-${new Date().valueOf()}`,
+    id: `window-${new Date().valueOf().toString(36) + Math.random().toString(36).substr(2)}`,
     canvasIndex: 0,
     collectionIndex: 0,
     manifestId: null,

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -26,13 +26,22 @@ class Window extends Component {
    */
   renderViewer() {
     const { manifest, window } = this.props;
-    if (manifest) {
-      return (
-        <WindowViewer
-          window={window}
-          manifest={manifest}
-        />
-      );
+    if (!manifest) return null;
+    switch (manifest.isFetching) {
+      case true:
+        return 'loading';
+      case false:
+        if (manifest.manifestation) {
+          return (
+            <WindowViewer
+              window={window}
+              manifest={manifest}
+            />
+          );
+        }
+        break;
+      default:
+        return null;
     }
     return null;
   }

--- a/src/init.js
+++ b/src/init.js
@@ -1,66 +1,9 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
-import deepmerge from 'deepmerge';
-import App from './components/App';
-import createRootReducer from './reducers/index';
-import { store, actions } from './store';
-import settings from './config/settings';
+import MiradorViewer from './lib/MiradorViewer';
 import './styles/index.scss';
-
-/**
- * Process Plugins
- */
-const processPlugins = (plugins = []) => {
-  const actionCreators = [];
-  const reducers = [];
-
-  plugins.forEach((pluginName) => {
-    const plugin = window.Mirador.plugins[pluginName];
-
-    // Add Actions
-    if (plugin.actions) {
-      Object.keys(plugin.actions)
-        .forEach(actionName => actionCreators.push({
-          name: actionName,
-          action: plugin.actions[actionName],
-        }));
-    }
-    // Add Reducers
-    if (plugin.reducers) {
-      Object.keys(plugin.reducers)
-        .forEach(reducerName => reducers.push({
-          name: reducerName,
-          reducer: plugin.reducers[reducerName],
-        }));
-    }
-  });
-
-  actionCreators.forEach((action) => { actions[action.name] = action.action; });
-  reducers.forEach((reducer) => { store.pluginReducers[reducer.name] = reducer.reducer; });
-  store.replaceReducer(createRootReducer(store.pluginReducers));
-};
 
 /**
  * Default Mirador instantiation
  */
 export default function (config) {
-  processPlugins(config.plugins);
-
-  const viewer = {
-    actions,
-    store,
-  };
-
-  const action = actions.setConfig(deepmerge(settings, config));
-  store.dispatch(action);
-
-  ReactDOM.render(
-    <Provider store={store}>
-      <App config={config} />
-    </Provider>,
-    document.getElementById(config.id),
-  );
-
-  return viewer;
+  return new MiradorViewer(config);
 }

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import deepmerge from 'deepmerge';
+import App from '../components/App';
+import createRootReducer from '../reducers/index';
+import { store, actions } from '../store';
+import settings from '../config/settings';
+
+/**
+ * Default Mirador instantiation
+ */
+class MiradorViewer {
+  /**
+   */
+  constructor(config) {
+    this.config = config;
+    this.processPlugins();
+
+    const viewer = {
+      actions,
+      store,
+    };
+
+    const action = actions.setConfig(deepmerge(settings, config));
+    store.dispatch(action);
+
+    ReactDOM.render(
+      <Provider store={store}>
+        <App config={config} />
+      </Provider>,
+      document.getElementById(config.id),
+    );
+
+    return viewer;
+  }
+
+  /**
+   * Process Plugins
+   */
+  processPlugins() {
+    const plugins = this.config.plugins || [];
+    const actionCreators = [];
+    const reducers = [];
+
+    plugins.forEach((pluginName) => {
+      const plugin = window.Mirador.plugins[pluginName];
+
+      // Add Actions
+      if (plugin.actions) {
+        Object.keys(plugin.actions)
+          .forEach(actionName => actionCreators.push({
+            name: actionName,
+            action: plugin.actions[actionName],
+          }));
+      }
+      // Add Reducers
+      if (plugin.reducers) {
+        Object.keys(plugin.reducers)
+          .forEach(reducerName => reducers.push({
+            name: reducerName,
+            reducer: plugin.reducers[reducerName],
+          }));
+      }
+    });
+
+    actionCreators.forEach((action) => { actions[action.name] = action.action; });
+    reducers.forEach((reducer) => { store.pluginReducers[reducer.name] = reducer.reducer; });
+    store.replaceReducer(createRootReducer(store.pluginReducers));
+  }
+}
+
+export default MiradorViewer;

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -16,6 +16,7 @@ class MiradorViewer {
   constructor(config) {
     this.config = config;
     this.processPlugins();
+    this.processWindows();
 
     const viewer = {
       actions,
@@ -33,6 +34,19 @@ class MiradorViewer {
     );
 
     return viewer;
+  }
+
+  /**
+   * Process Window
+   */
+  processWindows() {
+    const miradorWindows = this.config.miradorWindows || [];
+    miradorWindows.forEach((miradorWindow) => {
+      store.dispatch(actions.fetchManifest(miradorWindow.loadedManifest));
+      store.dispatch(actions.addWindow({
+        manifestId: miradorWindow.loadedManifest,
+      }));
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes #1579 

This PR does a few things that I hope improve overall experience. The original intent here is to move initialization code into a class for better testability, and long term maintaince structure, while still retaining the same function based API discussed w/ @aeschylus .

3aa974b resolves the issue where the manifest needs to be loaded before the window can render
2a23163 is needed as `new Date` is not enough (windows can be created at the same millisecond)

And the final commit adds a testable way to process windows added via config.

https://deploy-preview-1579--mirador-dev.netlify.com/__tests__/integration/mirador/configured.html