### PR TITLE
close viewer on tile change (cleans up existing tileSources)

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -38,10 +38,14 @@ class OpenSeadragonViewer extends Component {
   }
 
   /**
+   * When the tileSources change, make sure to close the OSD viewer.
    */
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const { tileSources } = this.props;
-    tileSources.forEach(tileSource => this.addTileSource(tileSource));
+    if (prevProps.tileSources !== tileSources) {
+      this.viewer.close();
+      tileSources.forEach(tileSource => this.addTileSource(tileSource));
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes a sizable memory leak.