### PR TITLE
Incorrect labels for infoResponse tests. Closes #1607

### DIFF
--- a/__tests__/src/actions/infoResponse.test.js
+++ b/__tests__/src/actions/infoResponse.test.js
@@ -42,13 +42,13 @@ describe('infoResponse actions', () => {
       beforeEach(() => {
         fetch.mockResponseOnce(JSON.stringify({ data: '12345' })); // eslint-disable-line no-undef
       });
-      it('dispatches the REQUEST_MANIFEST action', () => {
+      it('dispatches the REQUEST_INFO_RESPONSE action', () => {
         store.dispatch(actions.fetchInfoResponse('https://stacks.stanford.edu/image/iiif/sn904cj3429%2F12027000/info.json'));
         expect(store.getActions()).toEqual([
           { infoId: 'https://stacks.stanford.edu/image/iiif/sn904cj3429%2F12027000/info.json', type: 'REQUEST_INFO_RESPONSE' },
         ]);
       });
-      it('dispatches the REQUEST_MANIFEST and then RECEIVE_MANIFEST', () => {
+      it('dispatches the REQUEST_INFO_RESPONSE and then RECEIVE_INFO_RESPONSE', () => {
         store.dispatch(actions.fetchInfoResponse('https://stacks.stanford.edu/image/iiif/sn904cj3429%2F12027000/info.json'))
           .then(() => {
             const expectedActions = store.getActions();


### PR DESCRIPTION
Closes #1607 