### PR TITLE
Pass the window as a prop to the Window component instead of windowId

### DIFF
--- a/__tests__/src/components/Window.test.js
+++ b/__tests__/src/components/Window.test.js
@@ -13,7 +13,7 @@ describe('Window', () => {
       store.dispatch(actions.addWindow({ manifestId: 'foo' }));
       [window] = store.getState().windows;
       wrapper = mount(
-        <Window store={store} id={window.id} />,
+        <Window store={store} window={window} id={window.id} />,
         // We need to attach this to something created by our JSDOM instance.
         // Also need to provide context of the store so that connected sub components
         // can render effectively.
@@ -26,7 +26,14 @@ describe('Window', () => {
     });
 
     it('returns the width and height style attribute', () => {
-      wrapper = shallow(<Window store={store} id={window.id} />, { context: { store } });
+      wrapper = shallow(
+        <Window
+          store={store}
+          window={window}
+          id={window.id}
+        />,
+        { context: { store } },
+      );
       expect(wrapper.dive().instance().styleAttributes())
         .toEqual({ width: '400px', height: '400px' });
     });
@@ -46,7 +53,14 @@ describe('Window', () => {
     beforeEach(() => {
       store.dispatch(actions.addWindow({ manifestId: 'foo' }));
       [window] = store.getState().windows;
-      wrapper = shallow(<Window store={store} id={window.id} />, { context: { store } }).dive();
+      wrapper = shallow(
+        <Window
+          store={store}
+          window={window}
+          id={window.id}
+        />,
+        { context: { store } },
+      ).dive();
     });
 
     it('returns the width and height style attribute', () => {

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -71,12 +71,8 @@ Window.defaultProps = {
  * @memberof Window
  * @private
  */
-const mapStateToProps = ({ windows, manifests }, props) => {
-  const window = windows.find(win => props.id === win.id);
-  return {
-    window,
-    manifest: manifests[window.manifestId],
-  };
-};
+const mapStateToProps = ({ manifests }, props) => ({
+  manifest: manifests[props.window.manifestId],
+});
 
 export default connect(mapStateToProps)(Window);

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -14,8 +14,9 @@ const Workspace = ({ windows }) => (
     {
       windows.map(window => (
         <Window
-          key={window.id}
           id={window.id}
+          key={window.id}
+          window={window}
         />
       ))
     }


### PR DESCRIPTION
This prevents us from having to dereference the window out of the windows state by ID in mapStateToProps

Closes #1597 

