### PR TITLE
Provides a more collision resistant unique id generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "redux": "3.7.2",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "2.2.0",
-    "sass-loader": "^7.1.0"
+    "sass-loader": "^7.1.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/src/actions/window.js
+++ b/src/actions/window.js
@@ -1,3 +1,4 @@
+import uuid from 'uuid/v4';
 import ActionTypes from '../action-types';
 
 /**
@@ -20,7 +21,7 @@ export function addWindow(options) {
   const defaultOptions = {
     // TODO: Windows should be a hash with id's as keys for easy lookups
     // https://redux.js.org/faq/organizing-state#how-do-i-organize-nested-or-duplicate-data-in-my-state
-    id: `window-${new Date().valueOf()}`,
+    id: `window-${uuid()}`,
     canvasIndex: 0,
     collectionIndex: 0,
     manifestId: null,


### PR DESCRIPTION
When programmatically creating `Window`'s, millisecond when created is not unique enough and can cause some issues with windows having the same id.