### PR TITLE
Export unconnected component to better test Mirador components

### DIFF
--- a/__tests__/src/components/ViewerNavigation.test.js
+++ b/__tests__/src/components/ViewerNavigation.test.js
@@ -1,23 +1,43 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { store } from '../../../src/store';
-import ViewerNavigation from '../../../src/components/ViewerNavigation';
+import { ViewerNavigation } from '../../../src/components/ViewerNavigation';
 
 describe('ViewerNavigation', () => {
   let wrapper;
+  let nextCanvas;
+  let previousCanvas;
   beforeEach(() => {
-    wrapper = mount(
+    nextCanvas = jest.fn();
+    previousCanvas = jest.fn();
+    wrapper = shallow(
       <ViewerNavigation
         canvases={[1, 2]}
+        nextCanvas={nextCanvas}
+        previousCanvas={previousCanvas}
         window={{ canvasIndex: 0 }}
       />,
-      { context: { store } },
     );
   });
   it('renders the component', () => {
     expect(wrapper.find('.mirador-osd-navigation').length).toBe(1);
   });
-  it('if canvases are present then disabled on nextCanvas button should be false', () => {
-    expect(wrapper.find('.mirador-next-canvas-button').prop('disabled')).toBe(false);
+  describe('when next canvases are present', () => {
+    it('disabled on nextCanvas button', () => {
+      expect(wrapper.find('.mirador-next-canvas-button').prop('disabled')).toBe(false);
+    });
+    it('nextCanvas function is called after click', () => {
+      wrapper.find('.mirador-next-canvas-button').simulate('click');
+      expect(nextCanvas).toHaveBeenCalled();
+    });
+  });
+  describe('when previous canvases are not present', () => {
+    it('disabled on previousCanvas button', () => {
+      expect(wrapper.find('.mirador-previous-canvas-button').prop('disabled')).toBe(true);
+    });
+    it('previousCanvas function is not called after click, as its disabled', () => {
+      wrapper.find('.mirador-previous-canvas-button').simulate('click');
+      expect(nextCanvas).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -7,7 +7,7 @@ import ns from '../config/css-ns';
 
 /**
  */
-class ViewerNavigation extends Component {
+export class ViewerNavigation extends Component {
   /**
    */
   constructor(props) {

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { actions } from '../store';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import OpenSeadragonViewer from './OpenSeadragonViewer';
-import ViewerNavigation from './ViewerNavigation';
+import ConnectedViewerNavigation from './ViewerNavigation';
 
 /**
  * Represents a WindowViewer in the mirador workspace. Responsible for mounting
@@ -85,7 +85,7 @@ class WindowViewer extends Component {
           tileSources={this.tileInfoFetchedFromStore()}
           window={window}
         />
-        <ViewerNavigation window={window} canvases={this.canvases} />
+        <ConnectedViewerNavigation window={window} canvases={this.canvases} />
       </Fragment>
     );
   }


### PR DESCRIPTION
Based off of group discussion in #1611 

Seems like a really useful approach for us to test components easier and also provide unconnected for reuse in plugins/ custom apps.