### PR TITLE
Refactor mapDispatchToProps to more readable pattern (fixes #1624)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -107,11 +107,7 @@ const mapStateToProps = state => (
  * @memberof App
  * @private
  */
-const mapDispatchToProps = dispatch => ({
-  fetchManifest: manifestUrl => (
-    dispatch(actions.fetchManifest(manifestUrl))
-  ),
-});
+const mapDispatchToProps = { fetchManifest: actions.fetchManifest };
 
 export default connect(
   mapStateToProps,

--- a/src/components/ManifestForm.js
+++ b/src/components/ManifestForm.js
@@ -87,11 +87,7 @@ const mapStateToProps = () => (
  * @memberof ManifestForm
  * @private
  */
-const mapDispatchToProps = dispatch => ({
-  fetchManifest: manifestUrl => (
-    dispatch(actions.fetchManifest(manifestUrl))
-  ),
-});
+const mapDispatchToProps = { fetchManifest: actions.fetchManifest };
 
 export default connect(
   mapStateToProps,

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -50,11 +50,7 @@ const mapStateToProps = () => (
  * @memberof ManifestListItem
  * @private
  */
-const mapDispatchToProps = dispatch => ({
-  addWindow: options => (
-    dispatch(actions.addWindow(options))
-  ),
-});
+const mapDispatchToProps = { addWindow: actions.addWindow };
 
 export default connect(
   mapStateToProps,

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -85,9 +85,9 @@ ViewerNavigation.propTypes = {
  * @memberof ManifestForm
  * @private
  */
-const mapDispatchToProps = dispatch => ({
-  nextCanvas: windowId => dispatch(actions.nextCanvas(windowId)),
-  previousCanvas: windowId => dispatch(actions.previousCanvas(windowId)),
-});
+const mapDispatchToProps = {
+  nextCanvas: actions.nextCanvas,
+  previousCanvas: actions.previousCanvas,
+};
 
 export default connect(null, mapDispatchToProps)(miradorWithPlugins(ViewerNavigation));

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -44,11 +44,7 @@ class WindowTopBar extends Component {
  * @memberof ManifestListItem
  * @private
  */
-const mapDispatchToProps = dispatch => ({
-  removeWindow: windowId => (
-    dispatch(actions.removeWindow(windowId))
-  ),
-});
+const mapDispatchToProps = { removeWindow: actions.removeWindow };
 
 WindowTopBar.propTypes = {
   manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -107,9 +107,7 @@ const mapStateToProps = state => (
  * @memberof WindowViewer
  * @private
  */
-const mapDispatchToProps = dispatch => ({
-  fetchInfoResponse: infoId => dispatch(actions.fetchInfoResponse(infoId)),
-});
+const mapDispatchToProps = { fetchInfoResponse: actions.fetchInfoResponse };
 
 WindowViewer.propTypes = {
   infoResponses: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types


### PR DESCRIPTION
Fixes #1624 
Before:

```js
const mapDispatchToProps = dispatch => ({
  fetchManifest: manifestUrl => (
    dispatch(actions.fetchManifest(manifestUrl))
  ),
});
```

After:
```js
const mapDispatchToProps = { fetchManifest: actions.fetchManifest };
```