### PR TITLE
Fix async problems if manifest loads too slow

### DIFF
--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -26,7 +26,7 @@ class Window extends Component {
    */
   renderViewer() {
     const { manifest, window } = this.props;
-    if (manifest) {
+    if (manifest && manifest.isFetching === false) {
       return (
         <WindowViewer
           window={window}


### PR DESCRIPTION
If loading the manifest takes too long the Viewer tries to process it before it's there.