### PR TITLE
Run tests using headless chrome by default

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   launch: {
-    headless: process.env.CI === 'true',
+    headless: process.env.HEADLESS !== 'false',
   },
   server: {
     command: 'npm run server -- -p 4488',


### PR DESCRIPTION
Instead of opting out of headless mode (using `CI=true`), switch the jest-puppeteer configuration to use an opt-in environment variable (`HEADLESS=false`).