### PR TITLE
Zoom OSD canvas based off of the first tilesource passed in

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -23,4 +23,34 @@ describe('OpenSeadragonViewer', () => {
       expect(wrapper.instance().tileSourcesMatch([{ '@id': 'http://foo' }])).toBe(true);
     });
   });
+  describe('addTileSource', () => {
+    it('calls addTiledImage asynchronously on the OSD viewer', async () => {
+      wrapper.instance().viewer = {
+        addTiledImage: jest.fn().mockResolvedValue('event'),
+      };
+      wrapper.instance().addTileSource({}).then((event) => {
+        expect(event).toBe('event');
+      });
+    });
+    it('when a viewer is not available, returns an unresolved Promise', () => {
+      expect(wrapper.instance().addTileSource({})).toEqual(expect.any(Promise));
+    });
+  });
+  describe('fitBounds', () => {
+    it('calls OSD viewport.fitBounds with provided x, y, w, h', () => {
+      wrapper.instance().viewer = {
+        viewport: {
+          fitBounds: jest.fn(),
+          imageToViewportRectangle: jest.fn(),
+        },
+      };
+      wrapper.instance().fitBounds(1, 2, 3, 4);
+      expect(
+        wrapper.instance().viewer.viewport.imageToViewportRectangle,
+      ).toHaveBeenCalledWith(1, 2, 3, 4);
+      expect(
+        wrapper.instance().viewer.viewport.fitBounds,
+      ).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -44,7 +44,15 @@ export class OpenSeadragonViewer extends Component {
     const { tileSources } = this.props;
     if (!this.tileSourcesMatch(prevProps.tileSources)) {
       this.viewer.close();
-      tileSources.forEach(tileSource => this.addTileSource(tileSource));
+      Promise.all(
+        tileSources.map(tileSource => this.addTileSource(tileSource)),
+      ).then(() => {
+        // TODO: An incredibly naive way to evaluate this for now. Update this
+        // to handle multiple canvases in the future.
+        if (tileSources[0]) {
+          this.fitBounds(0, 0, tileSources[0].width, tileSources[0].height);
+        }
+      });
     }
   }
 
@@ -57,11 +65,25 @@ export class OpenSeadragonViewer extends Component {
   /**
    */
   addTileSource(tileSource) {
-    this.viewer.addTiledImage({
-      tileSource,
-      success: (event) => {
-      },
+    return new Promise((resolve, reject) => {
+      if (!this.viewer) {
+        return;
+      }
+      this.viewer.addTiledImage({
+        tileSource,
+        success: event => resolve(event),
+        error: event => reject(event),
+      });
     });
+  }
+
+  /**
+   */
+  fitBounds(x, y, w, h) {
+    this.viewer.viewport.fitBounds(
+      this.viewer.viewport.imageToViewportRectangle(x, y, w, h),
+      true,
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes #1674 

Useful fixture manifest with canvases that vary in size: https://media.nga.gov/public/manifests/nga_highlights.json

## Before
![canvassize](https://user-images.githubusercontent.com/1656824/51566178-23019000-1e51-11e9-9b0f-32a3307df566.gif)
## After
![canvassizefix](https://user-images.githubusercontent.com/1656824/51572900-58fc3f80-1e64-11e9-85dd-f3a9fbd1918c.gif)
