### PR TITLE
Enhance thumbnail navigation to be handled by a react-virtualized for increasing performance

### DIFF
--- a/__mocks__/css.js
+++ b/__mocks__/css.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -5,6 +5,7 @@ import { ThumbnailNavigation } from '../../../src/components/ThumbnailNavigation
 describe('ThumbnailNavigation', () => {
   let wrapper;
   let setCanvas;
+  let renderedGrid;
   beforeEach(() => {
     setCanvas = jest.fn();
     wrapper = shallow(
@@ -12,9 +13,15 @@ describe('ThumbnailNavigation', () => {
         canvases={[
           {
             index: 0,
+            getHeight: () => (1000),
+            getWidth: () => (2000),
+            getCanonicalImageUri: () => ('http://imageuri'),
           },
           {
             index: 1,
+            getHeight: () => (1000),
+            getWidth: () => (2000),
+            getCanonicalImageUri: () => ('http://imageuri'),
           },
         ]}
         window={{
@@ -26,18 +33,26 @@ describe('ThumbnailNavigation', () => {
         setCanvas={setCanvas}
       />,
     );
+    renderedGrid = wrapper.find('AutoSizer')
+      .dive()
+      .find('Grid')
+      .dive();
   });
   it('renders the component', () => {
     expect(wrapper.find('.mirador-thumb-navigation').length).toBe(1);
   });
   it('renders li elements based off of number of canvases', () => {
-    expect(wrapper.find('.mirador-thumbnail-nav-canvas').length).toBe(2);
+    expect(renderedGrid.find('.mirador-thumbnail-nav-canvas').length).toBe(2);
   });
   it('sets a mirador-current-canvas class on current canvas', () => {
     expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas'));
   });
   it('when clicked, updates the current canvas', () => {
-    wrapper.find('.mirador-thumbnail-nav-canvas-0').simulate('click');
+    renderedGrid.find('.mirador-thumbnail-nav-canvas-0').simulate('click');
     expect(setCanvas).toHaveBeenCalledWith('foobar', 0);
+  });
+  it('sets up calculated width based off of height of area and dimensions of canvas', () => {
+    expect(renderedGrid.find('.mirador-thumbnail-nav-container').first().prop('style').width).toEqual(308);
+    expect(renderedGrid.find('.mirador-thumbnail-nav-canvas').first().prop('style').width).toEqual(300);
   });
 });

--- a/jest.json
+++ b/jest.json
@@ -5,6 +5,9 @@
   ],
   "coverageDirectory": "<rootDir>/coverage",
   "coverageReporters": ["html", "lcov"],
+  "moduleNameMapper": {
+    "\\.css$": "<rootDir>/__mocks__/css.js"
+  },
   "setupFiles": [
     "<rootDir>/setupJest.js"
   ],

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^16.7.0",
     "react-dom": "^16.4.0",
     "react-redux": "^5.0.7",
+    "react-virtualized": "^9.21.0",
     "redux": "4.0.1",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "2.2.0",

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -43,34 +43,15 @@ body {
 
   &-thumb-navigation {
     bottom: 0;
-    padding-left: 8px;
-    padding-right: 8px;
     position: absolute;
     width: 100%;
 
-    ul {
-      display: flex;
-      flex-wrap: nowrap;
-      height: 100%;
-      list-style: none;
-      margin-block-end: 0;
-      margin-block-start: 0;
-      min-width: 100%;
-      overflow-x: auto;
-      padding-inline-start: 0;
-    }
-
-    li {
+    .mirador-thumbnail-nav-canvas {
       background-color: $gray;
       border: 1px solid $black;
       color: $white;
       cursor: pointer;
-      display: flex;
-      flex: 0 0 auto;
       height: 100%;
-      margin-left: 2px;
-      margin-right: 8px;
-      min-width: 40px;
 
       &.mirador-current-canvas {
         border: 3px solid $blue;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,7 +73,7 @@ const baseConfig = [
         eslintLoaderConfig,
         babelLoaderConfig,
         {
-          test: /\.scss$/,
+          test: /\.s?css$/,
           use: [
             'style-loader', // creates style nodes from JS strings
             'css-loader', // translates CSS into CommonJS


### PR DESCRIPTION
Manifests with many canvases will cause performance bottlenecks in canvas navigation type interfaces. This PR aims to solve that problem.

Also creates `Grid` cells sized based on the height of the thumb area, and the canvas aspect ratio.

Fixes #1688 

![virtualized](https://user-images.githubusercontent.com/1656824/51768586-f68e8380-209d-11e9-83a5-4e1f26cdc262.gif)
