### PR TITLE
add size task useful for providing size of current distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "node_modules/.bin/eslint ./ && node_modules/.bin/sass-lint -v ./src/styles/**/*",
     "server": "node_modules/.bin/http-server",
-    "test": "npm run build && npm run lint && jest -c jest.json",
+    "test": "npm run build && npm run lint && npm run size && jest -c jest.json",
     "test:watch": "jest -c jest.json --watch",
     "build": "webpack --mode=production",
     "build:dev": "webpack --mode=development",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "webpack --mode=production",
     "build:dev": "webpack --mode=development",
     "build:watch": "webpack --watch --mode=development",
+    "size": "size-limit",
     "start": "npm run build:dev && concurrently \"npm run build:watch\" \"npm run server -- -p 4444\"",
     "server:json": "node ./scripts/json-server/server.js >> ./scripts/json-server/json-server.log"
   },
@@ -20,6 +21,12 @@
     "Jack Reed <phillipjreed@gmail.com> (https://www.jack-reed.com)"
   ],
   "repository": "https://github.com/ProjectMirador/mirador",
+  "size-limit": [
+    {
+      "limit": "300 KB",
+      "path": "dist/mirador.min.js"
+    }
+  ],
   "dependencies": {
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
@@ -73,6 +80,7 @@
     "react-dev-utils": "^6.1.1",
     "redux-mock-store": "^1.5.1",
     "sass-lint": "^1.12.1",
+    "size-limit": "^0.21.1",
     "style-loader": "^0.22.1",
     "supertest": "^3.4.1",
     "terser-webpack-plugin": "^1.2.1",


### PR DESCRIPTION
I think this might be a useful tool, so we can be consistently evaluate our distribution size. Note, that the size shown here is gzipped. 

```sh
user$ npm run size

> mirador@3.0.0-alpha.0 size /Users/user/dev/mirador
> size-limit


  Package size: 204.85 KB
  Size limit:   300 KB
  With all dependencies, minified and gzipped
```
