### PR TITLE
Split out additional workspace control panel buttons into components

### DIFF
--- a/__tests__/src/components/WorkspaceAddButton.test.js
+++ b/__tests__/src/components/WorkspaceAddButton.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { WorkspaceAddButton } from '../../../src/components/WorkspaceAddButton';
+import fixture from '../../fixtures/version-2/002.json';
+
+describe('WorkspaceAddButton', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(
+      <WorkspaceAddButton manifests={{ foo: fixture, bar: fixture }} classes={{}} />,
+    );
+  });
+
+  it('renders without an error', () => {
+  });
+
+  it('renders a list item for each manifest in the state', () => {
+    expect(wrapper.find('ul Connect(ManifestListItem)').length).toBe(2);
+  });
+
+  describe('handleAddManifestClick', () => {
+    it('sets the anchor state', () => {
+      wrapper.instance().handleAddManifestClick({ currentTarget: true });
+
+      expect(wrapper.dive().find('WithStyles(Menu)').props().open).toBe(true);
+    });
+  });
+
+  describe('handleAddManifestClose', () => {
+    it('resets the anchor state', () => {
+      wrapper.instance().handleAddManifestClose();
+
+      expect(wrapper.dive().find('WithStyles(Menu)').props().open).toBe(false);
+    });
+  });
+});

--- a/__tests__/src/components/WorkspaceControlPanel.test.js
+++ b/__tests__/src/components/WorkspaceControlPanel.test.js
@@ -9,31 +9,11 @@ describe('WorkspaceControlPanel', () => {
   beforeEach(() => {
     store.dispatch(actions.receiveManifest('foo', fixture));
     store.dispatch(actions.receiveManifest('bar', fixture));
-    wrapper = shallow(<WorkspaceControlPanel store={store} />).dive().dive();
+    wrapper = shallow(<WorkspaceControlPanel store={store} />).dive();
   });
 
   it('renders without an error', () => {
     expect(wrapper.find('WithStyles(Drawer)').length).toBe(1);
     expect(wrapper.find('Connect(miradorWithPlugins(WorkspaceControlPanelButtons))').length).toBe(1);
-  });
-
-  it('renders a list item for each manifest in the state', () => {
-    expect(wrapper.find('ul Connect(ManifestListItem)').length).toBe(2);
-  });
-
-  describe('handleAddManifestClick', () => {
-    it('sets the anchor state', () => {
-      wrapper.instance().handleAddManifestClick({ currentTarget: true });
-
-      expect(wrapper.dive().find('WithStyles(Menu)').props().open).toBe(true);
-    });
-  });
-
-  describe('handleAddManifestClose', () => {
-    it('resets the anchor state', () => {
-      wrapper.instance().handleAddManifestClose();
-
-      expect(wrapper.dive().find('WithStyles(Menu)').props().open).toBe(false);
-    });
   });
 });

--- a/__tests__/src/components/WorkspaceMenuButton.test.js
+++ b/__tests__/src/components/WorkspaceMenuButton.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { WorkspaceMenuButton } from '../../../src/components/WorkspaceMenuButton';
+
+describe('WorkspaceMenuButton', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(
+      <WorkspaceMenuButton classes={{}} />,
+    );
+  });
+
+  it('renders without an error', () => {
+    expect(wrapper.find('WithStyles(IconButton)').length).toBe(1);
+  });
+  it('when clicked, updates the state', () => {
+    wrapper.find('WithStyles(IconButton)').simulate('click');
+    // TODO: this is currently a no-op
+  });
+});

--- a/src/components/WorkspaceAddButton.js
+++ b/src/components/WorkspaceAddButton.js
@@ -1,0 +1,146 @@
+import React, { Component } from 'react';
+import { compose } from 'redux';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import ListItem from '@material-ui/core/ListItem';
+import Fab from '@material-ui/core/Fab';
+import AddIcon from '@material-ui/icons/Add';
+import { withStyles } from '@material-ui/core/styles';
+import Menu from '@material-ui/core/Menu';
+import ConnectedManifestForm from './ManifestForm';
+import ConnectedManifestListItem from './ManifestListItem';
+
+/**
+ */
+export class WorkspaceAddButton extends Component {
+  /**
+   * constructor -
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      lastRequested: '',
+      anchorEl: null,
+    };
+
+    this.handleAddManifestClick = this.handleAddManifestClick.bind(this);
+    this.handleAddManifestClose = this.handleAddManifestClose.bind(this);
+    this.setLastRequested = this.setLastRequested.bind(this);
+  }
+
+  /**
+   * setLastRequested - Sets the state lastRequested
+   *
+   * @private
+   */
+  setLastRequested(requested) {
+    this.setState({
+      lastRequested: requested,
+    });
+  }
+
+  /**
+   * @private
+   */
+  handleAddManifestClick(event) {
+    this.setState({
+      anchorEl: event.currentTarget,
+    });
+  }
+
+  /**
+   * @private
+   */
+  handleAddManifestClose() {
+    this.setState({
+      anchorEl: null,
+    });
+  }
+
+  /**
+   * render
+   * @return
+   */
+  render() {
+    const { classes, manifests } = this.props;
+    const { lastRequested, anchorEl } = this.state;
+
+    const manifestList = Object.keys(manifests).map(manifest => (
+      <ConnectedManifestListItem
+        key={manifest}
+        manifest={manifest}
+        handleClose={this.handleAddManifestClose}
+      />
+    ));
+
+    return (
+      <ListItem>
+        <Fab
+          color="primary"
+          id="addBtn"
+          aria-label="Add"
+          className={classes.fab}
+          aria-owns={anchorEl ? 'add-form' : undefined}
+          aria-haspopup="true"
+          onClick={this.handleAddManifestClick}
+        >
+          <AddIcon />
+        </Fab>
+        <Menu
+          id="ws-ctrl-pnl-mn"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={this.handleAddManifestClose}
+        >
+          <ConnectedManifestForm
+            id="add-form"
+            setLastRequested={this.setLastRequested}
+          />
+          <ul>{manifestList}</ul>
+          {lastRequested}
+        </Menu>
+      </ListItem>
+    );
+  }
+}
+
+WorkspaceAddButton.propTypes = {
+  manifests: PropTypes.instanceOf(Object).isRequired,
+  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+/**
+ * mapDispatchToProps - used to hook up connect to action creators
+ * @memberof ManifestListItem
+ * @private
+ */
+const mapDispatchToProps = {};
+
+/**
+ * mapStateToProps - to hook up connect
+ * @memberof WorkspaceControlPanel
+ * @private
+ */
+const mapStateToProps = state => (
+  {
+    manifests: state.manifests,
+  }
+);
+
+/**
+ * @private
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+});
+
+
+const enhance = compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  withStyles(styles),
+  // further HOC go here
+);
+
+export default enhance(WorkspaceAddButton);

--- a/src/components/WorkspaceControlPanel.js
+++ b/src/components/WorkspaceControlPanel.js
@@ -2,20 +2,9 @@ import React, { Component } from 'react';
 import { compose } from 'redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import Fab from '@material-ui/core/Fab';
-import IconButton from '@material-ui/core/IconButton';
-import AddIcon from '@material-ui/icons/Add';
-import MenuIcon from '@material-ui/icons/Menu';
 import { withStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
-import Menu from '@material-ui/core/Menu';
-import Divider from '@material-ui/core/Divider';
 import ConnectedWorkspaceControlPanelButtons from './WorkspaceControlPanelButtons';
-import ConnectedManifestListItem from './ManifestListItem';
-import ConnectedManifestForm from './ManifestForm';
 import ns from '../config/css-ns';
 
 /**
@@ -23,72 +12,11 @@ import ns from '../config/css-ns';
  */
 class WorkspaceControlPanel extends Component {
   /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      lastRequested: '',
-      anchorEl: null,
-    };
-
-    this.setLastRequested = this.setLastRequested.bind(this);
-    this.handleAddManifestClick = this.handleAddManifestClick.bind(this);
-    this.handleAddManifestClose = this.handleAddManifestClose.bind(this);
-    this.handleMenuClick = this.handleMenuClick.bind(this);
-  }
-
-  /**
-   * setLastRequested - Sets the state lastRequested
-   *
-   * @private
-   */
-  setLastRequested(requested) {
-    this.setState({
-      lastRequested: requested,
-    });
-  }
-
-  /**
-   * @private
-   */
-  handleAddManifestClick(event) {
-    this.setState({
-      anchorEl: event.currentTarget,
-    });
-  }
-
-  /**
-   * @private
-   */
-  handleMenuClick() {
-    const state = { ...this.state };
-    this.setState(state);
-  }
-
-  /**
-   * @private
-   */
-  handleAddManifestClose() {
-    this.setState({
-      anchorEl: null,
-    });
-  }
-
-  /**
    * render
    * @return {String} - HTML markup for the component
    */
   render() {
-    const { manifests, classes } = this.props;
-    const { lastRequested, anchorEl } = this.state;
-    const manifestList = Object.keys(manifests).map(manifest => (
-      <ConnectedManifestListItem
-        key={manifest}
-        manifest={manifest}
-        handleClose={this.handleAddManifestClose}
-      />
-    ));
+    const { classes } = this.props;
     return (
       <Drawer
         className={classNames(classes.drawer, ns('workspace-control-panel'))}
@@ -96,47 +24,6 @@ class WorkspaceControlPanel extends Component {
         classes={{ paper: classNames(classes.drawer) }}
         open
       >
-        <Menu
-          id="ws-ctrl-pnl-mn"
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={this.handleAddManifestClose}
-        >
-          <ConnectedManifestForm
-            id="add-form"
-            setLastRequested={this.setLastRequested}
-          />
-          <ul>{manifestList}</ul>
-          {lastRequested}
-        </Menu>
-        <List>
-          <ListItem>
-            <Fab
-              color="primary"
-              id="addBtn"
-              aria-label="Add"
-              className={classes.fab}
-              aria-owns={anchorEl ? 'add-form' : undefined}
-              aria-haspopup="true"
-              onClick={this.handleAddManifestClick}
-            >
-              <AddIcon />
-            </Fab>
-          </ListItem>
-          <Divider />
-          <ListItem>
-            <IconButton
-              color="primary"
-              id="menuBtn"
-              aria-label="Menu"
-              className={classNames(classes.ctrlBtn)}
-              aria-haspopup="true"
-              onClick={this.handleMenuClick}
-            >
-              <MenuIcon />
-            </IconButton>
-          </ListItem>
-        </List>
         <ConnectedWorkspaceControlPanelButtons />
       </Drawer>
     );
@@ -144,20 +31,8 @@ class WorkspaceControlPanel extends Component {
 }
 
 WorkspaceControlPanel.propTypes = {
-  manifests: PropTypes.instanceOf(Object).isRequired,
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
-
-/**
- * mapStateToProps - to hook up connect
- * @memberof WorkspaceControlPanel
- * @private
- */
-const mapStateToProps = state => (
-  {
-    manifests: state.manifests,
-  }
-);
 
 /**
  * @private
@@ -168,9 +43,7 @@ const styles = theme => ({
   },
 });
 
-
 const enhance = compose(
-  connect(mapStateToProps),
   withStyles(styles),
   // further HOC go here
 );

--- a/src/components/WorkspaceControlPanelButtons.js
+++ b/src/components/WorkspaceControlPanelButtons.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import List from '@material-ui/core/List';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import ConnectedWorkspaceFullScreenButton from './WorkspaceFullScreenButton';
+import ConnectedWorkspaceAddButton from './WorkspaceAddButton';
+import ConnectedWorkspaceMenuButton from './WorkspaceMenuButton';
 /**
  *
  */
@@ -16,6 +18,8 @@ export class WorkspaceControlPanelButtons extends Component {
     const { children } = this.props;
     return (
       <List>
+        <ConnectedWorkspaceAddButton />
+        <ConnectedWorkspaceMenuButton />
         <ConnectedWorkspaceFullScreenButton />
         {children}
       </List>

--- a/src/components/WorkspaceMenuButton.js
+++ b/src/components/WorkspaceMenuButton.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import { compose } from 'redux';
+import IconButton from '@material-ui/core/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+import ListItem from '@material-ui/core/ListItem';
+import { withStyles } from '@material-ui/core/styles';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ */
+export class WorkspaceMenuButton extends Component {
+  /**
+   * constructor -
+   */
+  constructor(props) {
+    super(props);
+
+    this.handleMenuClick = this.handleMenuClick.bind(this);
+  }
+
+  /**
+   * @private
+   */
+  handleMenuClick() {
+    const state = { ...this.state };
+    this.setState(state);
+  }
+
+  /**
+   * render
+   * @return
+   */
+  render() {
+    const { classes } = this.props;
+    return (
+      <ListItem>
+        <IconButton
+          color="primary"
+          id="menuBtn"
+          aria-label="Menu"
+          className={classes.ctrlBtn}
+          aria-haspopup="true"
+          onClick={this.handleMenuClick}
+        >
+          <MenuIcon />
+        </IconButton>
+      </ListItem>
+    );
+  }
+}
+
+WorkspaceMenuButton.propTypes = {
+  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+/**
+ * mapDispatchToProps - used to hook up connect to action creators
+ * @memberof ManifestListItem
+ * @private
+ */
+const mapDispatchToProps = {};
+
+/**
+ * @private
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+});
+
+
+const enhance = compose(
+  connect(null, mapDispatchToProps),
+  withStyles(styles),
+  // further HOC go here
+);
+
+export default enhance(WorkspaceMenuButton);


### PR DESCRIPTION
Is this an incremental step in the right direction for these workspace controls? Again, ideally, we'd make them more pluggable instead of hard-coded, but at least this makes them independent components?