### PR TITLE
return null from getDerivedStateFromProps per React docs h/t @jkeck

### DIFF
--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -36,7 +36,7 @@ export class ThumbnailNavigation extends Component {
         manifest: props.manifest,
       };
     }
-    return [];
+    return null;
   }
 
   /**


### PR DESCRIPTION
https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops

> It should return an object to update the state, or null to update nothing.