### PR TITLE
Fixes plugin page on netlify for Chrome

### DIFF
--- a/__tests__/integration/mirador/plugins.html
+++ b/__tests__/integration/mirador/plugins.html
@@ -11,12 +11,16 @@
     <script src="../../../node_modules/react/umd/react.development.js"></script>
     <!-- Request from CDN if unavailable locally -->
     <script type="text/javascript">
-      (window.React)||document.write('<script type="text/javascript" crossorigin src="https://unpkg.com/react@16/umd/react.development.js"><\/script>');
+      if (!window.React) {
+        var script = document.createElement('script'); script.src = "https://unpkg.com/react@16/umd/react.development.js"; script.crossorigin = true; document.head.appendChild(script)
+      }
     </script>
     <script src="../../../node_modules/react-dom/umd/react-dom.development.js"></script>
     <!-- Request from CDN if unavailable locally -->
     <script type="text/javascript">
-      (window.ReactDOM)||document.write('<script type="text/javascript" crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"><\/script>');
+      if (!window.ReactDOM) {
+        var script = document.createElement('script'); script.src = "https://unpkg.com/react-dom@16/umd/react-dom.development.js"; script.crossorigin = true; document.head.appendChild(script)
+      }
     </script>
     <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
     <script type="text/javascript">


### PR DESCRIPTION
Removes document.write in favor of appendChild. We get a warning because of the use of `document.write`

https://mirador-dev.netlify.com/__tests__/integration/mirador/plugins.html

See: https://developers.google.com/web/updates/2016/08/removing-document-write