### PR TITLE
Use Material UI Drawer instead of custom component

### DIFF
--- a/__tests__/src/components/WindowSideBar.test.js
+++ b/__tests__/src/components/WindowSideBar.test.js
@@ -9,7 +9,7 @@ describe('WindowSideBar', () => {
   });
 
   it('renders without an error', () => {
-    expect(wrapper.find('.mirador-window-sidebar').length).toBe(1);
+    expect(wrapper.find('WithStyles(Drawer)').length).toBe(1);
     expect(wrapper.find('WithStyles(List)').length).toBe(1);
   });
 });

--- a/src/components/WindowSideBar.js
+++ b/src/components/WindowSideBar.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Drawer from '@material-ui/core/Drawer';
 import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import WindowSideBarButtons from '../containers/WindowSideBarButtons';
-import ns from '../config/css-ns';
 
 /**
  * WindowSideBar
@@ -19,12 +20,25 @@ class WindowSideBar extends Component {
     } = this.props;
 
     return (
-      <div className={ns(['window-sidebar', (sideBarOpen ? 'window-sidebar-open' : 'window-sidebar-closed')])}>
+      <Drawer
+        variant="temporary"
+        className={classNames(classes.drawer)}
+        classes={{ paper: classNames(classes.drawer) }}
+        open={sideBarOpen}
+        anchor="left"
+        PaperProps={{ style: { position: 'relative' } }}
+        ModalProps={{
+          container: document.getElementById(windowId),
+          disablePortal: true,
+          hideBackdrop: true,
+          style: { position: 'absolute' },
+        }}
+      >
         <div className={classes.toolbar} />
         <List>
           <WindowSideBarButtons windowId={windowId} />
         </List>
-      </div>
+      </Drawer>
     );
   }
 }
@@ -46,6 +60,16 @@ WindowSideBar.defaultProps = {
  */
 const styles = theme => ({
   toolbar: theme.mixins.toolbar,
+  drawer: {
+    overflowX: 'hidden',
+    left: 0,
+    width: 55,
+    flexShrink: 0,
+    height: '100%',
+  },
+  grow: {
+    flexGrow: 1,
+  },
 });
 
 export default withStyles(styles)(WindowSideBar);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -35,22 +35,6 @@ body {
     position: relative;
   }
 
-  &-window-sidebar {
-    background: lighten($gray, 60%);
-    height: 100%;
-    position: absolute;
-    transition: width 200ms linear;
-    z-index: 42;
-  }
-
-  &-window-sidebar-closed {
-    width: 0;
-  }
-
-  &-window-sidebar-open {
-    width: 50px;
-  }
-
   &-window-companion-side {
     background: lighten($gray, 40%);
     min-width: 75px;


### PR DESCRIPTION
I realize I made a mistake by removing this in  https://github.com/ProjectMirador/mirador/pull/1715/files#diff-fa3a921ddee889e02c9025a5c2d2ef60L24

Apologies.. and heads up to @jkeck and @glefi who this may affect

![sidebar](https://user-images.githubusercontent.com/1656824/52069032-2d9be380-253b-11e9-83ea-a6c52c206bba.gif)
