### PR TITLE
set OSD preserveZoom option

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -32,6 +32,7 @@ class OpenSeadragonViewer extends Component {
       blendTime: 0.1,
       alwaysBlend: false,
       showNavigationControl: false,
+      preserveImageSizeOnResize: true,
     });
     tileSources.forEach(tileSource => this.addTileSource(tileSource));
   }


### PR DESCRIPTION
Possibly related to #1660 , but fixes and issue that @jvine raised about wanting to preserver the zoom level.s

Confirmed w/ @jvine this is the expected behavior.

![zoomy](https://user-images.githubusercontent.com/1656824/52152435-a1211c00-2633-11e9-9211-37b155cf4f3e.gif)
