### PR TITLE
Address eslint forbidden prop types shapes

### DIFF
--- a/__tests__/src/components/ViewerNavigation.test.js
+++ b/__tests__/src/components/ViewerNavigation.test.js
@@ -11,7 +11,7 @@ describe('ViewerNavigation', () => {
     previousCanvas = jest.fn();
     wrapper = shallow(
       <ViewerNavigation
-        canvases={[1, 2]}
+        canvases={[{ id: '1' }, { id: '2' }]}
         nextCanvas={nextCanvas}
         previousCanvas={previousCanvas}
         window={{ canvasIndex: 0 }}

--- a/__tests__/src/components/Window.test.js
+++ b/__tests__/src/components/Window.test.js
@@ -6,7 +6,7 @@ import WindowMiddleContent from '../../../src/containers/WindowMiddleContent';
 
 describe('Window', () => {
   let wrapper;
-  const window = { id: 123, xywh: [0, 0, 400, 500] };
+  const window = { id: '123', xywh: [0, 0, 400, 500] };
   it('should render outer element', () => {
     wrapper = shallow(<Window window={window} />);
     expect(wrapper.find('.mirador-window')).toHaveLength(1);

--- a/__tests__/src/components/WindowList.test.js
+++ b/__tests__/src/components/WindowList.test.js
@@ -17,7 +17,6 @@ describe('WindowList', () => {
 
     wrapper = shallow(
       <WindowList
-        anchorEl={{}}
         manifests={manifests}
         windows={windows}
         handleClose={handleClose}
@@ -36,7 +35,6 @@ describe('WindowList', () => {
 
       wrapper = shallow(
         <WindowList
-          anchorEl={{}}
           manifests={manifests}
           windows={windows}
           handleClose={handleClose}
@@ -64,7 +62,6 @@ describe('WindowList', () => {
 
       wrapper = shallow(
         <WindowList
-          anchorEl={{}}
           manifests={manifests}
           windows={windows}
           handleClose={handleClose}

--- a/__tests__/src/components/WindowMiddleContent.test.js
+++ b/__tests__/src/components/WindowMiddleContent.test.js
@@ -21,7 +21,7 @@ describe('WindowMiddleContent', () => {
     expect(wrapper.find(WindowSideBar)).toHaveLength(1);
   });
   it('should render <WindowViewer> if manifest is present', () => {
-    manifest = { id: 456, isFetching: false };
+    manifest = { id: '456', isFetching: false };
     wrapper = shallow(<WindowMiddleContent window={window} manifest={manifest} />);
     expect(wrapper.find(WindowViewer)).toHaveLength(1);
   });

--- a/__tests__/src/components/WindowViewer.test.js
+++ b/__tests__/src/components/WindowViewer.test.js
@@ -7,7 +7,7 @@ import ViewerNavigation from '../../../src/containers/ViewerNavigation';
 import fixture from '../../fixtures/version-2/024.json';
 
 const mockManifest = {
-  id: 123,
+  id: '123',
   manifestation: manifesto.create(fixture),
 };
 

--- a/__tests__/src/components/Workspace.test.js
+++ b/__tests__/src/components/Workspace.test.js
@@ -4,7 +4,7 @@ import WorkspaceMosaic from '../../../src/containers/WorkspaceMosaic';
 import Window from '../../../src/containers/Window';
 import Workspace from '../../../src/components/Workspace';
 
-const windows = { 1: { id: 1 }, 2: { id: 2 } };
+const windows = { w1: { id: 'w1' }, w2: { id: 'w2' } };
 
 describe('Workspace', () => {
   describe('if workspace type is mosaic', () => {
@@ -28,8 +28,8 @@ describe('Workspace', () => {
 
       expect(wrapper.matchesElement(
         <div className="mirador-workspace">
-          <Window window={{ id: 1 }} />
-          <Window window={{ id: 2 }} />
+          <Window window={{ id: 'w1' }} />
+          <Window window={{ id: 'w2' }} />
         </div>,
       )).toBe(true);
     });

--- a/__tests__/src/components/WorkspaceMosaic.test.js
+++ b/__tests__/src/components/WorkspaceMosaic.test.js
@@ -4,7 +4,7 @@ import { Mosaic } from 'react-mosaic-component';
 import WorkspaceMosaic from '../../../src/components/WorkspaceMosaic';
 
 describe('WorkspaceMosaic', () => {
-  const windows = { 1: { id: 1 }, 2: { id: 2 } };
+  const windows = { w1: { id: 'w1' }, w2: { id: 'w2' } };
   let wrapper;
   beforeEach(() => {
     wrapper = shallow(
@@ -17,7 +17,7 @@ describe('WorkspaceMosaic', () => {
   });
   it('should render properly with an initialValue', () => {
     expect(wrapper.matchesElement(
-      <Mosaic initialValue={{ direction: 'row', first: '1', second: '2' }} />,
+      <Mosaic initialValue={{ direction: 'row', first: 'w1', second: 'w2' }} />,
     )).toBe(true);
   });
   describe('determineWorkspaceLayout', () => {
@@ -30,7 +30,7 @@ describe('WorkspaceMosaic', () => {
         />,
       );
       expect(wrapper.instance().determineWorkspaceLayout()).toMatchObject({
-        direction: 'row', first: '1', second: '2',
+        direction: 'row', first: 'w1', second: 'w2',
       });
     });
     it('when window ids match workspace layout', () => {
@@ -46,7 +46,7 @@ describe('WorkspaceMosaic', () => {
   });
   describe('tileRenderer', () => {
     it('when window is available', () => {
-      expect(wrapper.instance().tileRenderer('1')).not.toBeNull();
+      expect(wrapper.instance().tileRenderer('w1')).not.toBeNull();
     });
     it('when window is not available', () => {
       expect(wrapper.instance().tileRenderer('bar')).toBeNull();

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -52,8 +52,8 @@ class App extends Component {
 }
 
 App.propTypes = {
-  theme: PropTypes.string.isRequired, // eslint-disable-line react/forbid-prop-types
-  isFullscreenEnabled: PropTypes.bool.isRequired, // eslint-disable-line react/forbid-prop-types
+  theme: PropTypes.string.isRequired,
+  isFullscreenEnabled: PropTypes.bool.isRequired,
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types,
   setWorkspaceFullscreen: PropTypes.func.isRequired,
 };

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -30,7 +30,7 @@ const ManifestListItem = ({ manifest, addWindow, handleClose }) => (
 );
 
 ManifestListItem.propTypes = {
-  manifest: PropTypes.string.isRequired, // eslint-disable-line react/forbid-prop-types
+  manifest: PropTypes.string.isRequired,
   addWindow: PropTypes.func.isRequired,
   handleClose: PropTypes.func,
 };

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import OpenSeadragon from 'openseadragon';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 
 /**
@@ -167,7 +168,7 @@ OpenSeadragonViewer.defaultProps = {
 OpenSeadragonViewer.propTypes = {
   children: PropTypes.element,
   tileSources: PropTypes.arrayOf(PropTypes.object),
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.shape(shapes.windowShape).isRequired,
   updateViewport: PropTypes.func.isRequired,
 };
 

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -4,6 +4,7 @@ import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import Grid from 'react-virtualized/dist/commonjs/Grid';
 import CanvasThumbnail from './CanvasThumbnail';
 import ManifestoCanvas from '../lib/ManifestoCanvas';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 import 'react-virtualized/styles.css';
 
@@ -136,9 +137,9 @@ class ThumbnailNavigation extends Component {
 
 ThumbnailNavigation.propTypes = {
   config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  manifest: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  manifest: PropTypes.shape(shapes.manifestShape).isRequired,
   setCanvas: PropTypes.func.isRequired,
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.shape(shapes.windowShape).isRequired,
 };
 
 export default ThumbnailNavigation;

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 
 /**
@@ -70,10 +71,10 @@ class ViewerNavigation extends Component {
 }
 
 ViewerNavigation.propTypes = {
-  canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  canvases: PropTypes.arrayOf(PropTypes.shape(shapes.canvasShape)).isRequired,
   nextCanvas: PropTypes.func.isRequired,
   previousCanvas: PropTypes.func.isRequired,
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.shape(shapes.windowShape).isRequired,
 };
 
 export default ViewerNavigation;

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 import WindowTopBar from '../containers/WindowTopBar';
 import WindowMiddleContent from '../containers/WindowMiddleContent';
@@ -38,8 +39,8 @@ class Window extends Component {
 }
 
 Window.propTypes = {
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.shape(shapes.windowShape).isRequired,
+  manifest: PropTypes.shape(shapes.manifestShape),
 };
 
 Window.defaultProps = {

--- a/src/components/WindowList.js
+++ b/src/components/WindowList.js
@@ -4,6 +4,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import PropTypes from 'prop-types';
+import * as shapes from '../shapes';
 
 /**
  */
@@ -57,9 +58,9 @@ class WindowList extends Component {
 WindowList.propTypes = {
   focusWindow: PropTypes.func.isRequired,
   handleClose: PropTypes.func.isRequired,
-  anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  windows: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  manifests: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  anchorEl: PropTypes.element,
+  windows: PropTypes.shape(shapes.windowShape).isRequired,
+  manifests: PropTypes.objectOf(PropTypes.shape(shapes.manifestShape)).isRequired,
 };
 
 WindowList.defaultProps = {

--- a/src/components/WindowMiddleContent.js
+++ b/src/components/WindowMiddleContent.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import WindowSideBar from '../containers/WindowSideBar';
 import CompanionWindow from '../containers/CompanionWindow';
 import WindowViewer from '../containers/WindowViewer';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 
 /**
@@ -56,8 +57,8 @@ class WindowMiddleContent extends Component {
 }
 
 WindowMiddleContent.propTypes = {
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.shape(shapes.windowShape).isRequired,
+  manifest: PropTypes.shape(shapes.manifestShape),
 };
 
 WindowMiddleContent.defaultProps = {

--- a/src/components/WindowSideBar.js
+++ b/src/components/WindowSideBar.js
@@ -6,6 +6,7 @@ import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import WindowSideBarButtons from '../containers/WindowSideBarButtons';
 import WindowSideBarPanel from './WindowSideBarPanel';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 
 /**
@@ -71,7 +72,7 @@ WindowSideBar.propTypes = {
   classes: PropTypes.shape({
     drawer: PropTypes.string,
   }).isRequired,
-  manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  manifest: PropTypes.shape(shapes.manifestShape),
   windowId: PropTypes.string.isRequired,
   sideBarOpen: PropTypes.bool,
   sideBarPanel: PropTypes.string,

--- a/src/components/WindowSideBar.js
+++ b/src/components/WindowSideBar.js
@@ -68,7 +68,9 @@ class WindowSideBar extends Component {
 
 
 WindowSideBar.propTypes = {
-  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types,
+  classes: PropTypes.shape({
+    drawer: PropTypes.string,
+  }).isRequired,
   manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   windowId: PropTypes.string.isRequired,
   sideBarOpen: PropTypes.bool,

--- a/src/components/WindowSideBarInfoPanel.js
+++ b/src/components/WindowSideBarInfoPanel.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 
 /**
@@ -52,7 +53,7 @@ class WindowSideBarInfoPanel extends Component {
 
 WindowSideBarInfoPanel.propTypes = {
   classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  manifest: PropTypes.shape(shapes.manifestShape),
 };
 
 

--- a/src/components/WindowSideBarPanel.js
+++ b/src/components/WindowSideBarPanel.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import WindowSideBarInfoPanel from './WindowSideBarInfoPanel';
+import * as shapes from '../shapes';
 
 /**
  * WindowSideBarPanel - the panel that pops out from the sidebar
@@ -35,7 +36,7 @@ class WindowSideBarPanel extends Component {
 }
 
 WindowSideBarPanel.propTypes = {
-  manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  manifest: PropTypes.shape(shapes.manifestShape),
   sideBarPanel: PropTypes.string,
 };
 WindowSideBarPanel.defaultProps = {

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import WindowIcon from './WindowIcon';
 import WindowTopMenuButton from './WindowTopMenuButton';
 import WindowTopBarButtons from '../containers/WindowTopBarButtons';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 
 /**
@@ -59,7 +60,7 @@ class WindowTopBar extends Component {
 }
 
 WindowTopBar.propTypes = {
-  manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  manifest: PropTypes.shape(shapes.manifestShape),
   removeWindow: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
   classes: PropTypes.shape({

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -62,7 +62,10 @@ WindowTopBar.propTypes = {
   manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   removeWindow: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
-  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.shape({
+    reallyDense: PropTypes.string,
+    typographyBody: PropTypes.string,
+  }).isRequired,
   toggleWindowSideBar: PropTypes.func,
 };
 

--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -43,7 +43,7 @@ class WindowTopMenu extends Component {
 WindowTopMenu.propTypes = {
   windowId: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
-  anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  anchorEl: PropTypes.element,
 };
 
 WindowTopMenu.defaultProps = {

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -71,7 +71,9 @@ class WindowTopMenuButton extends Component {
 
 WindowTopMenuButton.propTypes = {
   windowId: PropTypes.string.isRequired,
-  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.shape({
+    ctrlBtn: PropTypes.string,
+  }).isRequired,
 };
 
 /**

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import OSDViewer from '../containers/OpenSeadragonViewer';
 import ViewerNavigation from '../containers/ViewerNavigation';
+import * as shapes from '../shapes';
 
 /**
  * Represents a WindowViewer in the mirador workspace. Responsible for mounting
@@ -90,10 +91,10 @@ class WindowViewer extends Component {
 }
 
 WindowViewer.propTypes = {
-  infoResponses: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  infoResponses: PropTypes.objectOf(PropTypes.shape(shapes.infoResponsesShape)).isRequired,
   fetchInfoResponse: PropTypes.func.isRequired,
-  manifest: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  manifest: PropTypes.shape(shapes.manifestShape).isRequired,
+  window: PropTypes.shape(shapes.windowShape).isRequired,
 };
 
 export default WindowViewer;

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Window from '../containers/Window';
 import WorkspaceMosaic from '../containers/WorkspaceMosaic';
+import * as shapes from '../shapes';
 import ns from '../config/css-ns';
 
 /**
@@ -41,8 +42,8 @@ class Workspace extends React.Component {
 }
 
 Workspace.propTypes = {
-  windows: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  workspaceType: PropTypes.string.isRequired, // eslint-disable-line react/forbid-prop-types
+  windows: PropTypes.objectOf(PropTypes.shape(shapes.windowShape)).isRequired,
+  workspaceType: PropTypes.string.isRequired,
 };
 
 export default Workspace;

--- a/src/components/WorkspaceAddButton.js
+++ b/src/components/WorkspaceAddButton.js
@@ -104,7 +104,9 @@ class WorkspaceAddButton extends Component {
 
 WorkspaceAddButton.propTypes = {
   manifests: PropTypes.instanceOf(Object).isRequired,
-  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.shape({
+    fab: PropTypes.string,
+  }).isRequired,
 };
 
 /**

--- a/src/components/WorkspaceAddButton.js
+++ b/src/components/WorkspaceAddButton.js
@@ -7,6 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Menu from '@material-ui/core/Menu';
 import ManifestForm from '../containers/ManifestForm';
 import ManifestListItem from '../containers/ManifestListItem';
+import * as shapes from '../shapes';
 
 /**
  */
@@ -103,7 +104,7 @@ class WorkspaceAddButton extends Component {
 }
 
 WorkspaceAddButton.propTypes = {
-  manifests: PropTypes.instanceOf(Object).isRequired,
+  manifests: PropTypes.objectOf(PropTypes.shape(shapes.manifestShape)).isRequired,
   classes: PropTypes.shape({
     fab: PropTypes.string,
   }).isRequired,

--- a/src/components/WorkspaceControlPanel.js
+++ b/src/components/WorkspaceControlPanel.js
@@ -33,7 +33,9 @@ class WorkspaceControlPanel extends Component {
 }
 
 WorkspaceControlPanel.propTypes = {
-  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.shape({
+    drawer: PropTypes.string,
+  }).isRequired,
 };
 
 /**

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -44,7 +44,7 @@ class WorkspaceExport extends Component {
 
 WorkspaceExport.propTypes = {
   handleClose: PropTypes.func.isRequired,
-  open: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
+  open: PropTypes.bool,
   children: PropTypes.node,
   state: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/src/components/WorkspaceFullScreenButton.js
+++ b/src/components/WorkspaceFullScreenButton.js
@@ -26,7 +26,9 @@ class WorkspaceFullScreenButton extends Component {
 
 WorkspaceFullScreenButton.propTypes = {
   setWorkspaceFullscreen: PropTypes.func.isRequired,
-  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.shape({
+    ctrlBtn: PropTypes.string,
+  }).isRequired,
 };
 
 /**

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -116,7 +116,7 @@ class WorkspaceMenu extends Component {
 
 WorkspaceMenu.propTypes = {
   handleClose: PropTypes.func.isRequired,
-  anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  anchorEl: PropTypes.element,
 };
 
 WorkspaceMenu.defaultProps = {

--- a/src/components/WorkspaceMenuButton.js
+++ b/src/components/WorkspaceMenuButton.js
@@ -72,7 +72,9 @@ class WorkspaceMenuButton extends Component {
 }
 
 WorkspaceMenuButton.propTypes = {
-  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.shape({
+    ctrlBtn: PropTypes.string,
+  }).isRequired,
 };
 
 /**

--- a/src/components/WorkspaceMosaic.js
+++ b/src/components/WorkspaceMosaic.js
@@ -5,6 +5,7 @@ import {
 } from 'react-mosaic-component';
 import 'react-mosaic-component/react-mosaic-component.css';
 import Window from '../containers/Window';
+import * as shapes from '../shapes';
 
 /**
  * Represents a work area that contains any number of windows
@@ -84,8 +85,8 @@ class WorkspaceMosaic extends React.Component {
 
 WorkspaceMosaic.propTypes = {
   updateWorkspaceMosaicLayout: PropTypes.func.isRequired,
-  windows: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  workspace: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  windows: PropTypes.objectOf(PropTypes.shape(shapes.windowShape)).isRequired,
+  workspace: PropTypes.shape(shapes.workspaceShape).isRequired,
 };
 
 export default WorkspaceMosaic;

--- a/src/components/WorkspaceSettings.js
+++ b/src/components/WorkspaceSettings.js
@@ -63,7 +63,7 @@ class WorkspaceSettings extends Component {
 
 WorkspaceSettings.propTypes = {
   handleClose: PropTypes.func.isRequired,
-  open: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
+  open: PropTypes.bool,
   children: PropTypes.node,
   updateConfig: PropTypes.func.isRequired,
   theme: PropTypes.string.isRequired,

--- a/src/shapes/index.js
+++ b/src/shapes/index.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+
+export const windowShape = {
+  id: PropTypes.string,
+  canvasIndex: PropTypes.number,
+  manifestId: PropTypes.string,
+  viewer: PropTypes.shape({
+    x: PropTypes.number,
+    y: PropTypes.number,
+    zoom: PropTypes.number,
+  }),
+};
+
+export const canvasShape = {
+  id: PropTypes.string,
+  aspectRatio: PropTypes.number,
+};
+
+export const manifestShape = {
+  id: PropTypes.string,
+  manifestation: PropTypes.object,
+};
+
+export const workspaceShape = {
+  fullscreen: PropTypes.bool,
+};
+
+export const infoResponsesShape = {
+  isFetching: PropTypes.bool,
+  json: PropTypes.object,
+};


### PR DESCRIPTION
Fixes #1781 (by giving shapes to forbidden prop types).

I don't know if this is an idiomatic way to do this, but I also agree with @camillevilla that we're probably not a point where we can strictly define our types yet.