### PR TITLE
Allow canvasIndex to be passed in with the window config on viewer…

### DIFF
--- a/__tests__/integration/mirador/index.html
+++ b/__tests__/integration/mirador/index.html
@@ -14,6 +14,7 @@
        id: 'mirador',
        windows: [{
          loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+         canvasIndex: 2,
        },
        {
          loadedManifest: 'https://media.nga.gov/public/manifests/nga_highlights.json',

--- a/__tests__/integration/mirador/thumbnail-navigation.test.js
+++ b/__tests__/integration/mirador/thumbnail-navigation.test.js
@@ -10,8 +10,10 @@ describe('Thumbnail navigation', () => {
     let windows = await page.evaluate(() => (
       miradorInstance.store.getState().windows
     ));
-    expect(Object.values(windows)[0].canvasIndex).toBe(0);
+    expect(Object.values(windows)[0].canvasIndex).toBe(2); // test harness in index.html starts at 2
+    await page.waitFor(1000);
     await expect(page).toClick('.mirador-thumbnail-nav-canvas-1');
+    await expect(page).toMatchElement('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas', { timeout: 1500 });
     windows = await page.evaluate(() => (
       miradorInstance.store.getState().windows
     ));

--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -46,6 +46,7 @@ describe('MiradorViewer', () => {
         id: 'mirador',
         windows: [{
           loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+          canvasIndex: 2,
         },
         {
           loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
@@ -57,6 +58,8 @@ describe('MiradorViewer', () => {
       const { windows } = instance.store.getState();
       const windowIds = Object.keys(windows);
       expect(Object.keys(windowIds).length).toBe(2);
+      expect(windows[windowIds[0]].canvasIndex).toBe(2);
+      expect(windows[windowIds[1]].canvasIndex).toBe(0);
       expect(windows[windowIds[0]].thumbnailNavigationPosition).toBe('bottom');
       expect(windows[windowIds[1]].thumbnailNavigationPosition).toBe('off');
     });

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -51,6 +51,7 @@ class MiradorViewer {
       }
       store.dispatch(actions.fetchManifest(miradorWindow.loadedManifest));
       store.dispatch(actions.addWindow({
+        canvasIndex: (miradorWindow.canvasIndex || 0),
         manifestId: miradorWindow.loadedManifest,
         thumbnailNavigationPosition,
       }));


### PR DESCRIPTION
…initialization.

Closes #1783 

<img width="1319" alt="new-init" src="https://user-images.githubusercontent.com/96776/52244308-ef335b00-2891-11e9-975b-65202bdb737c.png">

_Canvas loaded on init in screenshot above_