### PR TITLE
Add withMiradorAPI HoC

### DIFF
--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -37,7 +37,7 @@ describe('MiradorViewer', () => {
         plugins: ['fooPlugin'],
       });
       expect(instance.actions.fooAction).toBeDefined();
-      expect(instance.store.pluginReducers).toBeDefined();
+      expect(instance.store).toBeDefined();
     });
   });
   describe('processConfig', () => {

--- a/jest.json
+++ b/jest.json
@@ -1,4 +1,5 @@
 {
+  "displayName": "unit",
   "collectCoverage": true,
   "collectCoverageFrom": [
     "src/**/*.{js,jsx}",
@@ -13,8 +14,7 @@
     "<rootDir>/setupJest.js"
   ],
   "testMatch": [
-    "<rootDir>/**/__tests__/**/*.{js,jsx}",
-    "<rootDir>/src/**/?(*.)(spec|test|unit).{js,jsx}"
-  ],
-  "preset": "jest-puppeteer"
+    "<rootDir>/**/__tests__/src/**/*.{js,jsx}"
+  ]
 }
+

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,22 +1,12 @@
 // Setup Jest to mock fetch
 
-import { JSDOM } from 'jsdom'; // eslint-disable-line import/no-extraneous-dependencies
 import fetch from 'jest-fetch-mock'; // eslint-disable-line import/no-extraneous-dependencies
 import Enzyme from 'enzyme'; // eslint-disable-line import/no-extraneous-dependencies
 import Adapter from 'enzyme-adapter-react-16'; // eslint-disable-line import/no-extraneous-dependencies
 
-const jsdom = new JSDOM('<!doctype html><html><body><div id="main"></div></body></html>');
-const { window } = jsdom;
-
 window.HTMLCanvasElement.prototype.getContext = () => {};
 jest.setMock('node-fetch', fetch);
 global.fetch = require('jest-fetch-mock'); // eslint-disable-line import/no-extraneous-dependencies
-
-global.window = window;
-global.document = window.document;
-global.navigator = {
-  userAgent: 'node.js',
-};
 
 /* eslint-disable  require-jsdoc, class-methods-use-this */
 class IntersectionObserverPolyfill {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-import init from './init';
+import mirador from './lib/MiradorViewer';
+import './styles/index.scss';
 
 const exports = {
-  viewer: init,
+  viewer: mirador,
   plugins: {},
 };
 

--- a/src/init.js
+++ b/src/init.js
@@ -1,9 +1,0 @@
-import MiradorViewer from './lib/MiradorViewer';
-import './styles/index.scss';
-
-/**
- * Default Mirador instantiation
- */
-export default function (config) {
-  return new MiradorViewer(config);
-}

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -7,6 +7,7 @@ import createStore from '../state/createStore';
 import * as actions from '../state/actions';
 import withMiradorAPI from './withMiradorAPI';
 import settings from '../config/settings';
+import createRootReducer from '../state/reducers';
 
 /**
  * miradorDefaultImplementation.
@@ -15,6 +16,7 @@ import settings from '../config/settings';
  */
 export default function miradorDefaultImplementation(config) {
   const store = createStore();
+  processPlugins(store, config);
   const mixinConfig = deepmerge(settings, config);
   const MiradorViewer = withMiradorAPI(store, mixinConfig)(App);
   const element = (
@@ -24,4 +26,55 @@ export default function miradorDefaultImplementation(config) {
   );
   ReactDOM.render(element, document.getElementById(mixinConfig.id));
   return { actions, store };
+}
+
+/**
+ *
+ * @param plugins
+ */
+function addPluginActions(plugins) {
+  const actionCreators = [];
+  // TODO this can be simplified
+  plugins.forEach((pluginName) => {
+    const plugin = window.Mirador.plugins[pluginName];
+    if (plugin.actions) {
+      Object.keys(plugin.actions)
+        .forEach(actionName => actionCreators.push({
+          name: actionName, action: plugin.actions[actionName],
+        }));
+    }
+  });
+  actionCreators.forEach((action) => { actions[action.name] = action.action; });
+}
+
+/**
+ *
+ * @param store
+ * @param plugins
+ */
+function addPluginReducersToStore(store, plugins) {
+  const reducers = [];
+  const pluginReducers = {};
+  // TODO this can be simplified
+  plugins.forEach((pluginName) => {
+    const plugin = window.Mirador.plugins[pluginName];
+    if (plugin.reducers) {
+      Object.keys(plugin.reducers)
+        .forEach(reducerName => reducers.push({
+          name: reducerName,
+          reducer: plugin.reducers[reducerName],
+        }));
+    }
+  });
+  reducers.forEach((reducer) => { pluginReducers[reducer.name] = reducer.reducer; });
+  store.replaceReducer(createRootReducer(pluginReducers));
+}
+
+/**
+ * processPlugins
+ */
+function processPlugins(store, config) {
+  const plugins = config.plugins || [];
+  addPluginActions(plugins);
+  addPluginReducersToStore(store, plugins);
 }

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -3,94 +3,25 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import deepmerge from 'deepmerge';
 import App from '../containers/App';
-import createRootReducer from '../state/reducers/index';
 import createStore from '../state/createStore';
 import * as actions from '../state/actions';
+import withMiradorAPI from './withMiradorAPI';
 import settings from '../config/settings';
 
-const store = createStore();
 /**
- * Default Mirador instantiation
+ * miradorDefaultImplementation.
+ * @param config
+ * @returns {{store, actions: {}}}
  */
-class MiradorViewer {
-  /**
-   */
-  constructor(config) {
-    this.config = config;
-    this.processPlugins();
-    this.processConfig();
-    const viewer = {
-      actions,
-      store,
-    };
-
-    ReactDOM.render(
-      <Provider store={store}>
-        <App config={config} />
-      </Provider>,
-      document.getElementById(config.id),
-    );
-
-    return viewer;
-  }
-
-  /**
-   * Process config into actions
-   */
-  processConfig() {
-    const mergedConfig = deepmerge(settings, this.config);
-    const action = actions.setConfig(mergedConfig);
-    store.dispatch(action);
-
-    mergedConfig.windows.forEach((miradorWindow) => {
-      let thumbnailNavigationPosition;
-      if (miradorWindow.thumbnailNavigationPosition !== undefined) {
-        ({ thumbnailNavigationPosition } = miradorWindow);
-      } else {
-        thumbnailNavigationPosition = mergedConfig.thumbnailNavigation.defaultPosition;
-      }
-      store.dispatch(actions.fetchManifest(miradorWindow.loadedManifest));
-      store.dispatch(actions.addWindow({
-        canvasIndex: (miradorWindow.canvasIndex || 0),
-        manifestId: miradorWindow.loadedManifest,
-        thumbnailNavigationPosition,
-      }));
-    });
-  }
-
-  /**
-   * Process Plugins
-   */
-  processPlugins() {
-    const plugins = this.config.plugins || [];
-    const actionCreators = [];
-    const reducers = [];
-
-    plugins.forEach((pluginName) => {
-      const plugin = window.Mirador.plugins[pluginName];
-
-      // Add Actions
-      if (plugin.actions) {
-        Object.keys(plugin.actions)
-          .forEach(actionName => actionCreators.push({
-            name: actionName,
-            action: plugin.actions[actionName],
-          }));
-      }
-      // Add Reducers
-      if (plugin.reducers) {
-        Object.keys(plugin.reducers)
-          .forEach(reducerName => reducers.push({
-            name: reducerName,
-            reducer: plugin.reducers[reducerName],
-          }));
-      }
-    });
-
-    actionCreators.forEach((action) => { actions[action.name] = action.action; });
-    reducers.forEach((reducer) => { store.pluginReducers[reducer.name] = reducer.reducer; });
-    store.replaceReducer(createRootReducer(store.pluginReducers));
-  }
+export default function miradorDefaultImplementation(config) {
+  const store = createStore();
+  const mixinConfig = deepmerge(settings, config);
+  const MiradorViewer = withMiradorAPI(store, mixinConfig)(App);
+  const element = (
+    <Provider store={store}>
+      <MiradorViewer />
+    </Provider>
+  );
+  ReactDOM.render(element, document.getElementById(mixinConfig.id));
+  return { actions, store };
 }
-
-export default MiradorViewer;

--- a/src/lib/withMiradorAPI.js
+++ b/src/lib/withMiradorAPI.js
@@ -1,0 +1,134 @@
+import React from 'react';
+
+import * as actions from '../state/actions';
+import createRootReducer from '../state/reducers';
+
+/**
+ * HoC that initializes a Mirador Application
+ * @param store
+ * @param config
+ * @returns {function(*): {contextType?: React.Context<any>,
+ * new(props: Readonly<P>): HOC, new(props: P, context?: any): HOC, prototype: HOC}}
+ */
+export default function withMiradorAPI(store, config) {
+  // TODO validate config schema before processing / handle invalid or missing configuration
+  // validateConfig(config);
+
+  doInitialization();
+
+  /**
+   * doInitialization
+   */
+  function doInitialization() {
+    processPlugins();
+    dispatchSetConfig(config);
+    fetchManifests();
+    addWindows(config);
+  }
+
+  /**
+   * dispatchSetConfig
+   */
+  function dispatchSetConfig() {
+    const action = actions.setConfig(config);
+    store.dispatch(action);
+  }
+
+  /**
+   * fetchManifests
+   */
+  function fetchManifests() {
+    config.windows.forEach(win => dispatchFetchManifest(win.loadedManifest));
+  }
+
+  /**
+   * dispatchFetchManifest
+   * @param uri
+   */
+  function dispatchFetchManifest(uri) {
+    store.dispatch(actions.fetchManifest(uri));
+  }
+
+  /**
+   * addWindows
+   */
+  function addWindows() {
+    const thumbnailPositions = getThumbnailNavigationPositions(config);
+    thumbnailPositions.forEach((thumbnailNavigationPosition, index) => {
+      dispatchAddWindow({
+        canvasIndex: (config.windows[index].canvasIndex || 0),
+        manifestId: config.windows[index].loadedManifest,
+        thumbnailNavigationPosition,
+      });
+    });
+  }
+
+  /**
+   * dispatchAddWindow
+   * @param options
+   */
+  function dispatchAddWindow(options) {
+    store.dispatch(actions.addWindow(options));
+  }
+
+  /**
+   * getThumbnailNavigationPositions
+   */
+  function getThumbnailNavigationPositions() {
+    const positions = [];
+    config.windows.forEach((val) => {
+      if (val.thumbnailNavigationPosition) {
+        positions.push(val.thumbnailNavigationPosition);
+      } else {
+        positions.push(config.thumbnailNavigation.defaultPosition);
+      }
+    });
+    return positions;
+  }
+
+  /**
+   * processPlugins
+   */
+  function processPlugins() {
+    // TODO refactor / remove window dependency
+    const plugins = config.plugins || [];
+    const actionCreators = [];
+    const reducers = [];
+
+    plugins.forEach((pluginName) => {
+      const plugin = window.Mirador.plugins[pluginName];
+
+      // Add Actions
+      if (plugin.actions) {
+        Object.keys(plugin.actions)
+          .forEach(actionName => actionCreators.push({
+            name: actionName,
+            action: plugin.actions[actionName],
+          }));
+      }
+      // Add Reducers
+      if (plugin.reducers) {
+        Object.keys(plugin.reducers)
+          .forEach(reducerName => reducers.push({
+            name: reducerName,
+            reducer: plugin.reducers[reducerName],
+          }));
+      }
+    });
+    actionCreators.forEach((action) => { actions[action.name] = action.action; });
+    reducers.forEach((reducer) => { store.pluginReducers[reducer.name] = reducer.reducer; }); // eslint-disable-line
+    store.replaceReducer(createRootReducer(store.pluginReducers));
+  }
+
+  return function HOCFactory(WrappedComponent) {
+    return class HOC extends React.Component {
+      /**
+       *
+       * @returns {*}
+       */
+      render() {
+        return <WrappedComponent {...this.props} />;
+      }
+    };
+  };
+}

--- a/src/lib/withMiradorAPI.js
+++ b/src/lib/withMiradorAPI.js
@@ -1,14 +1,16 @@
 import React from 'react';
 
 import * as actions from '../state/actions';
-import createRootReducer from '../state/reducers';
+
+/*
+eslint max-len: ["error", { "ignoreComments": true }]
+*/
 
 /**
  * HoC that initializes a Mirador Application
  * @param store
  * @param config
- * @returns {function(*): {contextType?: React.Context<any>,
- * new(props: Readonly<P>): HOC, new(props: P, context?: any): HOC, prototype: HOC}}
+ * @returns {function(*): {contextType?: React.Context<any>, new(props: Readonly<P>): HOC, new(props: P, context?: any): HOC, prototype: HOC}}
  */
 export default function withMiradorAPI(store, config) {
   // TODO validate config schema before processing / handle invalid or missing configuration
@@ -20,7 +22,6 @@ export default function withMiradorAPI(store, config) {
    * doInitialization
    */
   function doInitialization() {
-    processPlugins();
     dispatchSetConfig(config);
     fetchManifests();
     addWindows(config);
@@ -84,40 +85,6 @@ export default function withMiradorAPI(store, config) {
       }
     });
     return positions;
-  }
-
-  /**
-   * processPlugins
-   */
-  function processPlugins() {
-    // TODO refactor / remove window dependency
-    const plugins = config.plugins || [];
-    const actionCreators = [];
-    const reducers = [];
-
-    plugins.forEach((pluginName) => {
-      const plugin = window.Mirador.plugins[pluginName];
-
-      // Add Actions
-      if (plugin.actions) {
-        Object.keys(plugin.actions)
-          .forEach(actionName => actionCreators.push({
-            name: actionName,
-            action: plugin.actions[actionName],
-          }));
-      }
-      // Add Reducers
-      if (plugin.reducers) {
-        Object.keys(plugin.reducers)
-          .forEach(reducerName => reducers.push({
-            name: reducerName,
-            reducer: plugin.reducers[reducerName],
-          }));
-      }
-    });
-    actionCreators.forEach((action) => { actions[action.name] = action.action; });
-    reducers.forEach((reducer) => { store.pluginReducers[reducer.name] = reducer.reducer; }); // eslint-disable-line
-    store.replaceReducer(createRootReducer(store.pluginReducers));
   }
 
   return function HOCFactory(WrappedComponent) {

--- a/src/state/createStore.js
+++ b/src/state/createStore.js
@@ -17,6 +17,5 @@ export default function () {
     createRootReducer(),
     composeWithDevTools(applyMiddleware(thunkMiddleware)),
   );
-  store.pluginReducers = {};
   return store;
 }


### PR DESCRIPTION
refactors init methods from default `MiradorViewer` implementation 
simplifies initialization and allows for multiple implementations.
closes #1802