### PR TITLE
Position the workspace controls absolutely, instead of with position:…

### DIFF
--- a/src/components/WorkspaceControlPanel.js
+++ b/src/components/WorkspaceControlPanel.js
@@ -21,7 +21,9 @@ class WorkspaceControlPanel extends Component {
       <Drawer
         className={classNames(classes.drawer, ns('workspace-control-panel'))}
         variant="permanent"
+        anchor="left"
         classes={{ paper: classNames(classes.drawer) }}
+        PaperProps={{ style: { position: 'absolute' } }}
         open
       >
         <WorkspaceControlPanelButtons />
@@ -40,6 +42,10 @@ WorkspaceControlPanel.propTypes = {
 const styles = theme => ({
   ctrlBtn: {
     margin: theme.spacing.unit,
+  },
+  drawer: {
+    overflowX: 'hidden',
+    height: '100%',
   },
 });
 


### PR DESCRIPTION
… fixed so it plays nice when embedded on a page; fixes #1804.

@aeschylus, do you have a WIP branch or something with multiple miradors on a page that this can be tested against?