### PR TITLE
Bugfix: isFullscreenEnabled undefined.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -53,11 +53,14 @@ class App extends Component {
 
 App.propTypes = {
   theme: PropTypes.string.isRequired, // eslint-disable-line react/forbid-prop-types
-  isFullscreenEnabled: PropTypes.bool.isRequired, // eslint-disable-line react/forbid-prop-types
+  isFullscreenEnabled: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types,
   setWorkspaceFullscreen: PropTypes.func.isRequired,
 };
 
+App.defaultProps = {
+  isFullscreenEnabled: false,
+};
 /**
  Material UI style overrides
  @private


### PR DESCRIPTION
Error message in developer tools was: 

Warning: Failed prop type: The prop `isFullscreenEnabled` is marked as required in `App`, but its value is `undefined`.