### PR TITLE
Make icons respond to light / dark theme; fixes #1822

### DIFF
--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -28,11 +28,10 @@ class WindowSideBarButtons extends Component {
       <>
         <IconButton
           aria-label="Open information companion window"
-          color="inherit"
           onClick={() => (toggleWindowSideBarPanel('info'))}
         >
           <InfoIcon
-            color={this.sideBarPanelCurrentlySelected('info') ? 'action' : 'inherit'}
+            color={this.sideBarPanelCurrentlySelected('info') ? 'primary' : 'inherit'}
           />
         </IconButton>
       </>

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -50,7 +50,7 @@ class WindowTopMenuButton extends Component {
     return (
       <>
         <IconButton
-          color="primary"
+          color="inherit"
           aria-label="Menu"
           className={classes.ctrlBtn}
           aria-haspopup="true"

--- a/src/components/WorkspaceMenuButton.js
+++ b/src/components/WorkspaceMenuButton.js
@@ -51,7 +51,7 @@ class WorkspaceMenuButton extends Component {
       <>
         <ListItem>
           <IconButton
-            color="primary"
+            color="default"
             id="menuBtn"
             aria-label="Menu"
             className={classes.ctrlBtn}


### PR DESCRIPTION
Fixes #1817 

This PR sets button styles to `default`, or `primary` where emphasis is used. Let's not use `secondary` for component colors until Gary and Jennifer determine more about the app's visual design. 

## Before
![theme-switch](https://user-images.githubusercontent.com/5402927/52504293-dfbb5700-2b9c-11e9-916b-2a97f1e9a9c5.gif)

## After
![screen shot 2019-02-08 at 12 21 24 pm](https://user-images.githubusercontent.com/5402927/52504042-2492be00-2b9c-11e9-8ae0-d08552692382.png)
![screen shot 2019-02-08 at 12 21 17 pm](https://user-images.githubusercontent.com/5402927/52504043-2492be00-2b9c-11e9-86c1-3fa1adfad8cf.png)
![screen shot 2019-02-08 at 12 21 03 pm](https://user-images.githubusercontent.com/5402927/52504044-252b5480-2b9c-11e9-85e5-98dc48d9732c.png)
![screen shot 2019-02-08 at 12 20 54 pm](https://user-images.githubusercontent.com/5402927/52504045-252b5480-2b9c-11e9-9fdf-c10bd1c4b582.png)
