### PR TITLE
ignore blueprint requires of optional UI framework Fixes #1806

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const paths = require('./config/paths');
 
@@ -90,6 +91,11 @@ const baseConfig = [
         }),
       ],
     },
+    plugins: [
+      new webpack.IgnorePlugin({
+        resourceRegExp: /@blueprintjs\/(core|icons)/, // ignore optional UI framework dependencies
+      }),
+    ],
   },
 ];
 


### PR DESCRIPTION
cc @sdellis I wasn't sure if you were still actively working on this, but it started to get in my way a bit so I wanted to see if I could resolve.

https://webpack.js.org/plugins/ignore-plugin