### PR TITLE
Provide more robust theming of all the MaterialUI options.

### DIFF
--- a/__tests__/src/components/App.test.js
+++ b/__tests__/src/components/App.test.js
@@ -6,6 +6,7 @@ import WorkspaceControlPanel from '../../../src/components/WorkspaceControlPanel
 import Workspace from '../../../src/containers/Workspace';
 import WorkspaceAdd from '../../../src/containers/WorkspaceAdd';
 import App from '../../../src/components/App';
+import settings from '../../../src/config/settings';
 
 /** */
 function createWrapper(props) {
@@ -13,7 +14,7 @@ function createWrapper(props) {
     <App
       isFullscreenEnabled={false}
       setWorkspaceFullscreen={() => {}}
-      theme="light"
+      theme={settings.theme}
       classes={{}}
       {...props}
     />,
@@ -32,6 +33,14 @@ describe('App', () => {
     expect(wrapper.find(Fullscreen).length).toBe(1);
     expect(wrapper.find(Workspace).length).toBe(1);
     expect(wrapper.find(WorkspaceControlPanel).length).toBe(1);
+  });
+
+  it('sets up a theme based on the config passed in merged w/ MaterialUI', () => {
+    const wrapper = createWrapper();
+    const { theme } = wrapper.find(MuiThemeProvider).props();
+    expect(theme.palette.type).toEqual('light');
+    expect(theme.typography.useNextVariants).toBe(true);
+    expect(Object.keys(theme).length).toBeGreaterThan(10);
   });
 
   it('should pass setWorkspaceFullscreen to Fullscreen.onChange', () => {

--- a/__tests__/src/components/WindowTopBar.test.js
+++ b/__tests__/src/components/WindowTopBar.test.js
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import Toolbar from '@material-ui/core/Toolbar';
+import AppBar from '@material-ui/core/AppBar';
 
 import WindowTopMenuButton from '../../../src/containers/WindowTopMenuButton';
 import WindowTopBarButtons from '../../../src/containers/WindowTopBarButtons';
@@ -29,6 +30,7 @@ function createWrapper(props) {
 describe('WindowTopBar', () => {
   it('renders all needed elements', () => {
     const wrapper = createWrapper();
+    expect(wrapper.find(AppBar).length).toBe(1);
     expect(wrapper.find(Toolbar).length).toBe(1);
     expect(wrapper.find(IconButton).length).toBe(2);
     expect(wrapper.find(MenuIcon).length).toBe(1);

--- a/__tests__/src/components/WorkspaceSettings.test.js
+++ b/__tests__/src/components/WorkspaceSettings.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import WorkspaceSettings from '../../../src/components/WorkspaceSettings';
+import settings from '../../../src/config/settings';
 
 describe('WorkspaceSettings', () => {
   let wrapper;
@@ -16,7 +17,7 @@ describe('WorkspaceSettings', () => {
         open
         handleClose={handleClose}
         updateConfig={updateConfig}
-        theme="light"
+        theme={settings.theme}
       />,
     );
   });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -14,31 +14,18 @@ import ns from '../config/css-ns';
  */
 class App extends Component {
   /**
-  */
-  makeMuiTheme() {
-    const { theme } = this.props;
-    return createMuiTheme({
-      palette: {
-        type: theme,
-      },
-      typography: {
-        useNextVariants: true,
-      },
-    });
-  }
-
-  /**
    * render
    * @return {String} - HTML markup for the component
    */
   render() {
     const {
-      isFullscreenEnabled, setWorkspaceFullscreen, classes, isWorkspaceAddVisible,
+      isFullscreenEnabled, setWorkspaceFullscreen, classes,
+      isWorkspaceAddVisible, theme,
     } = this.props;
 
     return (
       <div className={classNames(classes.background, ns('app'))}>
-        <MuiThemeProvider theme={this.makeMuiTheme()}>
+        <MuiThemeProvider theme={createMuiTheme(theme)}>
           <Fullscreen
             enabled={isFullscreenEnabled}
             onChange={setWorkspaceFullscreen}
@@ -57,7 +44,7 @@ class App extends Component {
 }
 
 App.propTypes = {
-  theme: PropTypes.string.isRequired, // eslint-disable-line react/forbid-prop-types
+  theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   isFullscreenEnabled: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types,
   setWorkspaceFullscreen: PropTypes.func.isRequired,

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -6,6 +6,7 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import CloseIcon from '@material-ui/icons/Close';
 import Toolbar from '@material-ui/core/Toolbar';
+import AppBar from '@material-ui/core/AppBar';
 import classNames from 'classnames';
 import WindowIcon from '../containers/WindowIcon';
 import WindowTopMenuButton from '../containers/WindowTopMenuButton';
@@ -26,29 +27,31 @@ class WindowTopBar extends Component {
       removeWindow, windowId, classes, toggleWindowSideBar, t, manifestTitle,
     } = this.props;
     return (
-      <Toolbar disableGutters className={classNames(classes.reallyDense, ns('window-top-bar'))} variant="dense">
-        <IconButton
-          aria-label={t('toggleWindowSideBar')}
-          color="inherit"
-          onClick={toggleWindowSideBar}
-        >
-          <MenuIcon />
-        </IconButton>
-        <WindowIcon windowId={windowId} />
-        <Typography variant="h3" noWrap color="inherit" className={classes.typographyBody}>
-          {manifestTitle}
-        </Typography>
-        <WindowTopBarButtons windowId={windowId} />
-        <WindowTopMenuButton className={ns('window-menu-btn')} windowId={windowId} />
-        <IconButton
-          color="inherit"
-          className={ns('window-close')}
-          aria-label={t('closeWindow')}
-          onClick={removeWindow}
-        >
-          <CloseIcon />
-        </IconButton>
-      </Toolbar>
+      <AppBar position="relative">
+        <Toolbar disableGutters className={classNames(classes.reallyDense, ns('window-top-bar'))} variant="dense">
+          <IconButton
+            aria-label={t('toggleWindowSideBar')}
+            color="inherit"
+            onClick={toggleWindowSideBar}
+          >
+            <MenuIcon />
+          </IconButton>
+          <WindowIcon windowId={windowId} />
+          <Typography variant="h3" noWrap color="inherit" className={classes.typographyBody}>
+            {manifestTitle}
+          </Typography>
+          <WindowTopBarButtons windowId={windowId} />
+          <WindowTopMenuButton className={ns('window-menu-btn')} windowId={windowId} />
+          <IconButton
+            color="inherit"
+            className={ns('window-close')}
+            aria-label={t('closeWindow')}
+            onClick={removeWindow}
+          >
+            <CloseIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
     );
   }
 }

--- a/src/components/WorkspaceSettings.js
+++ b/src/components/WorkspaceSettings.js
@@ -20,12 +20,18 @@ class WorkspaceSettings extends Component {
   }
 
   /**
-   * Propagate theme selection into the global state
+   * Propagate theme palette type selection into the global state
    */
   handleThemeChange(event) {
     const { updateConfig } = this.props;
 
-    updateConfig({ theme: event.target.value });
+    updateConfig({
+      theme: {
+        palette: {
+          type: event.target.value,
+        },
+      },
+    });
   }
 
   /**
@@ -44,7 +50,7 @@ class WorkspaceSettings extends Component {
           <FormControl>
             <InputLabel htmlFor="theme-simple">{t('theme')}</InputLabel>
             <Select
-              value={theme}
+              value={theme.palette.type}
               onChange={this.handleThemeChange}
               inputProps={{
                 name: 'theme',
@@ -66,7 +72,7 @@ WorkspaceSettings.propTypes = {
   open: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
   children: PropTypes.node,
   updateConfig: PropTypes.func.isRequired,
-  theme: PropTypes.string.isRequired,
+  theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   t: PropTypes.func,
 };
 

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -1,5 +1,12 @@
 export default {
-  theme: 'light', // dark also available
+  theme: { // Sets up a MaterialUI theme. See https://material-ui.com/customization/default-theme/
+    palette: {
+      type: 'light', // dark also available
+    },
+    typography: {
+      useNextVariants: true // set so that console deprecation warning is removed
+    }
+  },
   windows: [],
   thumbnailNavigation: {
     defaultPosition: 'bottom',

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -52,10 +52,6 @@
     resize: horizontal;
   }
 
-  &-window-top-bar {
-    background: lighten($black, 80%);
-  }
-
   &-companion-bottom {
     background: lighten($black, 60%);
     overflow-y: auto;


### PR DESCRIPTION
Fixes #1878 

Also added a documentation page here with examples: https://github.com/ProjectMirador/mirador/wiki/Theming-Mirador

A quick usage of this can be done by dispatching an action to update the config:
```javascript
var action = miradorInstance.actions.updateConfig({
  theme: {
    palette: {
      type: 'dark',
      primary: {
        main: '#8c1515'
      }
    }
  }
});
miradorInstance.store.dispatch(action);
```

@ggeisler @jvine ^^ you can copy and paste that into the console on the [demo site](https://deploy-preview-1886--mirador-dev.netlify.com/) to test things out. Defaults are coming from here: https://material-ui.com/customization/default-theme/