### PR TITLE
Add support for configuration initial manifests for the viewer

### DIFF
--- a/__tests__/integration/mirador/index.html
+++ b/__tests__/integration/mirador/index.html
@@ -19,7 +19,23 @@
        {
          loadedManifest: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json',
          thumbnailNavigationPosition: 'off',
-       }]
+       }],
+       manifests: {
+         "http://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
+         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
+         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
+         "http://dams.llgc.org.uk/iiif/2.0/4389767/manifest.json": { provider: "The National Library of Wales"},
+         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
+         "http://beta.biblissima.fr/iiif/manifest/ark:/43093/desc57cb76cd3739a24a9277b6669d95b5f3a590e771": { provider: "Biblissima"},
+         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
+         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
+         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
+         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
+         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
+         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
+         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+         "http://storiiies.cogapp.com/holbein/manifest.json": { provider: "National Gallery, London"}
+       }
      });
     </script>
   </body>

--- a/__tests__/src/actions/manifest.test.js
+++ b/__tests__/src/actions/manifest.test.js
@@ -45,7 +45,7 @@ describe('manifest actions', () => {
       it('dispatches the REQUEST_MANIFEST action', () => {
         store.dispatch(actions.fetchManifest('https://purl.stanford.edu/sn904cj3429/iiif/manifest'));
         expect(store.getActions()).toEqual([
-          { manifestId: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest', type: 'REQUEST_MANIFEST' },
+          { manifestId: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest', type: 'REQUEST_MANIFEST', properties: { isFetching: true } },
         ]);
       });
       it('dispatches the REQUEST_MANIFEST and then RECEIVE_MANIFEST', () => {

--- a/__tests__/src/components/ManifestListItem.test.js
+++ b/__tests__/src/components/ManifestListItem.test.js
@@ -2,60 +2,54 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import ManifestListItem from '../../../src/components/ManifestListItem';
 
+/** */
+function createWrapper(props) {
+  return shallow(
+    <ManifestListItem
+      manifestId="http://example.com"
+      title="xyz"
+      ready
+      addWindow={() => {}}
+      fetchManifest={() => {}}
+      t={t => t}
+      {...props}
+    />,
+  ).dive(); // to unwrapp HOC created by withStyle()
+}
+
 describe('ManifestListItem', () => {
   it('renders without an error', () => {
-    const addWindow = jest.fn();
-    const wrapper = shallow(
-      <ManifestListItem
-        manifestId="http://example.com"
-        title="xyz"
-        ready
-        addWindow={addWindow}
-        t={t => t}
-      />,
-    ).dive();
+    const wrapper = createWrapper();
     expect(wrapper.find('.mirador-manifest-list-item').length).toBe(1);
     expect(wrapper.find('WithStyles(ButtonBase)').length).toBe(1);
     expect(wrapper.find('WithStyles(ButtonBase) WithStyles(Typography)').children().text()).toEqual('xyz');
   });
   it('renders a placeholder element until real data is available', () => {
-    const addWindow = jest.fn();
-    const wrapper = shallow(
-      <ManifestListItem manifestId="http://example.com" addWindow={addWindow} />,
-    ).dive();
+    const wrapper = createWrapper({ ready: false });
+
     expect(wrapper.find('.mirador-manifest-list-item').length).toBe(1);
     expect(wrapper.find('ReactPlaceholder').length).toBe(1);
   });
   it('updates and adds window when button clicked', () => {
     const addWindow = jest.fn();
-    const wrapper = shallow(
-      <ManifestListItem manifestId="http://example.com" title="xyz" addWindow={addWindow} />,
-    ).dive();
+    const wrapper = createWrapper({ addWindow });
     wrapper.find('WithStyles(ButtonBase)').simulate('click');
     expect(addWindow).toHaveBeenCalledTimes(1);
   });
   it('uses the manifest id if the title is not available', () => {
-    const addWindow = jest.fn();
-    const wrapper = shallow(
-      <ManifestListItem manifestId="http://example.com" ready addWindow={addWindow} />,
-    ).dive();
+    const wrapper = createWrapper({ ready: true, title: null });
+
     expect(wrapper.find('WithStyles(ButtonBase)').length).toBe(1);
     expect(wrapper.find('WithStyles(ButtonBase) WithStyles(Typography)').children().text()).toEqual('http://example.com');
   });
 
   it('displays the provider information', () => {
-    const addWindow = jest.fn();
-    const wrapper = shallow(
-      <ManifestListItem manifestId="http://example.com" ready provider="ACME" addWindow={addWindow} />,
-    ).dive();
+    const wrapper = createWrapper({ provider: 'ACME' });
     expect(wrapper.find('WithStyles(Typography).mirador-manifest-list-item-provider').children().text()).toEqual('ACME');
   });
 
   it('displays a placeholder provider if no information is given', () => {
-    const addWindow = jest.fn();
-    const wrapper = shallow(
-      <ManifestListItem manifestId="http://example.com" ready addWindow={addWindow} />,
-    ).dive();
+    const wrapper = createWrapper();
     expect(wrapper.find('WithStyles(Typography).mirador-manifest-list-item-provider').children().text()).toEqual('addedFromUrl');
   });
 });

--- a/__tests__/src/components/ManifestListItem.test.js
+++ b/__tests__/src/components/ManifestListItem.test.js
@@ -30,6 +30,12 @@ describe('ManifestListItem', () => {
     expect(wrapper.find('.mirador-manifest-list-item').length).toBe(1);
     expect(wrapper.find('ReactPlaceholder').length).toBe(1);
   });
+  it('renders an error message if fetching the manifest failed', () => {
+    const wrapper = createWrapper({ error: 'This is an error message' });
+
+    expect(wrapper.find('WithStyles(Paper)').length).toBe(1);
+    expect(wrapper.find('WithStyles(Paper)').children().text()).toEqual('This is an error message');
+  });
   it('updates and adds window when button clicked', () => {
     const addWindow = jest.fn();
     const wrapper = createWrapper({ addWindow });

--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -44,19 +44,23 @@ describe('MiradorViewer', () => {
     it('transforms config values to actions to dispatch to store', () => {
       instance = new MiradorViewer({
         id: 'mirador',
-        windows: [{
-          loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
-          canvasIndex: 2,
-        },
-        {
-          loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
-          thumbnailNavigationPosition: 'off',
-          view: 'book',
-        },
+        windows: [
+          {
+            loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+            canvasIndex: 2,
+          },
+          {
+            loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+            thumbnailNavigationPosition: 'off',
+            view: 'book',
+          },
         ],
+        manifests: {
+          'http://media.nga.gov/public/manifests/nga_highlights.json': { provider: 'National Gallery of Art' },
+        },
       });
 
-      const { windows } = instance.store.getState();
+      const { windows, manifests } = instance.store.getState();
       const windowIds = Object.keys(windows);
       expect(Object.keys(windowIds).length).toBe(2);
       expect(windows[windowIds[0]].canvasIndex).toBe(2);
@@ -65,6 +69,10 @@ describe('MiradorViewer', () => {
       expect(windows[windowIds[1]].thumbnailNavigationPosition).toBe('off');
       expect(windows[windowIds[0]].view).toBe('single');
       expect(windows[windowIds[1]].view).toBe('book');
+
+      const manifestIds = Object.keys(manifests);
+      expect(Object.keys(manifestIds).length).toBe(2);
+      expect(manifests['http://media.nga.gov/public/manifests/nga_highlights.json'].provider).toBe('National Gallery of Art');
     });
   });
 });

--- a/__tests__/src/reducers/manifests.test.js
+++ b/__tests__/src/reducers/manifests.test.js
@@ -9,7 +9,6 @@ describe('manifests reducer', () => {
     })).toEqual({
       abc123: {
         id: 'abc123',
-        isFetching: true,
       },
     });
   });

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -26,9 +26,29 @@ const handleOpenButtonClick = (event, manifest, addWindow) => {
 /** */
 class ManifestListItem extends React.Component {
   /** */
+  componentDidMount() {
+    const {
+      fetchManifest, manifestId, ready, isFetching, error,
+    } = this.props;
+
+    if (!ready && !error && !isFetching) fetchManifest(manifestId);
+  }
+
+  /** */
   render() {
     const {
-      manifestId, ready, title, thumbnail, logo, addWindow, handleClose, size, classes, provider, t,
+      manifestId,
+      ready,
+      title,
+      thumbnail,
+      logo,
+      addWindow,
+      handleClose,
+      size,
+      classes,
+      provider,
+      t,
+      error,
     } = this.props;
 
     const placeholder = (
@@ -47,6 +67,14 @@ class ManifestListItem extends React.Component {
         </Grid>
       </Grid>
     );
+
+    if (error) {
+      return (
+        <Paper elevation={1} className={classes.root} data-manifestid={manifestId}>
+          {error}
+        </Paper>
+      );
+    }
 
     return (
       <Paper elevation={1} className={classes.root} data-manifestid={manifestId}>
@@ -113,6 +141,9 @@ ManifestListItem.propTypes = {
   classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   provider: PropTypes.string,
   t: PropTypes.func,
+  fetchManifest: PropTypes.func.isRequired,
+  error: PropTypes.string,
+  isFetching: PropTypes.bool,
 };
 
 ManifestListItem.defaultProps = {
@@ -125,6 +156,8 @@ ManifestListItem.defaultProps = {
   size: 0,
   provider: null,
   t: key => key,
+  error: null,
+  isFetching: false,
 };
 
 /** */

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -13,6 +13,8 @@ const mapStateToProps = (state, { manifestId }) => {
 
   return {
     ready: !!manifest.manifestation,
+    error: manifest.error,
+    isFetching: manifest.isFetching,
     title: getManifestTitle(manifest),
     logo: getManifestLogo(manifest),
     thumbnail: getManifestThumbnail(manifest),
@@ -26,7 +28,7 @@ const mapStateToProps = (state, { manifestId }) => {
  * @memberof ManifestListItem
  * @private
  */
-const mapDispatchToProps = { addWindow: actions.addWindow };
+const mapDispatchToProps = { addWindow: actions.addWindow, fetchManifest: actions.fetchManifest };
 
 const enhance = compose(
   connect(mapStateToProps, mapDispatchToProps),

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -66,7 +66,7 @@ class MiradorViewer {
 
     Object.keys(mergedConfig.manifests || {}).forEach((manifestId) => {
       this.store.dispatch(
-        actions.fetchManifest(manifestId, mergedConfig.manifests[manifestId]),
+        actions.requestManifest(manifestId, mergedConfig.manifests[manifestId]),
       );
     });
   }

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -63,6 +63,12 @@ class MiradorViewer {
         thumbnailNavigationPosition,
       }));
     });
+
+    Object.keys(mergedConfig.manifests || {}).forEach((manifestId) => {
+      this.store.dispatch(
+        actions.fetchManifest(manifestId, mergedConfig.manifests[manifestId]),
+      );
+    });
   }
 
   /**

--- a/src/state/actions/manifest.js
+++ b/src/state/actions/manifest.js
@@ -53,7 +53,8 @@ export function receiveManifestFailure(manifestId, error) {
  */
 export function fetchManifest(manifestId, properties) {
   return ((dispatch) => {
-    dispatch(requestManifest(manifestId, properties));
+    dispatch(requestManifest(manifestId, { ...properties, isFetching: true }));
+
     return fetch(manifestId)
       .then(response => response.json())
       .then(json => dispatch(receiveManifest(manifestId, json)))

--- a/src/state/actions/manifest.js
+++ b/src/state/actions/manifest.js
@@ -7,10 +7,11 @@ import ActionTypes from './action-types';
  * @param  {String} manifestId
  * @memberof ActionCreators
  */
-export function requestManifest(manifestId) {
+export function requestManifest(manifestId, properties) {
   return {
     type: ActionTypes.REQUEST_MANIFEST,
     manifestId,
+    properties,
   };
 }
 
@@ -50,9 +51,9 @@ export function receiveManifestFailure(manifestId, error) {
  * @param  {String} manifestId
  * @memberof ActionCreators
  */
-export function fetchManifest(manifestId) {
+export function fetchManifest(manifestId, properties) {
   return ((dispatch) => {
-    dispatch(requestManifest(manifestId));
+    dispatch(requestManifest(manifestId, properties));
     return fetch(manifestId)
       .then(response => response.json())
       .then(json => dispatch(receiveManifest(manifestId, json)))

--- a/src/state/reducers/manifests.js
+++ b/src/state/reducers/manifests.js
@@ -13,7 +13,6 @@ export const manifestsReducer = (state = {}, action) => {
           ...state[action.manifestId],
           ...action.properties,
           id: action.manifestId,
-          isFetching: true,
         },
       };
     case ActionTypes.RECEIVE_MANIFEST:

--- a/src/state/reducers/manifests.js
+++ b/src/state/reducers/manifests.js
@@ -10,6 +10,8 @@ export const manifestsReducer = (state = {}, action) => {
       return {
         ...state,
         [action.manifestId]: {
+          ...state[action.manifestId],
+          ...action.properties,
           id: action.manifestId,
           isFetching: true,
         },
@@ -18,6 +20,7 @@ export const manifestsReducer = (state = {}, action) => {
       return {
         ...state,
         [action.manifestId]: {
+          ...state[action.manifestId],
           id: action.manifestId,
           manifestation: manifesto.create(action.manifestJson),
           isFetching: false,
@@ -27,6 +30,7 @@ export const manifestsReducer = (state = {}, action) => {
       return {
         ...state,
         [action.manifestId]: {
+          ...state[action.manifestId],
           id: action.manifestId,
           error: action.error,
           isFetching: false,

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -60,6 +60,10 @@ export function getManifestCanvases(manifest) {
     return [];
   }
 
+  if (!manifest.manifestation.getSequences || !manifest.manifestation.getSequences()[0]) {
+    return [];
+  }
+
   return manifest.manifestation.getSequences()[0].getCanvases();
 }
 


### PR DESCRIPTION
I guess this is part of #1833 so the initial load window view can be populated with data. It has an indirect dependency on #1901 in order to make the data actually show up in the interface, but is independent and can be merged with or without it.

There's some obvious follow-on work to make sure we lazy-load manifests instead of immediately dispatching requests for data we might not even use, but this hopefully is sufficient for now.