### PR TITLE
Add a workspaceControlPanel.enabled config option for displaying...

### DIFF
--- a/__tests__/src/components/App.test.js
+++ b/__tests__/src/components/App.test.js
@@ -14,6 +14,7 @@ function createWrapper(props) {
   return shallow(
     <App
       isFullscreenEnabled={false}
+      isWorkspaceControlPanelVisible
       setWorkspaceFullscreen={() => {}}
       theme={settings.theme}
       translations={{}}
@@ -65,6 +66,12 @@ describe('App', () => {
     wrapper = createWrapper({ isFullscreenEnabled: true });
     expect(wrapper.find(Fullscreen).first().prop('enabled'))
       .toEqual(true);
+  });
+
+  it('should not render WorkspaceControlPanel when isWorkspaceControlPanelVisible is false', () => {
+    const wrapper = createWrapper({ isWorkspaceControlPanelVisible: false });
+
+    expect(wrapper.find(WorkspaceControlPanel).length).toBe(0);
   });
 
   describe('with isWorkspaceAddVisible', () => {

--- a/__tests__/src/components/Workspace.test.js
+++ b/__tests__/src/components/Workspace.test.js
@@ -6,15 +6,28 @@ import Workspace from '../../../src/components/Workspace';
 
 const windows = { 1: { id: 1 }, 2: { id: 2 } };
 
+/**
+ * Utility function to create a Worksapce
+ * component with all required props set
+*/
+function createWrapper(props) {
+  return shallow(
+    <Workspace
+      isWorkspaceControlPanelVisible
+      windows={windows}
+      workspaceType="mosaic"
+      {...props}
+    />,
+  );
+}
+
 describe('Workspace', () => {
   describe('if workspace type is mosaic', () => {
     it('should render <WorkspaceMosaic/> properly', () => {
-      const wrapper = shallow(
-        <Workspace windows={windows} workspaceType="mosaic" />,
-      );
+      const wrapper = createWrapper();
 
       expect(wrapper.matchesElement(
-        <div className="mirador-workspace">
+        <div className="mirador-workspace mirador-workspace-with-control-panel">
           <WorkspaceMosaic windows={windows} />
         </div>,
       )).toBe(true);
@@ -22,16 +35,30 @@ describe('Workspace', () => {
   });
   describe('if workspace type is unknown', () => {
     it('should render <Window/> components as list', () => {
-      const wrapper = shallow(
-        <Workspace windows={windows} workspaceType="bubu" />,
-      );
+      const wrapper = createWrapper({ workspaceType: 'bubu' });
 
       expect(wrapper.matchesElement(
-        <div className="mirador-workspace">
+        <div className="mirador-workspace mirador-workspace-with-control-panel">
           <Window window={{ id: 1 }} />
           <Window window={{ id: 2 }} />
         </div>,
       )).toBe(true);
+    });
+  });
+
+  describe('when the workspace control panel is displayed', () => {
+    it('has the *-with-control-panel class applied', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('.mirador-workspace-with-control-panel').length).toBe(1);
+    });
+  });
+
+  describe('when the workspace control panel is not displayed', () => {
+    it('does not have the *-with-control-panel class applied', () => {
+      const wrapper = createWrapper({ isWorkspaceControlPanelVisible: false });
+
+      expect(wrapper.find('.mirador-workspace-with-control-panel').length).toBe(0);
     });
   });
 });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -54,7 +54,7 @@ class App extends Component {
 App.propTypes = {
   theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   translations: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  isFullscreenEnabled: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
+  isFullscreenEnabled: PropTypes.bool,
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types,
   setWorkspaceFullscreen: PropTypes.func.isRequired,
   isWorkspaceAddVisible: PropTypes.bool,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,7 +22,7 @@ class App extends Component {
   render() {
     const {
       isFullscreenEnabled, setWorkspaceFullscreen, classes,
-      isWorkspaceAddVisible, theme, translations,
+      isWorkspaceAddVisible, isWorkspaceControlPanelVisible, theme, translations,
     } = this.props;
 
     Object.keys(translations).forEach((lng) => {
@@ -43,7 +43,10 @@ class App extends Component {
                   : <Workspace />
                }
             </Fullscreen>
-            <WorkspaceControlPanel />
+            {
+              isWorkspaceControlPanelVisible
+                && <WorkspaceControlPanel />
+            }
           </MuiThemeProvider>
         </I18nextProvider>
       </div>
@@ -58,6 +61,7 @@ App.propTypes = {
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types,
   setWorkspaceFullscreen: PropTypes.func.isRequired,
   isWorkspaceAddVisible: PropTypes.bool,
+  isWorkspaceControlPanelVisible: PropTypes.bool.isRequired,
 };
 
 App.defaultProps = {

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import Window from '../containers/Window';
 import WorkspaceMosaic from '../containers/WorkspaceMosaic';
 import ns from '../config/css-ns';
@@ -32,8 +33,17 @@ class Workspace extends React.Component {
    * render
    */
   render() {
+    const { isWorkspaceControlPanelVisible } = this.props;
+
     return (
-      <div className={ns('workspace')}>
+      <div
+        className={
+          classNames(
+            ns('workspace'),
+            (isWorkspaceControlPanelVisible && ns('workspace-with-control-panel')),
+          )
+        }
+      >
         {this.workspaceByType()}
       </div>
     );
@@ -41,6 +51,7 @@ class Workspace extends React.Component {
 }
 
 Workspace.propTypes = {
+  isWorkspaceControlPanelVisible: PropTypes.bool.isRequired,
   windows: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   workspaceType: PropTypes.string.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -19,5 +19,8 @@ export default {
   },
   workspace: {
     type: 'mosaic',
+  },
+  workspaceControlPanel: {
+    enabled: true,
   }
 };

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -14,6 +14,7 @@ const mapStateToProps = state => (
     translations: state.config.translations,
     isFullscreenEnabled: state.workspace.isFullscreenEnabled,
     isWorkspaceAddVisible: state.workspace.isWorkspaceAddVisible,
+    isWorkspaceControlPanelVisible: state.config.workspaceControlPanel.enabled,
   }
 );
 

--- a/src/containers/Workspace.js
+++ b/src/containers/Workspace.js
@@ -9,6 +9,7 @@ import Workspace from '../components/Workspace';
  */
 const mapStateToProps = state => (
   {
+    isWorkspaceControlPanelVisible: state.config.workspaceControlPanel.enabled,
     workspaceType: state.config.workspace.type,
     windows: state.windows,
   }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -13,10 +13,13 @@
     left: 0;
     margin: 0;
     overflow: scroll;
-    padding-left: 100px;
     position: absolute;
     right: 0;
     top: 0;
+  }
+
+  &-workspace-with-control-panel {
+    padding-left: 100px; // The width of the control panel
   }
 
   &-workspace-add {


### PR DESCRIPTION
...the WorkspaceControlPanel component.

Closes #1885

You can modify this in the netlify deploy by putting this in your console (and changing the `enabled` value to `true` or `false` based on if you want it to display or not)

```js
miradorInstance.store.dispatch(
  {
    type: "UPDATE_CONFIG",
    config: {
      ...miradorInstance.store.getState()['config'],
      workspaceControlPanel: { enabled: false }
    }
  }
);
```

![toggleworkspacesidebar](https://user-images.githubusercontent.com/96776/52878932-be191d00-3112-11e9-99f9-fe74e8d98003.gif)
