### PR TITLE
Refactor viewer state out into a separate reducer

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -16,7 +16,7 @@ describe('OpenSeadragonViewer', () => {
     wrapper = shallow(
       <OpenSeadragonViewer
         tileSources={[{ '@id': 'http://foo', width: 100, height: 200 }, { '@id': 'http://bar', width: 150, height: 201 }]}
-        window={{ id: 'base' }}
+        windowId="base"
         config={{}}
         updateViewport={updateViewport}
       >
@@ -90,7 +90,8 @@ describe('OpenSeadragonViewer', () => {
       wrapper = shallow(
         <OpenSeadragonViewer
           tileSources={[{ '@id': 'http://foo' }]}
-          window={{ id: 'base', viewer: { x: 1, y: 0, zoom: 0.5 } }}
+          windowId="base"
+          viewer={{ x: 1, y: 0, zoom: 0.5 }}
           config={{}}
           updateViewport={updateViewport}
         >
@@ -136,8 +137,8 @@ describe('OpenSeadragonViewer', () => {
         },
       };
 
-      wrapper.setProps({ window: { id: 'base', viewer: { x: 0.5, y: 0.5, zoom: 0.1 } } });
-      wrapper.setProps({ window: { id: 'base', viewer: { x: 1, y: 0, zoom: 0.5 } } });
+      wrapper.setProps({ viewer: { x: 0.5, y: 0.5, zoom: 0.1 } });
+      wrapper.setProps({ viewer: { x: 1, y: 0, zoom: 0.5 } });
 
       expect(panTo).toHaveBeenCalledWith(
         { x: 1, y: 0, zoom: 0.5 }, false,

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -24,7 +24,7 @@ class OpenSeadragonViewer extends Component {
    * React lifecycle event
    */
   componentDidMount() {
-    const { tileSources, window } = this.props;
+    const { tileSources, viewer } = this.props;
     if (!this.ref.current) {
       return;
     }
@@ -38,9 +38,9 @@ class OpenSeadragonViewer extends Component {
     });
     this.viewer.addHandler('viewport-change', this.onViewportChange);
 
-    if (window.viewer) {
-      this.viewer.viewport.panTo(window.viewer, false);
-      this.viewer.viewport.zoomTo(window.viewer.zoom, window.viewer, false);
+    if (viewer) {
+      this.viewer.viewport.panTo(viewer, false);
+      this.viewer.viewport.zoomTo(viewer.zoom, viewer, false);
     }
 
     tileSources.forEach((tileSource, i) => this.addTileSource(tileSource, i));
@@ -51,7 +51,7 @@ class OpenSeadragonViewer extends Component {
    * When the viewport state changes, pan or zoom the OSD viewer as appropriate
    */
   componentDidUpdate(prevProps) {
-    const { tileSources, window } = this.props;
+    const { tileSources, viewer } = this.props;
     if (!this.tileSourcesMatch(prevProps.tileSources)) {
       this.viewer.close();
       Promise.all(
@@ -61,16 +61,16 @@ class OpenSeadragonViewer extends Component {
           this.fitBounds(...this.boundsFromTileSources(), true);
         }
       });
-    } else if (window.viewer) {
+    } else if (viewer) {
       const { viewport } = this.viewer;
 
-      if (window.viewer.x !== viewport.centerSpringX.target.value
-        || window.viewer.y !== viewport.centerSpringY.target.value) {
-        this.viewer.viewport.panTo(window.viewer, false);
+      if (viewer.x !== viewport.centerSpringX.target.value
+        || viewer.y !== viewport.centerSpringY.target.value) {
+        this.viewer.viewport.panTo(viewer, false);
       }
 
-      if (window.viewer.zoom !== viewport.zoomSpring.target.value) {
-        this.viewer.viewport.zoomTo(window.viewer.zoom, window.viewer, false);
+      if (viewer.zoom !== viewport.zoomSpring.target.value) {
+        this.viewer.viewport.zoomTo(viewer.zoom, viewer, false);
       }
     }
   }
@@ -85,11 +85,11 @@ class OpenSeadragonViewer extends Component {
    * Forward OSD state to redux
    */
   onViewportChange(event) {
-    const { updateViewport, window } = this.props;
+    const { updateViewport, windowId } = this.props;
 
     const { viewport } = event.eventSource;
 
-    updateViewport(window.id, {
+    updateViewport(windowId, {
       x: viewport.centerSpringX.target.value,
       y: viewport.centerSpringY.target.value,
       zoom: viewport.zoomSpring.target.value,
@@ -199,17 +199,17 @@ class OpenSeadragonViewer extends Component {
    * Renders things
    */
   render() {
-    const { window, children } = this.props;
+    const { windowId, children } = this.props;
     return (
       <>
         <div
           className={ns('osd-container')}
-          id={`${window.id}-osd`}
+          id={`${windowId}-osd`}
           ref={this.ref}
         >
           { children }
         </div>
-        <ZoomControls windowId={window.id} />
+        <ZoomControls windowId={windowId} />
       </>
     );
   }
@@ -218,13 +218,15 @@ class OpenSeadragonViewer extends Component {
 OpenSeadragonViewer.defaultProps = {
   children: null,
   tileSources: [],
+  viewer: null,
 };
 
 OpenSeadragonViewer.propTypes = {
   children: PropTypes.element,
   tileSources: PropTypes.arrayOf(PropTypes.object),
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   updateViewport: PropTypes.func.isRequired,
+  windowId: PropTypes.string.isRequired,
 };
 
 export default OpenSeadragonViewer;

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -122,7 +122,7 @@ class WindowViewer extends Component {
       <>
         <OSDViewer
           tileSources={this.tileInfoFetchedFromStore()}
-          window={window}
+          windowId={window.id}
         >
           <ViewerNavigation window={window} canvases={this.canvases} />
         </OSDViewer>

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -5,6 +5,15 @@ import OpenSeadragonViewer from '../components/OpenSeadragonViewer';
 import * as actions from '../state/actions';
 
 /**
+ * mapStateToProps - used to hook up connect to action creators
+ * @memberof Window
+ * @private
+ */
+const mapStateToProps = ({ viewers }, { windowId }) => ({
+  viewer: viewers[windowId],
+});
+
+/**
  * mapDispatchToProps - used to hook up connect to action creators
  * @memberof ManifestListItem
  * @private
@@ -14,7 +23,7 @@ const mapDispatchToProps = {
 };
 
 const enhance = compose(
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
   // further HOC go here
 );

--- a/src/state/reducers/index.js
+++ b/src/state/reducers/index.js
@@ -3,3 +3,4 @@ export * from './windows';
 export * from './manifests';
 export * from './infoResponses';
 export * from './config';
+export * from './viewers';

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -1,6 +1,11 @@
 import { combineReducers } from 'redux';
 import {
-  configReducer, infoResponsesReducer, manifestsReducer, windowsReducer, workspaceReducer,
+  configReducer,
+  infoResponsesReducer,
+  manifestsReducer,
+  viewersReducer,
+  windowsReducer,
+  workspaceReducer,
 } from '.';
 
 /**
@@ -15,6 +20,7 @@ export default function createRootReducer(pluginReducers) {
     manifests: manifestsReducer,
     infoResponses: infoResponsesReducer,
     config: configReducer,
+    viewers: viewersReducer,
     ...pluginReducers,
   });
 }

--- a/src/state/reducers/viewers.js
+++ b/src/state/reducers/viewers.js
@@ -1,0 +1,18 @@
+import ActionTypes from '../actions/action-types';
+
+/**
+ * viewersReducer
+ */
+export const viewersReducer = (state = {}, action) => {
+  switch (action.type) {
+    case ActionTypes.UPDATE_VIEWPORT:
+      return {
+        ...state,
+        [action.windowId]: {
+          ...action.payload,
+        },
+      };
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
Push viewer state into a separate reducer and push it out of the window state so our window objects mutate less often.