### PR TITLE
Remove viewer state out of windows reducer

### DIFF
--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -230,27 +230,4 @@ describe('windows reducer', () => {
       },
     });
   });
-
-  it('should handle UPDATE_VIEWPORT', () => {
-    expect(windowsReducer({
-      abc123: {
-        id: 'abc123',
-      },
-      def456: {
-        id: 'def456',
-      },
-    }, {
-      type: ActionTypes.UPDATE_VIEWPORT,
-      windowId: 'abc123',
-      payload: { x: 0, y: 1, zoom: 0.5 },
-    })).toEqual({
-      abc123: {
-        id: 'abc123',
-        viewer: { x: 0, y: 1, zoom: 0.5 },
-      },
-      def456: {
-        id: 'def456',
-      },
-    });
-  });
 });

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -67,14 +67,6 @@ export const windowsReducer = (state = {}, action) => {
       return setCanvasIndex(state, action.windowId, currentIndex => currentIndex - 1);
     case ActionTypes.SET_CANVAS:
       return setCanvasIndex(state, action.windowId, currentIndex => action.canvasIndex);
-    case ActionTypes.UPDATE_VIEWPORT:
-      return {
-        ...state,
-        [action.windowId]: {
-          ...state[action.windowId],
-          viewer: action.payload,
-        },
-      };
     default:
       return state;
   }


### PR DESCRIPTION
PR #1904 moved viewer state into separate reducer but still left a copy in window reducer. This PR removed it.