### PR TITLE
Add back reducer UPDATE_VIEWPORT test and test window cleanup

### DIFF
--- a/__tests__/src/reducers/viewers.test.js
+++ b/__tests__/src/reducers/viewers.test.js
@@ -1,0 +1,45 @@
+import { viewersReducer } from '../../../src/state/reducers/viewers';
+import ActionTypes from '../../../src/state/actions/action-types';
+
+describe('viewers reducer', () => {
+  it('should handle UPDATE_VIEWPORT', () => {
+    expect(viewersReducer({
+      abc123: {
+        x: 1,
+      },
+      def456: {
+        y: 1,
+      },
+    }, {
+      type: ActionTypes.UPDATE_VIEWPORT,
+      windowId: 'abc123',
+      payload: { x: 0, y: 1, zoom: 0.5 },
+    })).toEqual({
+      abc123: {
+        x: 0,
+        y: 1,
+        zoom: 0.5,
+      },
+      def456: {
+        y: 1,
+      },
+    });
+  });
+  it('should handle REMOVE_WINDOW', () => {
+    expect(viewersReducer({
+      abc123: {
+        foo: 'bar',
+      },
+      def456: {
+        foo: 'bar',
+      },
+    }, {
+      type: ActionTypes.REMOVE_WINDOW,
+      windowId: 'abc123',
+    })).toEqual({
+      def456: {
+        foo: 'bar',
+      },
+    });
+  });
+});

--- a/src/state/reducers/viewers.js
+++ b/src/state/reducers/viewers.js
@@ -12,6 +12,13 @@ export const viewersReducer = (state = {}, action) => {
           ...action.payload,
         },
       };
+    case ActionTypes.REMOVE_WINDOW:
+      return Object.keys(state).reduce((object, key) => {
+        if (key !== action.windowId) {
+          object[key] = state[key]; // eslint-disable-line no-param-reassign
+        }
+        return object;
+      }, {});
     default:
       return state;
   }


### PR DESCRIPTION
Related to work in #1907 and #1904 

Now cleans up viewer state after a window is removed