### PR TITLE
Create <SanitizedHtml/> component. Part of #1854

### DIFF
--- a/__tests__/src/components/SanitizedHtml.test.js
+++ b/__tests__/src/components/SanitizedHtml.test.js
@@ -5,7 +5,7 @@ import SanitizedHtml from '../../../src/components/SanitizedHtml';
 const wrapper = shallow(
   <SanitizedHtml
     htmlString="<script>doBadThings()</script><b>Don't worry!</b>"
-    ruleSet="basic"
+    ruleSet="iiif"
   />,
 );
 

--- a/__tests__/src/components/SanitizedHtml.test.js
+++ b/__tests__/src/components/SanitizedHtml.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SanitizedHtml from '../../../src/components/SanitizedHtml';
+
+const wrapper = shallow(
+  <SanitizedHtml
+    htmlString="<script>doBadThings()</script><b>Don't worry!</b>"
+    ruleSet="basic"
+  />,
+);
+
+describe('SanitizedHtml', () => {
+  it('should render needed elements', () => {
+    expect(wrapper.find('span').length).toBe(1);
+  });
+
+  it('should pass correct class name to root element', () => {
+    expect(wrapper.find('span').first().props().className).toBe('mirador-third-party-html');
+  });
+
+  it('should pass sanitized html string to dangerouslySetInnerHTML attribute', () => {
+    expect(wrapper.find('span').first().props().dangerouslySetInnerHTML)
+      .toEqual({ __html: "<b>Don't worry!</b>" });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "classnames": "^2.2.6",
     "css-ns": "^1.2.2",
     "deepmerge": "^3.1.0",
+    "dompurify": "^1.0.9",
     "i18next": "^14.0.1",
     "intersection-observer": "^0.5.1",
     "manifesto.js": "^3.0.9",

--- a/src/components/SanitizedHtml.js
+++ b/src/components/SanitizedHtml.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { sanitize } from 'dompurify';
+import ns from '../config/css-ns';
+import htmlRules from '../lib/htmlRules';
+
+/**
+*/
+class SanitizedHtml extends Component {
+  /**
+  */
+  render() {
+    const { htmlString, ruleSet } = this.props;
+    return (
+      <span
+        className={ns('third-party-html')}
+        dangerouslySetInnerHTML={{ // eslint-disable-line react/no-danger
+          __html: sanitize(htmlString, htmlRules[ruleSet]),
+        }}
+      />
+    );
+  }
+}
+
+SanitizedHtml.propTypes = {
+  ruleSet: PropTypes.string.isRequired,
+  htmlString: PropTypes.string.isRequired,
+};
+
+export default SanitizedHtml;

--- a/src/lib/htmlRules.js
+++ b/src/lib/htmlRules.js
@@ -1,0 +1,7 @@
+
+const basic = {
+  ALLOWED_TAGS: ['a', 'b', 'br', 'i', 'img', 'p', 'span', 'strong', 'em', 'ul', 'ol', 'li'],
+  ALLOWED_ATTR: ['href', 'target', 'src', 'alt', 'dir'],
+};
+
+export default { basic };

--- a/src/lib/htmlRules.js
+++ b/src/lib/htmlRules.js
@@ -1,7 +1,27 @@
 
-const basic = {
+// Only remove security related tags and attributes. Allow each other.
+const liberal = {};
+
+// No html at all. Only text will remain.
+const noHtml = {
+  ALLOWED_TAGS: [],
+};
+
+// Presentation API 2 suggestion.
+const iiif = {
+  ALLOWED_TAGS: ['a', 'b', 'br', 'i', 'img', 'p', 'span'],
+  ALLOWED_ATTR: ['href', 'src', 'alt'],
+};
+
+// Rule set that is used in Mirador 2.
+const mirador2 = {
   ALLOWED_TAGS: ['a', 'b', 'br', 'i', 'img', 'p', 'span', 'strong', 'em', 'ul', 'ol', 'li'],
   ALLOWED_ATTR: ['href', 'target', 'src', 'alt', 'dir'],
 };
 
-export default { basic };
+export default {
+  liberal,
+  noHtml,
+  iiif,
+  mirador2,
+};


### PR DESCRIPTION
Create a <SanitizedHtml/> component for rendering third party html (e.g. from manifest). Part of #1854 

Example: 
```javascript
const thirdPartyHtml = `
  <script>
    doThis()
  </script>
  <a href="http://foo.bar">
    <b onClick="doThat()">
      foobar
    </b>
  </a>`;

<SanitizedHtml htmlString={thirdPartyHtml} ruleSet="iiif" />

// will be rendered to

<span className="mirador-sanitized-html">
  <a href="http://foo.bar">
    <b>
      foobar
    </b>
  </a>
</span>
```

HTML rule sets can be defined in `src/lib/htmlRules.js`.

Sanitizing is done by the [dompurify](https://github.com/cure53/DOMPurify) library. I also tried  [sanitize-html](https://github.com/punkave/sanitize-html) which is used by Mirador 2, but it's 50k minified, dompurify is only about 5K.