### PR TITLE
Updates webpack terser options to reduce bundle size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,7 +86,7 @@ const baseConfig = [
       minimizer: [
         new TerserPlugin({
           terserOptions: {
-            mangle: false,
+            keep_fnames: true,
           },
         }),
       ],


### PR DESCRIPTION
Reduces minified bundle from 1.7 MB to 1.27 MB.

We still need `keep_fnames` to enable the current approach to plugin injection.