### PR TITLE
update main and files values in package.json to publish distribution …

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "mirador",
   "version": "3.0.0-alpha.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/mirador.min.js",
+  "files": [
+     "dist"
+  ],
   "scripts": {
     "lint": "node_modules/.bin/eslint ./ && node_modules/.bin/sass-lint -v ./src/styles/**/*",
     "server": "node_modules/.bin/http-server",


### PR DESCRIPTION
…files

Run `tar tvf $(npm pack)` to verify output. Does not affect test harness behaviour or `npm start`.

This is to support publishing to npm under the alpha tag as described in https://github.com/ProjectMirador/mirador/issues/1921, when we're ready.