### PR TITLE
Sets up ThumbnailNavigation for BookView

### DIFF
--- a/__tests__/integration/mirador/thumbnail-navigation.test.js
+++ b/__tests__/integration/mirador/thumbnail-navigation.test.js
@@ -12,7 +12,7 @@ describe('Thumbnail navigation', () => {
     ));
     expect(Object.values(windows)[0].canvasIndex).toBe(2); // test harness in index.html starts at 2
     await page.waitFor(1000);
-    await expect(page).toClick('.mirador-thumbnail-nav-canvas-1');
+    await expect(page).toClick('.mirador-thumbnail-nav-canvas-1 img');
     await expect(page).toMatchElement('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas', { timeout: 1500 });
     windows = await page.evaluate(() => (
       miradorInstance.store.getState().windows

--- a/__tests__/src/components/CanvasThumbnail.test.js
+++ b/__tests__/src/components/CanvasThumbnail.test.js
@@ -16,11 +16,11 @@ describe('CanvasThumbnail', () => {
 
   it('renders properly', () => {
     expect(wrapper.matchesElement(
-      <div>
+      <>
         <IntersectionObserver onChange={wrapper.instance().handleIntersection}>
           <img alt="" />
         </IntersectionObserver>
-      </div>,
+      </>,
     )).toBe(true);
   });
 

--- a/__tests__/src/components/WindowViewer.test.js
+++ b/__tests__/src/components/WindowViewer.test.js
@@ -111,4 +111,14 @@ describe('WindowViewer', () => {
       });
     });
   });
+  it('when view type changes', () => {
+    expect(wrapper.instance().canvasGroupings.groupings().length).toEqual(3);
+    wrapper.setProps({
+      window: {
+        canvasIndex: 0,
+        view: 'book',
+      },
+    });
+    expect(wrapper.instance().canvasGroupings.groupings().length).toEqual(2);
+  });
 });

--- a/__tests__/src/lib/CanvasGroupings.test.js
+++ b/__tests__/src/lib/CanvasGroupings.test.js
@@ -1,0 +1,56 @@
+import CanvasGroupings from '../../../src/lib/CanvasGroupings';
+
+describe('CanvasGroupings', () => {
+  describe('constructor', () => {
+    it('sets canvases and viewType', () => {
+      const subject = new CanvasGroupings([null, null], 'book');
+      expect(subject.viewType).toEqual('book');
+      expect(subject.canvases.length).toEqual(2);
+    });
+    it('viewType default is single', () => {
+      const subject = new CanvasGroupings([null, null]);
+      expect(subject.viewType).toEqual('single');
+    });
+  });
+  describe('groupings', () => {
+    describe('single', () => {
+      it('creates an array of arrays of the canvases', () => {
+        const subject = new CanvasGroupings([null, null, null, null]);
+        expect(subject.groupings().length).toEqual(4);
+        expect(subject.groupings()[0]).toEqual(expect.arrayContaining([null]));
+      });
+    });
+    describe('book', () => {
+      let subject;
+      beforeEach(() => {
+        subject = new CanvasGroupings([0, 1, 2, 3], 'book');
+      });
+      it('creates an array of groupings of the canvases', () => {
+        expect(subject.groupings().length).toEqual(3);
+      });
+      it('first grouping has only 1 canvas', () => {
+        expect(subject.groupings()[0]).toEqual([0]);
+      });
+      it('second grouping has 2 canvases', () => {
+        expect(subject.groupings()[1]).toEqual([1, 2]);
+      });
+    });
+  });
+  describe('getCanvases', () => {
+    describe('single', () => {
+      it('selects by index', () => {
+        const subject = new CanvasGroupings([0, 1, 2, 3]);
+        expect(subject.getCanvases(2)).toEqual([2]);
+      });
+    });
+    describe('book', () => {
+      let subject;
+      beforeEach(() => {
+        subject = new CanvasGroupings([0, 1, 2, 3], 'book');
+      });
+      it('selects by index / 2', () => {
+        expect(subject.getCanvases(2)).toEqual([1, 2]);
+      });
+    });
+  });
+});

--- a/src/components/CanvasThumbnail.js
+++ b/src/components/CanvasThumbnail.js
@@ -40,7 +40,7 @@ export default class CanvasThumbnail extends Component {
     const { loaded, image } = this.state;
     const imgStyle = { height, width: '100%', ...style };
     return (
-      <div>
+      <>
         <IntersectionObserver onChange={this.handleIntersection}>
           <img
             alt=""
@@ -51,7 +51,7 @@ export default class CanvasThumbnail extends Component {
             style={imgStyle}
           />
         </IntersectionObserver>
-      </div>
+      </>
     );
   }
 }

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -68,7 +68,7 @@ class ThumbnailNavigation extends Component {
         >
           {currentGroupings.map((canvas, i) => (
             <div
-              key={i} // eslint-disable-line react/no-array-index-key
+              key={canvas.index}
               style={{ position: 'absolute', left: (style.width - 8) * i / 2, top: 2 }}
             >
               <CanvasThumbnail

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -44,17 +44,19 @@ class WindowSideBarCanvasPanel extends Component {
                 <ListItem
                   key={canvas.id}
                 >
-                  <CanvasThumbnail
-                    className={classNames(classes.clickable)}
-                    isValid={isValid}
-                    imageUrl={validationCanvas.thumbnail(config.canvasNavigation.height)}
-                    onClick={onClick}
-                    style={{
-                      cursor: 'pointer',
-                      height: config.canvasNavigation.height,
-                      width: isValid ? WindowSideBarCanvasPanel.calculateScaledWidth(config.canvasNavigation.height, validationCanvas.aspectRatio) : 'auto',
-                    }}
-                  />
+                  <div>
+                    <CanvasThumbnail
+                      className={classNames(classes.clickable)}
+                      isValid={isValid}
+                      imageUrl={validationCanvas.thumbnail(config.canvasNavigation.height)}
+                      onClick={onClick}
+                      style={{
+                        cursor: 'pointer',
+                        height: config.canvasNavigation.height,
+                        width: isValid ? WindowSideBarCanvasPanel.calculateScaledWidth(config.canvasNavigation.height, validationCanvas.aspectRatio) : 'auto',
+                      }}
+                    />
+                  </div>
                   <Typography
                     className={classNames(classes.clickable, classes.label)}
                     onClick={onClick}

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
+import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
 import ThumbnailNavigation from '../components/ThumbnailNavigation';
 import { getManifestCanvases } from '../state/selectors';
@@ -9,8 +10,8 @@ import { getManifestCanvases } from '../state/selectors';
  * @memberof ThumbnailNavigation
  * @private
  */
-const mapStateToProps = ({ config }, { manifest }) => ({
-  canvases: getManifestCanvases(manifest),
+const mapStateToProps = ({ config }, { manifest, window }) => ({
+  canvasGroupings: new CanvasGroupings(getManifestCanvases(manifest), window.view),
   config,
 });
 

--- a/src/lib/CanvasGroupings.js
+++ b/src/lib/CanvasGroupings.js
@@ -1,0 +1,52 @@
+/**
+ *
+ */
+export default class CanvasGroupings {
+  /**
+   */
+  constructor(canvases, viewType = 'single') {
+    this.canvases = canvases;
+    this.viewType = viewType;
+    this._groupings = null; // eslint-disable-line no-underscore-dangle
+  }
+
+  /**
+   */
+  getCanvases(index) {
+    switch (this.viewType) {
+      case 'book':
+        return this.groupings()[Math.ceil(index / 2)];
+      default:
+        return this.groupings()[index];
+    }
+  }
+
+  /**
+   * Groups a set of canvases based on the view type. Single, is just an array
+   * of canvases, while book view creates pairs.
+   */
+  groupings() {
+    if (this._groupings) { // eslint-disable-line no-underscore-dangle
+      return this._groupings; // eslint-disable-line no-underscore-dangle
+    }
+    if (this.viewType === 'single') {
+      return this.canvases.map(canvas => [canvas]);
+    }
+    const groupings = [];
+    this.canvases.forEach((canvas, i) => {
+      if (i === 0) {
+        groupings.push([canvas]);
+        return;
+      }
+      // Odd page
+      if (i % 2 !== 0) {
+        groupings.push([canvas]);
+      } else {
+        // Even page
+        groupings[Math.ceil(i / 2)].push(canvas);
+      }
+    });
+    this._groupings = groupings; // eslint-disable-line no-underscore-dangle
+    return groupings;
+  }
+}


### PR DESCRIPTION
Fixes #1868 Fixes #1791

This PR introduces CanvasGroupings that can effectively determine
what/which canvases should be grouped together for display. This logic
can be used throughout Mirador.

Out of scope for this PR is updated styling and labels See #1932

Nice fixture: https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest

![bookview](https://user-images.githubusercontent.com/1656824/53115232-e766ee00-3502-11e9-9294-db56367aed99.gif)


