### PR TITLE
Fixes #1943 by removing unnecessary trailing slashes

### DIFF
--- a/__tests__/fixtures/version-2/Osbornfa1.json
+++ b/__tests__/fixtures/version-2/Osbornfa1.json
@@ -1,0 +1,42 @@
+{
+  "@id": "https://manifests.britishart.yale.edu/Osbornfa1",
+  "@type": "sc:Manifest",
+  "description": "Osborn fa1 IIIF Manifest created for the Digitally Enabled Scholarship with Medieval Manuscripts project at Yale University.",
+  "label": "New Haven, Beinecke Rare Book and Manuscript Library, Yale University, Osborn fa1",
+  "sequences": [
+    {
+      "@id": "https://manifests.britishart.yale.edu/sequence/Osbornfa1",
+      "@type": "sc:Sequence",
+      "canvases": [
+        {
+          "@id": "http://scale.ydc2.yale.edu/canvas/684c8053-0247-45a2-b55d-10dd3defebe4",
+          "@type": "sc:Canvas",
+          "height": 4438,
+          "images": [
+            {
+              "@id": "http://scale.ydc2.yale.edu/annotation/b38081da-8991-4464-a71e-d9891226a35f",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "http://scale.ydc2.yale.edu/canvas/684c8053-0247-45a2-b55d-10dd3defebe4",
+              "resource": {
+                "@id": "https://images.britishart.yale.edu/iiif/b38081da-8991-4464-a71e-d9891226a35f/full/full/0/native.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 4438,
+                "label": "Osborn fa1, [Bookplates]",
+                "service": {
+                  "@id": "https://images.britishart.yale.edu/iiif/b38081da-8991-4464-a71e-d9891226a35f/",
+                  "profile": "http://library.stanford.edu/iiif/image-api/1.1/conformance.html#level1",
+                  "@context": "http://iiif.io/api/image/1/context.json"
+                },
+                "width": 3603
+              }
+            }
+          ],
+          "label": "Osborn fa1, [Bookplates]",
+          "width": 3603
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/src/lib/ManifestoCanvas.test.js
+++ b/__tests__/src/lib/ManifestoCanvas.test.js
@@ -1,6 +1,7 @@
 import manifesto from 'manifesto.js';
 import ManifestoCanvas from '../../../src/lib/ManifestoCanvas';
 import fixture from '../../fixtures/version-2/019.json';
+import imagev1Fixture from '../../fixtures/version-2/Osbornfa1.json';
 
 describe('ManifestoCanvas', () => {
   let instance;
@@ -14,6 +15,17 @@ describe('ManifestoCanvas', () => {
       expect(instance.canonicalImageUri).toEqual(
         'https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/5426,/0/default.jpg',
       );
+    });
+  });
+  describe('imageInformationUri', () => {
+    it('correctly returns an image information url for a v2 Image API', () => {
+      expect(instance.imageInformationUri).toEqual('https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/info.json');
+    });
+    it('correctly returns an image information url for a v1 Image API', () => {
+      const imagev1Instance = new ManifestoCanvas(
+        manifesto.create(imagev1Fixture).getSequences()[0].getCanvases()[0],
+      );
+      expect(imagev1Instance.imageInformationUri).toEqual('https://images.britishart.yale.edu/iiif/b38081da-8991-4464-a71e-d9891226a35f/info.json');
     });
   });
   describe('aspectRatio', () => {

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -25,7 +25,9 @@ export default class ManifestoCanvas {
   /**
    */
   get imageInformationUri() {
-    return `${this.canvas.getImages()[0].getResource().getServices()[0].id}/info.json`;
+    return `${
+      this.canvas.getImages()[0].getResource().getServices()[0].id.replace(/\/$/, '')
+    }/info.json`;
   }
 
   /**


### PR DESCRIPTION
Manifesto seems to return trailing slashes for v1 Image API resources.
This change makes our use of this consistent.

Previously broken fixture: https://manifests.britishart.yale.edu/Osbornfa1