### PR TITLE
moves withStyles to containers

### DIFF
--- a/__tests__/src/components/App.test.js
+++ b/__tests__/src/components/App.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import Fullscreen from 'react-fullscreen-crossbrowser';
-import WorkspaceControlPanel from '../../../src/components/WorkspaceControlPanel';
+import WorkspaceControlPanel from '../../../src/containers/WorkspaceControlPanel';
 import Workspace from '../../../src/containers/Workspace';
 import WorkspaceAdd from '../../../src/containers/WorkspaceAdd';
 import App from '../../../src/components/App';
@@ -21,7 +21,7 @@ function createWrapper(props) {
       classes={{}}
       {...props}
     />,
-  ).dive(); // to unwrapp HOC created by withStyle()
+  );
 }
 
 describe('App', () => {

--- a/__tests__/src/components/CompanionWindow.test.js
+++ b/__tests__/src/components/CompanionWindow.test.js
@@ -14,7 +14,7 @@ function createWrapper(props) {
       position="right"
       {...props}
     />,
-  ).dive(); // unwrap HOC created by withStyles()
+  );
 }
 
 describe('CompanionWindow', () => {

--- a/__tests__/src/components/ManifestListItem.test.js
+++ b/__tests__/src/components/ManifestListItem.test.js
@@ -15,7 +15,7 @@ function createWrapper(props) {
       t={t => t}
       {...props}
     />,
-  ).dive(); // to unwrapp HOC created by withStyle()
+  );
 }
 
 describe('ManifestListItem', () => {

--- a/__tests__/src/components/ManifestListItemError.test.js
+++ b/__tests__/src/components/ManifestListItemError.test.js
@@ -9,13 +9,14 @@ import ManifestListItemError from '../../../src/components/ManifestListItemError
 function createWrapper(props) {
   return shallow(
     <ManifestListItemError
+      classes={{}}
       manifestId="http://example.com"
       onDismissClick={() => {}}
       onTryAgainClick={() => {}}
       t={key => key}
       {...props}
     />,
-  ).dive(); // unwrap HOC created by withStyles()
+  );
 }
 
 describe('ManifestListItemError', () => {

--- a/__tests__/src/components/WindowSideBar.test.js
+++ b/__tests__/src/components/WindowSideBar.test.js
@@ -5,7 +5,7 @@ import WindowSideBar from '../../../src/components/WindowSideBar';
 describe('WindowSideBar', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(<WindowSideBar windowId="1" classes={{}} />).dive();
+    wrapper = shallow(<WindowSideBar windowId="1" classes={{}} />);
   });
 
   it('renders without an error', () => {

--- a/__tests__/src/components/WindowSideBarCanvasPanel.test.js
+++ b/__tests__/src/components/WindowSideBarCanvasPanel.test.js
@@ -27,7 +27,7 @@ describe('WindowSideBarCanvasPanel', () => {
         setCanvas={setCanvas}
         config={{ canvasNavigation: { height: 100 } }}
       />,
-    ).dive();
+    );
   });
 
   it('renders all needed elements', () => {

--- a/__tests__/src/components/WindowSideBarInfoPanel.test.js
+++ b/__tests__/src/components/WindowSideBarInfoPanel.test.js
@@ -21,7 +21,7 @@ describe('WindowSideBarInfoPanel', () => {
           manifestMetadata={metadata}
           t={str => str}
         />,
-      ).dive();
+      );
     });
 
     it('renders header', () => {
@@ -89,7 +89,7 @@ describe('WindowSideBarInfoPanel', () => {
     beforeEach(() => {
       wrapper = shallow(
         <WindowSideBarInfoPanel />,
-      ).dive();
+      );
     });
 
     it('does render header', () => {

--- a/__tests__/src/components/WindowTopBar.test.js
+++ b/__tests__/src/components/WindowTopBar.test.js
@@ -24,7 +24,7 @@ function createWrapper(props) {
       toggleWindowSideBar={() => {}}
       {...props}
     />,
-  ).dive(); // unwrap HOC created by withStyles()
+  );
 }
 
 describe('WindowTopBar', () => {

--- a/__tests__/src/components/WindowTopMenuButton.test.js
+++ b/__tests__/src/components/WindowTopMenuButton.test.js
@@ -14,7 +14,7 @@ function createWrapper(props) {
       t={str => str}
       {...props}
     />,
-  ).dive(); // unwrap HOC created by withStyles()
+  );
 }
 
 describe('WindowTopMenuButton', () => {

--- a/__tests__/src/components/WorkspaceAdd.test.js
+++ b/__tests__/src/components/WorkspaceAdd.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import WorkspaceAdd from '../../../src/components/WorkspaceAdd';
+import ManifestListItem from '../../../src/containers/ManifestListItem';
 import fixture from '../../fixtures/version-2/002.json';
+import ManifestForm from '../../../src/containers/ManifestForm';
 
 /** create wrapper */
 function createWrapper(props) {
@@ -13,20 +15,20 @@ function createWrapper(props) {
       t={str => str}
       {...props}
     />,
-  ).dive();
+  );
 }
 
-describe('WorkspaceAddButton', () => {
+describe('WorkspaceAdd', () => {
   it('renders a list item for each manifest in the state', () => {
     const wrapper = createWrapper();
-    expect(wrapper.find('Connect(LoadNamespace(WithStyles(ManifestListItem)))').length).toBe(2);
+    expect(wrapper.find(ManifestListItem).length).toBe(2);
   });
 
   it('toggles the workspace visibility', () => {
     const setWorkspaceAddVisibility = jest.fn();
     const wrapper = createWrapper({ setWorkspaceAddVisibility });
 
-    wrapper.find('Connect(LoadNamespace(WithStyles(ManifestListItem)))').first().props().handleClose();
+    wrapper.find(ManifestListItem).first().props().handleClose();
     expect(setWorkspaceAddVisibility).toHaveBeenCalledWith(false);
   });
 
@@ -54,8 +56,8 @@ describe('WorkspaceAddButton', () => {
     const wrapper = createWrapper();
     wrapper.setState({ addResourcesOpen: true });
 
-    expect(wrapper.find('WithStyles(Drawer) Connect(LoadNamespace(ManifestForm))').length).toBe(1);
-    wrapper.find('WithStyles(Drawer) Connect(LoadNamespace(ManifestForm))').props().onCancel();
+    expect(wrapper.find('WithStyles(Drawer)').find(ManifestForm).length).toBe(1);
+    wrapper.find('WithStyles(Drawer)').find(ManifestForm).props().onCancel();
     expect(wrapper.find('WithStyles(Drawer)').props().open).toBe(false);
   });
 });

--- a/__tests__/src/components/WorkspaceAddButton.test.js
+++ b/__tests__/src/components/WorkspaceAddButton.test.js
@@ -13,7 +13,7 @@ function createWrapper(props) {
       t={str => str}
       {...props}
     />,
-  ).dive(); // unwrap HOC created by withStyles()
+  );
 }
 
 describe('WorkspaceAddButton', () => {

--- a/__tests__/src/components/WorkspaceControlPanel.test.js
+++ b/__tests__/src/components/WorkspaceControlPanel.test.js
@@ -11,7 +11,12 @@ describe('WorkspaceControlPanel', () => {
   beforeEach(() => {
     store.dispatch(actions.receiveManifest('foo', fixture));
     store.dispatch(actions.receiveManifest('bar', fixture));
-    wrapper = shallow(<WorkspaceControlPanel store={store} />).dive();
+    wrapper = shallow(
+      <WorkspaceControlPanel
+        classes={{}}
+        store={store}
+      />,
+    );
   });
 
   it('renders without an error', () => {

--- a/__tests__/src/components/WorkspaceFullScreenButton.test.js
+++ b/__tests__/src/components/WorkspaceFullScreenButton.test.js
@@ -12,7 +12,7 @@ describe('WorkspaceFullScreenButton', () => {
         classes={{}}
         setWorkspaceFullscreen={setWorkspaceFullscreen}
       />,
-    ).dive();
+    );
   });
 
   it('renders without an error', () => {

--- a/__tests__/src/components/WorkspaceMenuButton.test.js
+++ b/__tests__/src/components/WorkspaceMenuButton.test.js
@@ -7,7 +7,7 @@ describe('WorkspaceMenuButton', () => {
   beforeEach(() => {
     wrapper = shallow(
       <WorkspaceMenuButton classes={{}} />,
-    ).dive();
+    );
   });
 
   it('renders without an error', () => {

--- a/__tests__/src/components/ZoomControls.test.js
+++ b/__tests__/src/components/ZoomControls.test.js
@@ -12,12 +12,13 @@ describe('ZoomControls', () => {
     updateViewport = jest.fn();
     wrapper = shallow(
       <ZoomControls
+        classes={{}}
         windowId="xyz"
         viewer={viewer}
         showZoomControls={showZoomControls}
         updateViewport={updateViewport}
       />,
-    ).dive();
+    );
   });
 
   describe('with showZoomControls=false', () => {
@@ -32,12 +33,13 @@ describe('ZoomControls', () => {
       updateViewport = jest.fn();
       wrapper = shallow(
         <ZoomControls
+          classes={{}}
           windowId="xyz"
           viewer={viewer}
           showZoomControls
           updateViewport={updateViewport}
         />,
-      ).dive();
+      );
     });
 
     it('renders a couple buttons', () => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { MuiThemeProvider, createMuiTheme, withStyles } from '@material-ui/core/styles';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import Fullscreen from 'react-fullscreen-crossbrowser';
 import { I18nextProvider } from 'react-i18next';
-import WorkspaceControlPanel from './WorkspaceControlPanel';
+import WorkspaceControlPanel from '../containers/WorkspaceControlPanel';
 import Workspace from '../containers/Workspace';
 import WorkspaceAdd from '../containers/WorkspaceAdd';
 import ns from '../config/css-ns';
@@ -68,14 +68,6 @@ App.defaultProps = {
   isFullscreenEnabled: false,
   isWorkspaceAddVisible: false,
 };
-/**
- Material UI style overrides
- @private
- */
-const styles = theme => ({
-  background: {
-    background: theme.palette.background.default,
-  },
-});
 
-export default withStyles(styles)(App);
+
+export default App;

--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import CloseIcon from '@material-ui/icons/Close';
 import IconButton from '@material-ui/core/IconButton';
 import Paper from '@material-ui/core/Paper';
-import { withStyles } from '@material-ui/core/styles';
 import ns from '../config/css-ns';
 import WindowSideBarInfoPanel from '../containers/WindowSideBarInfoPanel';
 import WindowSideBarCanvasPanel from '../containers/WindowSideBarCanvasPanel';
@@ -76,20 +75,4 @@ CompanionWindow.defaultProps = {
   t: key => key,
 };
 
-/**
- * Styles for Material-UI HOC
- */
-const styles = theme => ({
-  closeButton: {
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
-  root: {
-    ...theme.mixins.gutters(),
-    width: '200px',
-    overflowY: 'scroll',
-  },
-});
-
-export default withStyles(styles)(CompanionWindow);
+export default CompanionWindow;

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Grid from '@material-ui/core/Grid';
@@ -161,15 +160,4 @@ ManifestListItem.defaultProps = {
   isFetching: false,
 };
 
-/** */
-const styles = theme => ({
-  root: {
-    ...theme.mixins.gutters(),
-  },
-  label: {
-    textTransform: 'initial',
-    textAlign: 'left',
-  },
-});
-
-export default withStyles(styles)(ManifestListItem);
+export default ManifestListItem;

--- a/src/components/ManifestListItemError.js
+++ b/src/components/ManifestListItemError.js
@@ -4,7 +4,6 @@ import Button from '@material-ui/core/Button';
 import ErrorIcon from '@material-ui/icons/ErrorOutline';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
 
 /**
  * ManifestListItemError renders a component displaying a
@@ -61,19 +60,4 @@ ManifestListItemError.propTypes = {
   t: PropTypes.func.isRequired,
 };
 
-/**
- Material UI styles
- @private
- */
-const styles = theme => ({
-  errorIcon: {
-    color: theme.palette.error.main,
-    height: '2rem',
-    width: '2rem',
-  },
-  manifestIdText: {
-    wordBreak: 'break-all',
-  },
-});
-
-export default withStyles(styles)(ManifestListItemError);
+export default ManifestListItemError;

--- a/src/components/WindowSideBar.js
+++ b/src/components/WindowSideBar.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Drawer from '@material-ui/core/Drawer';
-import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import WindowSideBarButtons from '../containers/WindowSideBarButtons';
 import WindowSideBarPanel from '../containers/WindowSideBarPanel';
@@ -74,22 +73,4 @@ WindowSideBar.defaultProps = {
   sideBarPanel: 'closed',
 };
 
-/**
- Material UI style overrides
- @private
- */
-const styles = theme => ({
-  toolbar: theme.mixins.toolbar,
-  drawer: {
-    overflowX: 'hidden',
-    left: 0,
-    width: 55,
-    flexShrink: 0,
-    height: '100%',
-  },
-  grow: {
-    flexGrow: 1,
-  },
-});
-
-export default withStyles(styles)(WindowSideBar);
+export default WindowSideBar;

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
-import { withStyles } from '@material-ui/core/styles';
 import ValidationCanvas from './ValidationCanvas';
 import CanvasThumbnail from './CanvasThumbnail';
 import { getIdAndLabelOfCanvases } from '../state/selectors';
@@ -83,19 +82,4 @@ WindowSideBarCanvasPanel.propTypes = {
   windowId: PropTypes.string.isRequired,
 };
 
-/**
- * @private
- * custom style definitions
- */
-const styles = theme => ({
-  windowSideBarH2: theme.typography.h5,
-  clickable: {
-    cursor: 'pointer',
-  },
-  label: {
-    fontSize: '8pt',
-    paddingLeft: 8,
-  },
-});
-
-export default withStyles(styles)(WindowSideBarCanvasPanel);
+export default WindowSideBarCanvasPanel;

--- a/src/components/WindowSideBarInfoPanel.js
+++ b/src/components/WindowSideBarInfoPanel.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
 import LabelValueMetadata from './LabelValueMetadata';
 import SanitizedHtml from './SanitizedHtml';
 import ns from '../config/css-ns';
@@ -96,12 +95,4 @@ WindowSideBarInfoPanel.defaultProps = {
   t: key => key,
 };
 
-/**
- * @private
- */
-const styles = theme => ({
-  windowSideBarH2: theme.typography.h5,
-  windowSideBarH3: theme.typography.h6,
-});
-
-export default withStyles(styles)(WindowSideBarInfoPanel);
+export default WindowSideBarInfoPanel;

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
@@ -70,15 +69,4 @@ WindowTopBar.defaultProps = {
   t: key => key,
 };
 
-const styles = {
-  typographyBody: {
-    flexGrow: 1,
-    fontSize: '1em',
-  },
-  reallyDense: {
-    minHeight: 32,
-    paddingLeft: 4,
-  },
-};
-
-export default withStyles(styles)(WindowTopBar);
+export default WindowTopBar;

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
-import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import WindowTopMenu from '../containers/WindowTopMenu';
 
@@ -78,13 +77,4 @@ WindowTopMenuButton.defaultProps = {
   t: key => key,
 };
 
-/**
- * @private
- */
-const styles = theme => ({
-  ctrlBtn: {
-    margin: theme.spacing.unit,
-  },
-});
-
-export default withStyles(styles)(WindowTopMenuButton);
+export default (WindowTopMenuButton);

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -77,4 +77,4 @@ WindowTopMenuButton.defaultProps = {
   t: key => key,
 };
 
-export default (WindowTopMenuButton);
+export default WindowTopMenuButton;

--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -9,7 +9,6 @@ import IconButton from '@material-ui/core/IconButton';
 import Paper from '@material-ui/core/Paper';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
 import ns from '../config/css-ns';
 import ManifestForm from '../containers/ManifestForm';
 import ManifestListItem from '../containers/ManifestListItem';
@@ -106,27 +105,4 @@ WorkspaceAdd.defaultProps = {
   t: key => key,
 };
 
-/** */
-const styles = theme => ({
-  form: {
-    ...theme.mixins.gutters(),
-    paddingTop: theme.spacing.unit * 2,
-    paddingBottom: theme.spacing.unit * 2,
-    marginTop: 64,
-  },
-  fab: {
-    position: 'absolute',
-    bottom: theme.spacing.unit * 2,
-    right: theme.spacing.unit * 2,
-  },
-  typographyBody: {
-    flexGrow: 1,
-    fontSize: '1em',
-  },
-  menuButton: {
-    marginLeft: -12,
-    marginRight: 20,
-  },
-});
-
-export default withStyles(styles)(WorkspaceAdd);
+export default WorkspaceAdd;

--- a/src/components/WorkspaceAddButton.js
+++ b/src/components/WorkspaceAddButton.js
@@ -4,7 +4,6 @@ import ListItem from '@material-ui/core/ListItem';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 import ClearIcon from '@material-ui/icons/Clear';
-import { withStyles } from '@material-ui/core/styles';
 
 /**
  */
@@ -49,13 +48,4 @@ WorkspaceAddButton.defaultProps = {
   isWorkspaceAddVisible: false,
 };
 
-/**
- * @private
- */
-const styles = theme => ({
-  ctrlBtn: {
-    margin: theme.spacing.unit,
-  },
-});
-
-export default withStyles(styles)(WorkspaceAddButton);
+export default WorkspaceAddButton;

--- a/src/components/WorkspaceControlPanel.js
+++ b/src/components/WorkspaceControlPanel.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
 import WorkspaceControlPanelButtons
   from '../containers/WorkspaceControlPanelButtons';
@@ -36,17 +35,4 @@ WorkspaceControlPanel.propTypes = {
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
-/**
- * @private
- */
-const styles = theme => ({
-  ctrlBtn: {
-    margin: theme.spacing.unit,
-  },
-  drawer: {
-    overflowX: 'hidden',
-    height: '100%',
-  },
-});
-
-export default withStyles(styles)(WorkspaceControlPanel);
+export default WorkspaceControlPanel;

--- a/src/components/WorkspaceFullScreenButton.js
+++ b/src/components/WorkspaceFullScreenButton.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import FullscreenIcon from '@material-ui/icons/Fullscreen';
 import ListItem from '@material-ui/core/ListItem';
-import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 
 /**
@@ -34,13 +33,4 @@ WorkspaceFullScreenButton.defaultProps = {
   t: key => key,
 };
 
-/**
- * @private
- */
-const styles = theme => ({
-  ctrlBtn: {
-    margin: theme.spacing.unit,
-  },
-});
-
-export default withStyles(styles)(WorkspaceFullScreenButton);
+export default WorkspaceFullScreenButton;

--- a/src/components/WorkspaceMenuButton.js
+++ b/src/components/WorkspaceMenuButton.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import ListItem from '@material-ui/core/ListItem';
-import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import WorkspaceMenu from '../containers/WorkspaceMenu';
 
@@ -80,13 +79,4 @@ WorkspaceMenuButton.defaultProps = {
   t: key => key,
 };
 
-/**
- * @private
- */
-const styles = theme => ({
-  ctrlBtn: {
-    margin: theme.spacing.unit,
-  },
-});
-
-export default withStyles(styles)(WorkspaceMenuButton);
+export default (WorkspaceMenuButton);

--- a/src/components/WorkspaceMenuButton.js
+++ b/src/components/WorkspaceMenuButton.js
@@ -79,4 +79,4 @@ WorkspaceMenuButton.defaultProps = {
   t: key => key,
 };
 
-export default (WorkspaceMenuButton);
+export default WorkspaceMenuButton;

--- a/src/components/ZoomControls.js
+++ b/src/components/ZoomControls.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { withStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -117,18 +116,4 @@ ZoomControls.defaultProps = {
   t: key => key,
 };
 
-/**
- * @private
- */
-const styles = theme => ({
-  zoom_controls: {
-    position: 'absolute',
-    right: 0,
-  },
-  ListItem: {
-    paddingTop: 0,
-    paddingBottom: 0,
-  },
-});
-
-export default withStyles(styles)(ZoomControls);
+export default ZoomControls;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,5 +1,6 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { withStyles } from '@material-ui/core/styles';
 import * as actions from '../state/actions';
 import App from '../components/App';
 
@@ -27,9 +28,20 @@ const mapDispatchToProps = {
   setWorkspaceFullscreen: actions.setWorkspaceFullscreen,
 };
 
+/**
+ *
+ * @param theme
+ * @returns {{background: {background: string}}}
+ */
+const styles = theme => ({
+  background: {
+    background: theme.palette.background.default,
+  },
+});
+
 const enhance = compose(
+  withStyles(styles),
   connect(mapStateToProps, mapDispatchToProps),
-  // further HOC go here
 );
 
 export default enhance(App);

--- a/src/containers/CompanionWindow.js
+++ b/src/containers/CompanionWindow.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import * as actions from '../state/actions';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import CompanionWindow from '../components/CompanionWindow';
@@ -30,11 +31,30 @@ const mapDispatchToProps = {
   onCloseClick: actions.closeCompanionWindow,
 };
 
+/**
+ *
+ * @param theme
+ * @returns {{closeButton: {top: number, position: string, right: number},
+ * root: {overflowY: string, width: string}}}
+ */
+const styles = theme => ({
+  closeButton: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  root: {
+    ...theme.mixins.gutters(),
+    width: '200px',
+    overflowY: 'scroll',
+  },
+});
+
 const enhance = compose(
+  withNamespaces(),
+  withStyles(styles),
   connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
-  withNamespaces(),
-  // further HOC
 );
 
 export default enhance(CompanionWindow);

--- a/src/containers/ManifestForm.js
+++ b/src/containers/ManifestForm.js
@@ -12,9 +12,8 @@ import ManifestForm from '../components/ManifestForm';
 const mapDispatchToProps = { fetchManifest: actions.fetchManifest };
 
 const enhance = compose(
-  connect(null, mapDispatchToProps),
   withNamespaces(),
-  // further HOC go here
+  connect(null, mapDispatchToProps),
 );
 
 export default enhance(ManifestForm);

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -31,7 +31,11 @@ const mapStateToProps = (state, { manifestId }) => {
  */
 const mapDispatchToProps = { addWindow: actions.addWindow, fetchManifest: actions.fetchManifest };
 
-/** */
+/**
+ *
+ * @param theme
+ * @returns {{root: {}, label: {textAlign: string, textTransform: string}}}
+ */
 const styles = theme => ({
   root: {
     ...theme.mixins.gutters(),

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import {
   getManifestTitle, getManifestLogo, getManifestThumbnail, getManifestCanvases, getManifestProvider,
 } from '../state/selectors';
@@ -30,10 +31,21 @@ const mapStateToProps = (state, { manifestId }) => {
  */
 const mapDispatchToProps = { addWindow: actions.addWindow, fetchManifest: actions.fetchManifest };
 
+/** */
+const styles = theme => ({
+  root: {
+    ...theme.mixins.gutters(),
+  },
+  label: {
+    textTransform: 'initial',
+    textAlign: 'left',
+  },
+});
+
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
-  // further HOC go here
+  withStyles(styles),
+  connect(mapStateToProps, mapDispatchToProps),
 );
 
 export default enhance(ManifestListItem);

--- a/src/containers/ManifestListItemError.js
+++ b/src/containers/ManifestListItemError.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
 import { fetchManifest, removeManifest } from '../state/actions/manifest';
 import ManifestListItemError from '../components/ManifestListItemError';
 
@@ -10,10 +11,27 @@ const mapDispatchToProps = {
   onTryAgainClick: fetchManifest,
 };
 
+/**
+ *
+ * @param theme
+ * @returns {{manifestIdText: {wordBreak: string},
+ * errorIcon: {color: string, width: string, height: string}}}
+ */
+const styles = theme => ({
+  errorIcon: {
+    color: theme.palette.error.main,
+    height: '2rem',
+    width: '2rem',
+  },
+  manifestIdText: {
+    wordBreak: 'break-all',
+  },
+});
+
 const enhance = compose(
-  connect(null, mapDispatchToProps),
   withNamespaces(),
-  // further HOC
+  withStyles(styles),
+  connect(null, mapDispatchToProps),
 );
 
 export default enhance(ManifestListItemError);

--- a/src/containers/WindowIcon.js
+++ b/src/containers/WindowIcon.js
@@ -1,4 +1,6 @@
 import { connect } from 'react-redux';
+import { withStyles } from '@material-ui/core';
+import { compose } from 'redux';
 import { getWindowManifest, getManifestLogo } from '../state/selectors';
 import WindowIcon from '../components/WindowIcon';
 
@@ -7,4 +9,16 @@ const mapStateToProps = (state, { windowId }) => ({
   manifestLogo: getManifestLogo(getWindowManifest(state, windowId)),
 });
 
-export default connect(mapStateToProps)(WindowIcon);
+const styles = {
+  logo: {
+    height: '2.5rem',
+    paddingRight: 8,
+  },
+};
+
+const enhance = compose(
+  withStyles(styles),
+  connect(mapStateToProps),
+);
+
+export default enhance(WindowIcon);

--- a/src/containers/WindowList.js
+++ b/src/containers/WindowList.js
@@ -26,9 +26,8 @@ const mapStateToProps = state => (
 );
 
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
-  // further HOC
+  connect(mapStateToProps, mapDispatchToProps),
 );
 
 export default enhance(WindowList);

--- a/src/containers/WindowSideBar.js
+++ b/src/containers/WindowSideBar.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { withStyles } from '@material-ui/core';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import WindowSideBar from '../components/WindowSideBar';
 
@@ -15,10 +16,30 @@ const mapStateToProps = (state, props) => (
   }
 );
 
+/**
+ *
+ * @param theme
+ * @returns {{toolbar: CSSProperties | toolbar | {minHeight}, grow: {flexGrow: number},
+ * drawer: {overflowX: string, left: number, flexShrink: number, width: number, height: string}}}
+ */
+const styles = theme => ({
+  toolbar: theme.mixins.toolbar,
+  drawer: {
+    overflowX: 'hidden',
+    left: 0,
+    width: 55,
+    flexShrink: 0,
+    height: '100%',
+  },
+  grow: {
+    flexGrow: 1,
+  },
+});
+
 const enhance = compose(
+  withStyles(styles),
   connect(mapStateToProps, null),
   miradorWithPlugins,
-  // further HOC
 );
 
 export default enhance(WindowSideBar);

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -29,10 +29,9 @@ const mapStateToProps = (state, { windowId }) => ({
 
 
 const enhance = compose(
+  withNamespaces(),
   connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
-  withNamespaces(),
-  // further HOC go here
 );
 
 export default enhance(WindowSideBarButtons);

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
 import * as actions from '../state/actions';
 import WindowSideBarCanvasPanel from '../components/WindowSideBarCanvasPanel';
 import {
@@ -23,9 +24,25 @@ const mapStateToProps = (state, { windowId }) => {
 
 const mapDispatchToProps = { setCanvas: actions.setCanvas };
 
+/**
+ * @private
+ * custom style definitions
+ */
+const styles = theme => ({
+  windowSideBarH2: theme.typography.h5,
+  clickable: {
+    cursor: 'pointer',
+  },
+  label: {
+    fontSize: '8pt',
+    paddingLeft: 8,
+  },
+});
+
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
+  withStyles(styles),
+  connect(mapStateToProps, mapDispatchToProps),
 );
 
 export default enhance(WindowSideBarCanvasPanel);

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -25,8 +25,10 @@ const mapStateToProps = (state, { windowId }) => {
 const mapDispatchToProps = { setCanvas: actions.setCanvas };
 
 /**
- * @private
- * custom style definitions
+ *
+ * @param theme
+ * @returns {{clickable: {cursor: string},
+ * label: {fontSize: string, paddingLeft: number}, windowSideBarH2: *}}
  */
 const styles = theme => ({
   windowSideBarH2: theme.typography.h5,

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import {
   getDestructuredMetadata,
@@ -30,11 +31,21 @@ const mapStateToProps = (state, { windowId }) => ({
   manifestMetadata: getDestructuredMetadata(getWindowManifest(state, windowId).manifestation),
 });
 
+/**
+ *
+ * @param theme
+ * @returns {{windowSideBarH2: *, windowSideBarH3: *}}
+ */
+const styles = theme => ({
+  windowSideBarH2: theme.typography.h5,
+  windowSideBarH3: theme.typography.h6,
+});
+
 const enhance = compose(
-  connect(mapStateToProps, null),
   withNamespaces(),
+  withStyles(styles),
+  connect(mapStateToProps, null),
   miradorWithPlugins,
-  // further HOC
 );
 
 export default enhance(WindowSideBarInfoPanel);

--- a/src/containers/WindowSideBarPanel.js
+++ b/src/containers/WindowSideBarPanel.js
@@ -16,8 +16,7 @@ const mapStateToProps = (state, { windowId }) => ({
 });
 
 export default compose(
+  withNamespaces(),
   connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
-  withNamespaces(),
-  // further HOC
 )(WindowSideBarPanel);

--- a/src/containers/WindowThumbnailSettings.js
+++ b/src/containers/WindowThumbnailSettings.js
@@ -25,8 +25,8 @@ const mapStateToProps = (state, props) => (
 );
 
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
+  connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
   // further HOC go here
 );

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import * as actions from '../state/actions';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import { getWindowManifest, getManifestTitle } from '../state/selectors';
@@ -21,11 +22,23 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
   toggleWindowSideBar: () => dispatch(actions.toggleWindowSideBar(windowId)),
 });
 
+
+const styles = {
+  typographyBody: {
+    flexGrow: 1,
+    fontSize: '1em',
+  },
+  reallyDense: {
+    minHeight: 32,
+    paddingLeft: 4,
+  },
+};
+
 const enhance = compose(
+  withNamespaces(),
+  withStyles(styles),
   connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
-  withNamespaces(),
-  // further HOC go here
 );
 
 export default enhance(WindowTopBar);

--- a/src/containers/WindowTopMenuButton.js
+++ b/src/containers/WindowTopMenuButton.js
@@ -1,12 +1,24 @@
 import { compose } from 'redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import WindowTopMenuButton from '../components/WindowTopMenuButton';
 
+/**
+ *
+ * @param theme
+ * @returns {{ctrlBtn: {margin: (number|string)}}}
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+});
+
 const enhance = compose(
   withNamespaces(),
+  withStyles(styles),
   miradorWithPlugins,
-  // further HOC
 );
 
 export default enhance(WindowTopMenuButton);

--- a/src/containers/WindowViewSettings.js
+++ b/src/containers/WindowViewSettings.js
@@ -25,10 +25,9 @@ const mapStateToProps = (state, props) => (
 );
 
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
+  connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
-  // further HOC go here
 );
 
 export default enhance(WindowViewSettings);

--- a/src/containers/WorkspaceAdd.js
+++ b/src/containers/WorkspaceAdd.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import * as actions from '../state/actions';
 import WorkspaceAdd from '../components/WorkspaceAdd';
 
@@ -18,10 +19,40 @@ const mapStateToProps = state => ({ manifests: state.manifests });
  */
 const mapDispatchToProps = { setWorkspaceAddVisibility: actions.setWorkspaceAddVisibility };
 
+/**
+ *
+ * @param theme
+ * @returns {{typographyBody: {flexGrow: number, fontSize: string},
+ * form: {paddingBottom: number, paddingTop: number, marginTop: number},
+ * fab: {bottom: number, position: string, right: number},
+ * menuButton: {marginRight: number, marginLeft: number}}}
+ */
+const styles = theme => ({
+  form: {
+    ...theme.mixins.gutters(),
+    paddingTop: theme.spacing.unit * 2,
+    paddingBottom: theme.spacing.unit * 2,
+    marginTop: 64,
+  },
+  fab: {
+    position: 'absolute',
+    bottom: theme.spacing.unit * 2,
+    right: theme.spacing.unit * 2,
+  },
+  typographyBody: {
+    flexGrow: 1,
+    fontSize: '1em',
+  },
+  menuButton: {
+    marginLeft: -12,
+    marginRight: 20,
+  },
+});
+
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
-  // further HOC go here
+  withStyles(styles),
+  connect(mapStateToProps, mapDispatchToProps),
 );
 
 export default enhance(WorkspaceAdd);

--- a/src/containers/WorkspaceAddButton.js
+++ b/src/containers/WorkspaceAddButton.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import * as actions from '../state/actions';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import WorkspaceAddButton from '../components/WorkspaceAddButton';
@@ -24,9 +25,21 @@ const mapStateToProps = state => (
  */
 const mapDispatchToProps = { setWorkspaceAddVisibility: actions.setWorkspaceAddVisibility };
 
+/**
+ *
+ * @param theme
+ * @returns {{ctrlBtn: {margin: (number|string)}}}
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+});
+
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
+  withStyles(styles),
+  connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
 );
 

--- a/src/containers/WorkspaceControlPanel.js
+++ b/src/containers/WorkspaceControlPanel.js
@@ -1,0 +1,20 @@
+import { withStyles } from '@material-ui/core/styles';
+import WorkspaceControlPanel from '../components/WorkspaceControlPanel';
+
+/**
+ *
+ * @param theme
+ * @returns {{ctrlBtn: {margin: (number|string)},
+ * drawer: {overflowX: string, height: string}}}
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+  drawer: {
+    overflowX: 'hidden',
+    height: '100%',
+  },
+});
+
+export default withStyles(styles)(WorkspaceControlPanel);

--- a/src/containers/WorkspaceExport.js
+++ b/src/containers/WorkspaceExport.js
@@ -12,10 +12,9 @@ import WorkspaceExport from '../components/WorkspaceExport';
 const mapStateToProps = state => ({ state });
 
 const enhance = compose(
+  withNamespaces(),
   connect(mapStateToProps, {}),
   miradorWithPlugins,
-  withNamespaces(),
-  // further HOC go here
 );
 
 export default enhance(WorkspaceExport);

--- a/src/containers/WorkspaceFullScreenButton.js
+++ b/src/containers/WorkspaceFullScreenButton.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import * as actions from '../state/actions';
 import WorkspaceFullScreenButton
@@ -13,11 +14,22 @@ import WorkspaceFullScreenButton
  */
 const mapDispatchToProps = { setWorkspaceFullscreen: actions.setWorkspaceFullscreen };
 
+/**
+ *
+ * @param theme
+ * @returns {{ctrlBtn: {margin: (number|string)}}}
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+});
+
 const enhance = compose(
-  connect(null, mapDispatchToProps),
   withNamespaces(),
+  withStyles(styles),
+  connect(null, mapDispatchToProps),
   miradorWithPlugins,
-  // further HOC
 );
 
 export default enhance(WorkspaceFullScreenButton);

--- a/src/containers/WorkspaceMenu.js
+++ b/src/containers/WorkspaceMenu.js
@@ -22,10 +22,9 @@ const mapStateToProps = state => (
 );
 
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
+  connect(mapStateToProps, mapDispatchToProps),
   miradorWithPlugins,
-  // further HOC
 );
 
 export default enhance(WorkspaceMenu);

--- a/src/containers/WorkspaceMenuButton.js
+++ b/src/containers/WorkspaceMenuButton.js
@@ -1,10 +1,21 @@
 import { compose } from 'redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import WorkspaceMenuButton from '../components/WorkspaceMenuButton';
 
+/**
+ * @private
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+});
+
 const enhance = compose(
   withNamespaces(),
+  withStyles(styles),
   miradorWithPlugins,
   // further HOC
 );

--- a/src/containers/WorkspaceMenuButton.js
+++ b/src/containers/WorkspaceMenuButton.js
@@ -5,7 +5,9 @@ import miradorWithPlugins from '../lib/miradorWithPlugins';
 import WorkspaceMenuButton from '../components/WorkspaceMenuButton';
 
 /**
- * @private
+ *
+ * @param theme
+ * @returns {{ctrlBtn: {margin: (number|string)}}}
  */
 const styles = theme => ({
   ctrlBtn: {

--- a/src/containers/WorkspaceSettings.js
+++ b/src/containers/WorkspaceSettings.js
@@ -25,9 +25,8 @@ const mapStateToProps = state => (
 );
 
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
-  // further HOC go here
+  connect(mapStateToProps, mapDispatchToProps),
 );
 
 export default enhance(WorkspaceSettings);

--- a/src/containers/ZoomControls.js
+++ b/src/containers/ZoomControls.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withNamespaces } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import * as actions from '../state/actions';
 import ZoomControls from '../components/ZoomControls';
 
@@ -16,7 +17,6 @@ const mapStateToProps = (state, props) => (
   }
 );
 
-
 /**
  * mapDispatchToProps - used to hook up connect to action creators
  * @memberof Workspace
@@ -24,10 +24,27 @@ const mapStateToProps = (state, props) => (
  */
 const mapDispatchToProps = { updateViewport: actions.updateViewport };
 
+/**
+ *
+ * @param theme
+ * @returns {{zoom_controls: {position: string, right: number},
+ * ListItem: {paddingBottom: number, paddingTop: number}}}
+ */
+const styles = theme => ({
+  zoom_controls: {
+    position: 'absolute',
+    right: 0,
+  },
+  ListItem: {
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+});
+
 const enhance = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withNamespaces(),
-  // further HOC go here
+  withStyles(styles),
+  connect(mapStateToProps, mapDispatchToProps),
 );
 
 export default enhance(ZoomControls);


### PR DESCRIPTION
removes dive where applied and modifies tests
closes #1948

see attached console logs for comparison of names before this PR and names after
[before.log](https://github.com/ProjectMirador/mirador/files/2894165/before.log)
[after.log](https://github.com/ProjectMirador/mirador/files/2894166/after.log)

