### PR TITLE
Update light theme palette, part of #1906

### DIFF
--- a/src/components/ManifestForm.js
+++ b/src/components/ManifestForm.js
@@ -75,7 +75,7 @@ export class ManifestForm extends Component {
                 {t('cancel')}
               </Button>
             )}
-            <Button id="fetchBtn" type="submit" variant="contained" color="primary">
+            <Button id="fetchBtn" type="submit" variant="contained" color="secondary">
               {t('fetchManifest')}
             </Button>
           </Grid>

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -107,7 +107,7 @@ export class ManifestListItem extends React.Component {
                     }
                   </Grid>
                   <Grid item xs={8} sm={9}>
-                    <Typography component="span" variant="subtitle1" color="primary">
+                    <Typography component="span" variant="subtitle1" color="secondary">
                       {title || manifestId}
                     </Typography>
                   </Grid>

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -37,7 +37,7 @@ export class WindowSideBarButtons extends Component {
           onClick={() => (toggleWindowSideBarPanel('info'))}
         >
           <InfoIcon
-            color={this.sideBarPanelCurrentlySelected('info') ? 'primary' : 'inherit'}
+            color={this.sideBarPanelCurrentlySelected('info') ? 'secondary' : 'inherit'}
           />
         </IconButton>
         <IconButton
@@ -49,7 +49,7 @@ export class WindowSideBarButtons extends Component {
           onClick={() => (toggleWindowSideBarPanel('canvas_navigation'))}
         >
           <CanvasIndexIcon
-            color={this.sideBarPanelCurrentlySelected('canvas_navigation') ? 'primary' : 'inherit'}
+            color={this.sideBarPanelCurrentlySelected('canvas_navigation') ? 'secondary' : 'inherit'}
           />
         </IconButton>
       </>

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -60,6 +60,7 @@ export class WindowSideBarCanvasPanel extends Component {
                     className={classNames(classes.clickable, classes.label)}
                     onClick={onClick}
                     variant="body2"
+                    color="secondary"
                   >
                     {canvas.label}
                   </Typography>

--- a/src/components/WindowThumbnailSettings.js
+++ b/src/components/WindowThumbnailSettings.js
@@ -42,19 +42,19 @@ export class WindowThumbnailSettings extends Component {
         <RadioGroup aria-label={t('position')} name="position" value={thumbnailNavigationPosition} onChange={this.handleChange} row>
           <FormControlLabel
             value="off"
-            control={<Radio color="primary" icon={<ThumbnailsOffIcon />} checkedIcon={<ThumbnailsOffIcon />} />}
+            control={<Radio color="secondary" icon={<ThumbnailsOffIcon />} checkedIcon={<ThumbnailsOffIcon />} />}
             label={t('off')}
             labelPlacement="bottom"
           />
           <FormControlLabel
             value="bottom"
-            control={<Radio color="primary" icon={<ThumbnailNavigationBottomIcon />} checkedIcon={<ThumbnailNavigationBottomIcon />} />}
+            control={<Radio color="secondary" icon={<ThumbnailNavigationBottomIcon />} checkedIcon={<ThumbnailNavigationBottomIcon />} />}
             label={t('bottom')}
             labelPlacement="bottom"
           />
           <FormControlLabel
             value="right"
-            control={<Radio color="primary" icon={<ThumbnailNavigationRightIcon />} checkedIcon={<ThumbnailNavigationRightIcon />} />}
+            control={<Radio color="secondary" icon={<ThumbnailNavigationRightIcon />} checkedIcon={<ThumbnailNavigationRightIcon />} />}
             label={t('right')}
             labelPlacement="bottom"
           />

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -27,7 +27,7 @@ export class WindowTopBar extends Component {
     } = this.props;
     return (
       <AppBar position="relative">
-        <Toolbar disableGutters className={classNames(classes.reallyDense, ns('window-top-bar'))} variant="dense">
+        <Toolbar disableGutters className={classNames(classes.windowTopBarStyle, ns('window-top-bar'))} variant="dense">
           <IconButton
             aria-label={t('toggleWindowSideBar')}
             color="inherit"

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -42,13 +42,13 @@ export class WindowViewSettings extends Component {
         <RadioGroup aria-label={t('position')} name="position" value={windowViewType} onChange={this.handleChange} row>
           <FormControlLabel
             value="single"
-            control={<Radio color="primary" icon={<SingleIcon />} checkedIcon={<SingleIcon />} />}
+            control={<Radio color="secondary" icon={<SingleIcon />} checkedIcon={<SingleIcon />} />}
             label={t('single')}
             labelPlacement="bottom"
           />
           <FormControlLabel
             value="book"
-            control={<Radio color="primary" icon={<BookViewIcon />} checkedIcon={<BookViewIcon />} />}
+            control={<Radio color="secondary" icon={<BookViewIcon />} checkedIcon={<BookViewIcon />} />}
             label={t('book')}
             labelPlacement="bottom"
           />

--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -56,7 +56,7 @@ export class WorkspaceAdd extends React.Component {
       <div className={ns('workspace-add')}>
         {manifestList}
 
-        <Fab variant="extended" disabled={addResourcesOpen} className={classes.fab} color="primary" onClick={() => (this.setAddResourcesVisibility(true))}>
+        <Fab variant="extended" disabled={addResourcesOpen} className={classes.fab} color="secondary" onClick={() => (this.setAddResourcesVisibility(true))}>
           <AddIcon />
           {t('addResource')}
         </Fab>
@@ -75,9 +75,9 @@ export class WorkspaceAdd extends React.Component {
           <Paper
             className={classes.form}
           >
-            <AppBar position="absolute" color="primary" onClick={() => (this.setAddResourcesVisibility(false))}>
+            <AppBar position="absolute" color="secondary" onClick={() => (this.setAddResourcesVisibility(false))}>
               <Toolbar>
-                <IconButton className={classes.menuButton} color="inherit" aria-label={t('closeMenu')}>
+                <IconButton className={classes.menuButton} color="secondary" aria-label={t('closeMenu')}>
                   <ExpandMoreIcon />
                 </IconButton>
                 <Typography variant="h2" noWrap color="inherit" className={classes.typographyBody}>

--- a/src/components/WorkspaceAddButton.js
+++ b/src/components/WorkspaceAddButton.js
@@ -19,7 +19,7 @@ export class WorkspaceAddButton extends Component {
     return (
       <ListItem>
         <Fab
-          color="primary"
+          color="secondary"
           id="addBtn"
           aria-label={isWorkspaceAddVisible ? t('closeWindow') : t('add')}
           className={classes.fab}

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -5,6 +5,16 @@ export default {
   theme: { // Sets up a MaterialUI theme. See https://material-ui.com/customization/default-theme/
     palette: {
       type: 'light', // dark also available
+      primary: {
+        main: '#f5f5f5',
+        light: '#ffffff',
+        dark: '#eeeeee',
+      },
+      secondary: {
+        main: '#1967d2',
+        light: '#64b5f6',
+        dark: '#0d47a1',
+      },
     },
     typography: {
       useNextVariants: true // set so that console deprecation warning is removed

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -15,6 +15,9 @@ export default {
         light: '#64b5f6',
         dark: '#0d47a1',
       },
+      error: {
+        main: '#b00020',
+      },
     },
     typography: {
       useNextVariants: true // set so that console deprecation warning is removed

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -22,17 +22,22 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
   toggleWindowSideBar: () => dispatch(actions.toggleWindowSideBar(windowId)),
 });
 
-
-const styles = {
+/**
+ * @param theme
+ * @returns {{typographyBody: {flexGrow: number, fontSize: number|string},
+ * windowTopBarStyle: {minHeight: number, paddingLeft: number, backgroundColor: string}}}
+ */
+const styles = theme => ({
   typographyBody: {
     flexGrow: 1,
     fontSize: '1em',
   },
-  reallyDense: {
+  windowTopBarStyle: {
     minHeight: 32,
     paddingLeft: 4,
+    backgroundColor: theme.palette.primary.light,
   },
-};
+});
 
 const enhance = compose(
   withNamespaces(),


### PR DESCRIPTION
Part of #1906 

This PR:
- updates the palette hex values for primary, secondary, and error colors
- applies the `secondary` color (blue) to selection controls, some menu icons, links in the canvas nav, links in the add resources window,  
- connects the `WindowTopBar` to the `primary.light` color

The goal of this PR is to implement some color-to-component mappings for @jvine and @ggeisler to assess. There will be some more ironing out (see split-out tickets below).

You can test this out in the demo with the following: 
```
var action = miradorInstance.actions.updateConfig({
  theme: {
    palette: {
      type: 'light',
      primary: {
        light: '#7fffd4', // aquamarine
      },
      secondary: {
        main: '#dda0dd', // plum
      },
    },
  },
});
miradorInstance.store.dispatch(action);
```
## TODOs to ticket out:
🎟 Figure out how to "unset" the `light` and `dark` properties if the `main` color is overridden. In the example below, an implementer has overridden `main` to plum, but MUI uses the `light` and `dark` colors from `settings.js`. 
**OR:** instruct implementers to generate their `light` and `dark` values with the [MUI color tool](https://material-ui.com/style/color/#color-tool) and explicitly override all three values
![fab-primary](https://user-images.githubusercontent.com/5402927/53469069-6aaba680-3a11-11e9-9aad-932caffeefc4.gif)

## 
🎟 Override text input labels so they use our `secondary` color instead of `primary`? See the light grey color used for this picker's label. Might need to check in with @jvine and @ggeisler about this.
![grey-menu](https://user-images.githubusercontent.com/5402927/53469178-d726a580-3a11-11e9-974e-55293701d62b.gif)

