### PR TITLE
Comparison: styling with SCSS vs. MUI withStyles 

### DIFF
--- a/src/containers/Window.js
+++ b/src/containers/Window.js
@@ -15,8 +15,12 @@ const mapStateToProps = ({ manifests, windows, config }, props) => ({
   workspaceType: config.workspace.type,
 });
 
-const styles = {
+/**
+ * @param theme
+ */
+const styles = theme => ({
   window: {
+    backgroundColor: theme.palette.primary.dark,
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
@@ -53,9 +57,10 @@ const styles = {
     minHeight: 0,
   },
   thumbnailArea: {
+    backgroundColor: theme.palette.primary.dark,
     flex: '0',
   },
-};
+});
 
 const enhance = compose(
   withStyles(styles),

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -21,6 +21,7 @@
   }
 
   &-workspace-viewport {
+    background: $surface-dark;
     bottom: 0;
     left: 0;
     margin: 0;
@@ -68,7 +69,7 @@
   }
 
   &-osd-container {
-    background: $gray;
+    background: $primary-dark;
     flex: 1;
     position: relative;
   }
@@ -78,7 +79,7 @@
   }
 
   &-companion-bottom {
-    background: lighten($black, 60%);
+    background: $primary-dark;
     resize: vertical;
   }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -69,7 +69,6 @@
   }
 
   &-osd-container {
-    background: $primary-dark;
     flex: 1;
     position: relative;
   }
@@ -79,7 +78,6 @@
   }
 
   &-companion-bottom {
-    background: $primary-dark;
     resize: vertical;
   }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -5,3 +5,5 @@ $white: #fff;
 $window-top-bar-gradient-top: rgba(0, 0, 0, .65);
 $window-top-bar-gradient-bottom: rgba(0, 0, 0, 0);
 $window-sidebar-width: 55px;
+$primary-dark: #eee;
+$surface-dark: #f5f5f5;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -5,5 +5,4 @@ $white: #fff;
 $window-top-bar-gradient-top: rgba(0, 0, 0, .65);
 $window-top-bar-gradient-bottom: rgba(0, 0, 0, 0);
 $window-sidebar-width: 55px;
-$primary-dark: #eee;
 $surface-dark: #f5f5f5;


### PR DESCRIPTION
This works implements the following palette-to-component connections from #1906:
- Workspace surface: surface - dark
- Window surface: primary - dark
- Thumbnail strip surface: primary - dark
---
This PR is also a nice opportunity to compare the two patterns for styling components that currently exist in the project. Take a look at the commits in this PR to see each approach applied to the same set of components.

## namespaced classes and SCSS
- pro: lower bar to styling
- pro: allows maximum flexibility for styling
- neutral: overrides supplied via imported stylesheet? Needs further investigation.
- con: some information duplicated between `settings.js` and `variables.scss`.

## withStyles higher-order component
- pro: ability to tap into MUI theme colors, font sizes, etc. for styles
- pro: easier to enforce consistent visual style for plugin developers
- pro: keeps styles closer to the component
- neutral: overrides supplied via Mirador config object e.g. `palette: {...}`
- con: styles supplied by classes in `withStyles` cannot be overridden by SCSS classes
- con: dispersed; difficult to understand how styles are used across the project

---
You can test this out in the demo with the following: 
```
var action = miradorInstance.actions.updateConfig({
  theme: {
    palette: {
      type: 'light',
      primary: {
        main: '#7fffd4', // aquamarine
        light: '#98ffdc',
        dark: '#58b294',
      },
    },
  },
});
miradorInstance.store.dispatch(action);
```

### Resources
- [MUI API Design guide:](https://material-ui.com/guides/api/#css-classes) `classes`