### PR TITLE
Fix error in manifests that have a canvas w/o images

### DIFF
--- a/__tests__/fixtures/version-2/emptyCanvas.json
+++ b/__tests__/fixtures/version-2/emptyCanvas.json
@@ -1,0 +1,7984 @@
+{
+    "@context": "http://iiif.io/api/presentation/2/context.json",
+    "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/manifest.json",
+    "@type": "sc:Manifest",
+    "label": "Codex Florus dispersus",
+    "metadata": [
+       {
+		"label":"Object type",
+		"value":"Manuscrit dispersé"
+       },
+       {
+            "label": "Repository",
+            "value": [
+                "Paris, Bibliothèque nationale de France",
+                "Genève, Bibliothèque de Genève",
+                "Saint-Pétersbourg, Bibliothèque nationale de Russie"
+            ]
+        },
+        {
+            "label": "Shelfmark",
+            "value": [
+                "BnF, Latin 11641",
+                "BGE, Latin 16",
+                "BnR, Latin F.papyr.I.1"
+            ]
+        },
+        {
+            "label": "Title",
+            "value": "Épîtres et sermons de saint Augustin"
+        },
+        {
+            "label": "Language",
+            "value": "Latin"
+        },
+        {
+            "label": "Material",
+            "value": "Parchemin et papyrus"
+        },
+        {
+            "label": "Extent",
+            "value": [
+                "300 f. (lacunes comprises)",
+                "63 f. de Paris",
+                "53 f. de Genève",
+                "1 f. de Saint-Pétersbourg"
+            ]
+        },
+        {
+            "label": "Dimensions",
+            "value": "320 x 220 mm"
+        },
+        {
+            "label": "Provenance",
+            "value": "Luxeuil ou Lyon (?)"
+        },
+        {
+            "label": "Creator",
+            "value": [
+                "Saint Augustin. Auteur du texte",
+                "Florus de Lyon. Annotateur"
+            ]
+        },
+        {
+            "label": "Date",
+            "value": "VIIe/VIIIe siècle"
+        },
+        {
+            "label": "Provider",
+            "value": [
+                "Paris, Bibliothèque nationale de France",
+                "Genève, Bibliothèque de Genève",
+                "Saint-Pétersbourg, Bibliothèque nationale de Russie"
+            ]
+        },
+        {
+            "label": "Disseminator",
+            "value": "Biblissima"
+        },
+        {
+            "label": "Source Images",
+            "value": [
+                "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/",
+                "http://www.e-codices.unifr.ch/en/list/one/bge/lat0016",
+                "http://www.e-codices.unifr.ch/en/list/one/nlr/lat-F-I-1"
+            ]
+        }
+    ],
+    "description": "Le \"Florus dispersus\" contient une reconstruction virtuelle d'un manuscrit des lettres et des sermons d'Augustin dans la succession originelle des parties conservées. Il a été rédigé dans une écriture onciale par un copiste de la fin du VIIe siècle, respectivement du début du VIIIe siècle. A l'origine, il se composait de 300 feuillets, dont il reste encore aujourd'hui 117. Une partie de 63 feuillets, provenant des cahiers d'origine 4-11, se trouve aujourd'hui à Paris (BnF, lat. 11641); dans cette partie, peut être inséré, après le feuillet 26, un feuillet isolé, aujourd'hui conservé à Saint-Pétersbourg (BNR, Lat.F.papyr. I.1). Une autre partie de 53 feuillets provenant des cahiers d'origine 23-30 est aujourd'hui conservée à Genève (BGE, lat. 16). Le feuillet extérieur de chaque cahier (quinion) se compose à chaque fois d'un feuillet de parchemin, les autres sont en papyrus. Il s'agit du plus ancien exemple connu de manuscrit mêlant le parchemin et le papyrus. Durant le IXe siècle, le manuscrit appartenait à la bibliothèque de Florus de Lyon, qui y a inséré de sa main de nombreuses notes marginales. Dans la reconstruction virtuelle proposée, nous avons choisi de représenter la structure codicologique du manuscrit original et de signaler les lacunes aux endroits où elles se sont produites. Toutefois, ne sont représentés que les cahiers ayant au moins un feuillet conservé, c'est-à-dire les cahiers 4 à 11 et 23 à 30. Une navigation par œuvre est disponible à l'intérieur d'un cahier. Les feuillets mal placés dans les manuscrits actuels ont été remis dans l\u2019ordre original, à savoir: Paris fol. 1 et 2 ont été intervertis, Genève fol. 2a a été placé entre les feuillets Genève fol. 1 et 2, Genève fol. 9 - entre les feuillets Genève fol. 13 et 14, Genève fol. 45 - entre les feuillets Genève fol. 49 et 50.  La foliotation présumée du manuscrit original est indiquée entre parenthèses après les folios des manuscrits actuels.",
+    "license": ["http://creativecommons.org/licenses/by-nc/4.0/", "https://gallica.bnf.fr/html/und/conditions-dutilisation-des-contenus-de-gallica"],
+    "attribution": "Reconstruction virtuelle: Pierre Chambert-Protat / Manifest IIIF: Elena Koroleva / Images: e-codices - Virtual Manuscript Library of Switzerland ; Gallica - Bibliothèque nationale de France",
+    "structures": [
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r0",
+            "@type": "sc:Range",
+            "label": "Table of Contents",
+            "viewingHint": "top",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r7",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r8",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r14",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1",
+            "@type": "sc:Range",
+            "label": "Cahier IV",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1-3"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f13",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f14",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-7",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-8",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-9",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-10",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-11",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-12",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-13",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-14",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-15",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-16",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f11",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f12"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1-1",
+            "@type": "sc:Range",
+            "label": "Minuscule frg. du 1er f. du 4e cahier",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f13",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f14"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1-2",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-7",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-8",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-9",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-10",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-11",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-12",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-13",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-14",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-15",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-16"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r1-3",
+            "@type": "sc:Range",
+            "label": "Épitre 27, 4-6 d'Augustin (f.1r-v, 3r-v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f11",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f12"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2",
+            "@type": "sc:Range",
+            "label": "Cahier V",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-7"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f15",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f16",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f17",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f18",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f19",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f20",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f21",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f22",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-17",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-18",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-19",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-20",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f23",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f24",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f25",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f26",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f27",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f28",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f29",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f30"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-1",
+            "@type": "sc:Range",
+            "label": "Épitre 27, 4-6 d'Augustin (f.1r-v, 3r-v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f15",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f16"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-2",
+            "@type": "sc:Range",
+            "label": "Épitre 31, 1-6 d'Augustin (f. 3v-6v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f16",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f17",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f18",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f19",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f20",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f21",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f22"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-3",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-17",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-18",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-19",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-20"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-4",
+            "@type": "sc:Range",
+            "label": "Épitre 24 d'Augustin (f. 7r-8v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f23",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f24",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f25",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f26"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-5",
+            "@type": "sc:Range",
+            "label": "Épitre 42 d'Augustin (f. 8v-9r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f26",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f27"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-6",
+            "@type": "sc:Range",
+            "label": "Épitre 45 d'Augustin (f. 9r-10r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f27",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f28",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f29"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r2-7",
+            "@type": "sc:Range",
+            "label": "Épitre 94 d'Augustin (f. 10r-15v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f29",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f30"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3",
+            "@type": "sc:Range",
+            "label": "Cahier VI",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-7"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f31",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f32",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f33",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f34",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f35",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f36",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f37",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f38",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f39",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f40",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-21",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-22",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f41",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f42",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f43",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f44",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f45",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f46",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f47",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f48",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f49",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f50"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-1",
+            "@type": "sc:Range",
+            "label": "Épitre 94 d'Augustin (f. 10r-15v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f31",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f32",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f33",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f34",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f35",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f36",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f37",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f38",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f39",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f40"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-2",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-21",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-22"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-3",
+            "@type": "sc:Range",
+            "label": "Ex epistolis du Pseudo-Augustin (f. 16r-18v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f41",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f42",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f43",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f44"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-4",
+            "@type": "sc:Range",
+            "label": "Bande sans texte entre 17v et 18r (le reste de la marge du f. manquant?)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f45",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f46"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-5",
+            "@type": "sc:Range",
+            "label": "Ex epistolis du Pseudo-Augustin (f. 16r-18v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f47",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f48"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-6",
+            "@type": "sc:Range",
+            "label": "Épitre 260 d'Augustin (f. 18v-19r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f48",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f49"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r3-7",
+            "@type": "sc:Range",
+            "label": "Épitre 261, 1-4 d'Augustin (f. 19r-20v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f49",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f50"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4",
+            "@type": "sc:Range",
+            "label": "Cahier VII",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-5"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f51",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f52",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-23",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-24",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-25",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-26",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f53",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f54",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f55",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f56",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f57",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f58",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f59",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f60",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-27",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-28",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-29",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-30",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f61",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f62"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-1",
+            "@type": "sc:Range",
+            "label": "Épitre 261, 1-4 d'Augustin (f. 19r-20v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f51",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f52"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-2",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-23",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-24",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-25",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-26"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-3",
+            "@type": "sc:Range",
+            "label": "Sermon 351 d'Augustin, De utilitate agendae paenitentiae (f. 21r-34r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f53",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f54",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f55",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f56",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f57",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f58",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f59",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f60"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-4",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+               "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-27",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-28",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-29",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-30"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r4-5",
+            "@type": "sc:Range",
+            "label": "Sermon 351 d'Augustin, De utilitate agendae paenitentiae (f. 21r-34r)",
+            "canvases": [
+                 "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f61",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f62"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5",
+            "@type": "sc:Range",
+            "label": "Cahier VIII",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5-3"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f63",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f64",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_a.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_b.json",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f65",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f66",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f67",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f68",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f69",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f70",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f71",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f72",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f73",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f74",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f75",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f76",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-31",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-32",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f77",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f78"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5-1",
+            "@type": "sc:Range",
+            "label": "Sermon 351 d'Augustin, De utilitate agendae paenitentiae (f. 21r-34r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f63",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f64",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_a.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_b.json",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f65",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f66",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f67",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f68",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f69",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f70",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f71",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f72",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f73",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f74",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f75",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f76"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5-2",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-31",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-32"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r5-3",
+            "@type": "sc:Range",
+            "label": "Sermon 351 d'Augustin, De utilitate agendae paenitentiae (f. 21r-34r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f77",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f78"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6",
+            "@type": "sc:Range",
+            "label": "Cahier IX",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-4"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f79",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f80",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f81",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f82",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f83",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f84",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f85",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f86",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f87",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f88",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f89",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f90",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f91",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f92",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f93",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f94",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f95",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f96",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f97",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f98"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-1",
+            "@type": "sc:Range",
+            "label": "Sermon 351 d'Augustin, De utilitate agendae paenitentiae (f. 21r-34r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f79"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-2",
+            "@type": "sc:Range",
+            "label": "Sermon 392 d'Augustin, Ad coniugatos (f. 34r-37v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f79",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f80",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f81",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f82",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f83",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f84",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f85",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f86"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-3",
+            "@type": "sc:Range",
+            "label": "De vetere testamento, Sermon 18, De versu psalmi 49 (f. 38r-42r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f87",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f88",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f89",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f90",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f91",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f92",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f93",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f94",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f95"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r6-4",
+            "@type": "sc:Range",
+            "label": "In Matthaeum, Sermon 87 d'Augustin (f. 42r-53r)",
+            "canvases": [
+                 "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f95",
+                 "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f96",
+                 "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f97",
+                 "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f98"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r7",
+            "@type": "sc:Range",
+            "label": "Cahier X",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r7-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r7-2"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f99",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f100",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f101",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f102",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f103",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f104",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f105",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f106",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f107",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f108",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f109",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f110",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f111",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f112",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f113",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f114",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f115",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f116",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f117",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f118"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r7-1",
+            "@type": "sc:Range",
+            "label": "In Matthaeum, Sermon 87 d'Augustin (f. 42r-53r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f99",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f100",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f101",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f102",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f103",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f104",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f105",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f106",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f107",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f108",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f109",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f110",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f111",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f112",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f113",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f114",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f115",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f116",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f117"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r7-2",
+            "@type": "sc:Range",
+            "label": "In Matthaeum, Sermon 77 d'Augustin (f. 53r-62r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f117",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f118"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r8",
+            "@type": "sc:Range",
+            "label": "Cahier XI",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r8-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r8-2"
+            ],
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f119",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f120",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f121",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f122",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f123",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f124",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f125",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f126",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f127",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f128",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f129",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f130",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f131",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f132",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f133",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f134",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f135",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f136",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f137",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f138"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r8-1",
+            "@type": "sc:Range",
+            "label": "In Matthaeum, Sermon 77 d'Augustin (f. 53r-62r)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f119",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f120",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f121",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f122",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f123",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f124",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f125",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f126",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f127",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f128",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f129",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f130",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f131",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f132",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f133",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f134",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f135"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r8-2",
+            "@type": "sc:Range",
+            "label": "In Iohannem, Sermon 127 d'Augustin (f. 62v-63v)",
+            "canvases": [
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f136",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f137",
+                "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f138"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9",
+            "@type": "sc:Range",
+            "label": "Cahier XXIII",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-4"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002ar.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002av.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-33",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-34",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-35",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-36",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-37",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-38",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-39",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-40",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-41",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-42",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-43",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-44",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-1",
+            "@type": "sc:Range",
+            "label": "Sermon 279, ch.4-6 d'Augustin (f. 1r-1v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-2",
+            "@type": "sc:Range",
+            "label": "Languette en papyrus du 2e folio",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002ar.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002av.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-3",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                 "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-33",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-34",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-35",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-36",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-37",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-38",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-39",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-40",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-41",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-42",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-43",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-44"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r9-4",
+            "@type": "sc:Range",
+            "label": "Sermon 288, ch. 3-5 d'Augustin (f.2r-4v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10",
+            "@type": "sc:Range",
+            "label": "Cahier XXIV",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-7",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-8",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-9",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-10"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-45",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-46",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-47",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-48",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-49",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-50",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-51",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-52",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_010r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_0010v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-1",
+            "@type": "sc:Range",
+            "label": "Sermon 288, ch. 3-5 d'Augustin (f.2r-4v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-2",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-45",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-46"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-3",
+            "@type": "sc:Range",
+            "label": "Sermon 21, ch. 1-2 d'Augustin (f.5r-5v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-4",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-47",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-48"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-5",
+            "@type": "sc:Range",
+            "label": "Sermon 21, ch. 4-8 d'Augustin (f. 6r-7v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-6",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-49",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-50"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-7",
+            "@type": "sc:Range",
+            "label": "Sermon 21, ch. 9-10 d'Augustin (f. 8r)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008r.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-8",
+            "@type": "sc:Range",
+            "label": "Sermon 41, ch. 1 d'Augustin (f. 8r-8v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-9",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-51",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-52"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r10-10",
+            "@type": "sc:Range",
+            "label": "Sermon 41, ch. 3-5 d'Augustin (f. 10r-11v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_0010r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_0010v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11",
+            "@type": "sc:Range",
+            "label": "Cahier XXV",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-7",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-8",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-9"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-53",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-54",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-55",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-56",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-57",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-58",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_016r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_0016v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-1",
+            "@type": "sc:Range",
+            "label": "Sermon 41, ch. 3-5 d'Augustin (f. 10r-11v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-2",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-53",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-54"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-3",
+            "@type": "sc:Range",
+            "label": "Sermon 41, ch. 7 d'Augustin (f. 12r-12v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-4",
+            "@type": "sc:Range",
+            "label": "Sermon 41, ch. 7 d'Augustin (f. 12r-12v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-5",
+            "@type": "sc:Range",
+            "label": "Sermon 38, ch. 1,1 – 4,6 d'Augustin (f. 12v-13v, 9r-9v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-6",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-55",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-56"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-7",
+            "@type": "sc:Range",
+            "label": "Sermon 38, ch. 5,7 – 8,10 d'Augustin (f. 14r-15v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-8",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-57",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-58"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r11-9",
+            "@type": "sc:Range",
+            "label": "Sermon 20, ch. 1-5 d'Augustin (f. 16r-19r)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_016r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_016v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12",
+            "@type": "sc:Range",
+            "label": "Cahier XXVI",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-4"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-59",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-60",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-1",
+            "@type": "sc:Range",
+            "label": "Sermon 20, ch. 1-5 d'Augustin (f. 16r-19r)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019r.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-2",
+            "@type": "sc:Range",
+            "label": "Sermon 358, ch. 1-6 d'Augustin (f. 19r-22v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-3",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-59",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-60"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r12-4",
+            "@type": "sc:Range",
+            "label": "Sermon 99, ch. 2-8 d'Augustin (f. 23r-26v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13",
+            "@type": "sc:Range",
+            "label": "Cahier XXVII",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-4"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-61",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-62",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-63",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-64",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-65",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-66",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-67",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-68",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-69",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-70",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-71",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-72",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-73",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-74",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-75",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-76"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-1",
+            "@type": "sc:Range",
+            "label": "Sermon 99, ch. 2-8 d'Augustin (f. 23r-26v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-2",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-61",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-62",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-63",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-64",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-65",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-66",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-67",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-68",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-69",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-70",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-71",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-72",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-73",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-74"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-3",
+            "@type": "sc:Range",
+            "label": "Sermon 359, ch. 3-4 d'Augustin (f. 27r-27v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r13-4",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-75",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-76"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r14",
+            "@type": "sc:Range",
+            "label": "Cahier XXVIII",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r14-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r14-2"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r14-1",
+            "@type": "sc:Range",
+            "label": "Sermon 359, ch. 5-9 d'Augustin (f. 28r-31v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r14-2",
+            "@type": "sc:Range",
+            "label": "Sermon 81 d'Augustin (f. 31v-39v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15",
+            "@type": "sc:Range",
+            "label": "Cahier XXIX",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-7"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-77",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-78",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-1",
+            "@type": "sc:Range",
+            "label": "Sermon 81 d'Augustin (f. 31v-39v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-2",
+            "@type": "sc:Range",
+            "label": "Sermon 194 d'Augustin (f. 39v-41v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-3",
+            "@type": "sc:Range",
+            "label": "Sermon 374 d'Augustin (f. 42r-44v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-4",
+            "@type": "sc:Range",
+            "label": "Sermon De die sanctae epiphaniae de Maxime de Turin (début)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-5",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-77",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-78"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-6",
+            "@type": "sc:Range",
+            "label": "Sermon 352, ch.1,6 d'Augustin (f. 46r-46v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046v.json"
+             ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r15-7",
+            "@type": "sc:Range",
+            "label": "Enarrationes in Psalmos, Psaume 36 sermon 1, ch. 1-3 d'Augustin (f. 46v-48v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047v.json"
+             ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16",
+            "@type": "sc:Range",
+            "label": "Cahier XXX",
+            "ranges": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-1",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-2",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-3",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-4",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-5",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-6",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-7"
+            ],
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052v.json",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-79",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-80",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-81",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-82",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-83",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-84",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053v.json"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-1",
+            "@type": "sc:Range",
+            "label": "Enarrationes in Psalmos, Psaume 36 sermon 1, ch. 1-3 d'Augustin (f. 46v-48v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048v.json"
+             ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-2",
+            "@type": "sc:Range",
+            "label": "De doctrina christiana livre 1, ch.9-15 d'Augustin (f. 48v-49v, 45r-45v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045v.json"
+             ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-3",
+            "@type": "sc:Range",
+            "label": "Enarrationes in Psalmos, Psaume 36 sermon 2 d'Augustin (f. 45v, 50r-52r)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051v.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052r.json"
+             ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-4",
+            "@type": "sc:Range",
+            "label": "Sermon Mai 14, ch. 1 d'Augustin (f. 52r-52v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052v.json"
+             ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-5",
+            "@type": "sc:Range",
+            "label": "Lacune",
+            "canvases": [
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-79",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-80",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-81",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-82",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-83",
+                "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-84"
+            ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-6",
+            "@type": "sc:Range",
+            "label": "Enarrationes in Psalmos, Psaume 84 d'Augustin (4 l. du ch.10, f. 53r)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053r.json"
+             ]
+        },
+        {
+            "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/range/r16-7",
+            "@type": "sc:Range",
+            "label": "Diverses inscriptions et dessins à la plume (f.53r-53v)",
+            "canvases": [
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053r.json",
+                "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053v.json"
+             ]
+        }
+    ],
+    "sequences": [{
+        "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/sequence/normal",
+        "@type": "sc:Sequence",
+        "label": "Normal",
+        "canvases": [
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f13",
+                "@type": "sc:Canvas",
+                "label": "2r (31r)",
+                "width": 4396,
+                "height": 6197,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f13.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f13"
+                        },
+                        "width": 4396,
+                        "height": 6197
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f13"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f14",
+                "@type": "sc:Canvas",
+                "label": "2v (31v)",
+                "width": 4436,
+                "height": 6221,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f14.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f14"
+                        },
+                        "width": 4436,
+                        "height": 6221
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f14"
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-1",
+                "@type": "sc:Canvas",
+                "label": "Lacune (32r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-2",
+                "@type": "sc:Canvas",
+                "label": "Lacune (32v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-3",
+                "@type": "sc:Canvas",
+                "label": "Lacune (33r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-4",
+                "@type": "sc:Canvas",
+                "label": "Lacune (33v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-5",
+                "@type": "sc:Canvas",
+                "label": "Lacune (34r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-6",
+                "@type": "sc:Canvas",
+                "label": "Lacune (34v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-7",
+                "@type": "sc:Canvas",
+                "label": "Lacune (35r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-8",
+                "@type": "sc:Canvas",
+                "label": "Lacune (35v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-9",
+                "@type": "sc:Canvas",
+                "label": "Lacune (36r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-10",
+                "@type": "sc:Canvas",
+                "label": "Lacune (36v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-11",
+                "@type": "sc:Canvas",
+                "label": "Lacune (37r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-12",
+                "@type": "sc:Canvas",
+                "label": "Lacune (37v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-13",
+                "@type": "sc:Canvas",
+                "label": "Lacune (38r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-14",
+                "@type": "sc:Canvas",
+                "label": "Lacune (38v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-15",
+                "@type": "sc:Canvas",
+                "label": "Lacune (39r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-16",
+                "@type": "sc:Canvas",
+                "label": "Lacune (39v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f11",
+                "@type": "sc:Canvas",
+                "label": "1r (40r)",
+                "width": 4396,
+                "height": 6197,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f11.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f11"
+                        },
+                        "width": 4396,
+                        "height": 6197
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f11"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f12",
+                "@type": "sc:Canvas",
+                "label": "1v (40v)",
+                "width": 4436,
+                "height": 6221,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f12.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f12"
+                        },
+                        "width": 4436,
+                        "height": 6221
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f12"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f15",
+                "@type": "sc:Canvas",
+                "label": "3r (41r)",
+                "width": 4396,
+                "height": 6197,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f15.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f15"
+                        },
+                        "width": 4396,
+                        "height": 6197
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f15"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f16",
+                "@type": "sc:Canvas",
+                "label": "3v (41v)",
+                "width": 4405,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f16.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f16"
+                        },
+                        "width": 4405,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f16"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f17",
+                "@type": "sc:Canvas",
+                "label": "4r (42r)",
+                "width": 4413,
+                "height": 6172,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f17.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f17"
+                        },
+                        "width": 4413,
+                        "height": 6172
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f17"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f18",
+                "@type": "sc:Canvas",
+                "label": "4v (42v)",
+                "width": 4405,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f18.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f18"
+                        },
+                        "width": 4405,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f18"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f19",
+                "@type": "sc:Canvas",
+                "label": "5r (43r)",
+                "width": 4413,
+                "height": 6191,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f19.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f19"
+                        },
+                        "width": 4413,
+                        "height": 6191
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f19"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f20",
+                "@type": "sc:Canvas",
+                "label": "5v (43v)",
+                "width": 4379,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f20.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f20"
+                        },
+                        "width": 4379,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f20"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f21",
+                "@type": "sc:Canvas",
+                "label": "6r (44r)",
+                "width": 4413,
+                "height": 6197,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f21.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f21"
+                        },
+                        "width": 4413,
+                        "height": 6197
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f21"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f22",
+                "@type": "sc:Canvas",
+                "label": "6v (44v)",
+                "width": 4379,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f22.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f22"
+                        },
+                        "width": 4379,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f22"
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-17",
+                "@type": "sc:Canvas",
+                "label": "Lacune (45r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-18",
+                "@type": "sc:Canvas",
+                "label": "Lacune (45v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-19",
+                "@type": "sc:Canvas",
+                "label": "Lacune (46r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-20",
+                "@type": "sc:Canvas",
+                "label": "Lacune (46v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f23",
+                "@type": "sc:Canvas",
+                "label": "7r (47r)",
+                "width": 4417,
+                "height": 6214,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f23.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f23"
+                        },
+                        "width": 4417,
+                        "height": 6214
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f23"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f24",
+                "@type": "sc:Canvas",
+                "label": "7v (47v)",
+                "width": 4379,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f24.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f24"
+                        },
+                        "width": 4379,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f24"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f25",
+                "@type": "sc:Canvas",
+                "label": "8r (48r)",
+                "width": 4397,
+                "height": 6214,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f25.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f25"
+                        },
+                        "width": 4397,
+                        "height": 6214
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f25"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f26",
+                "@type": "sc:Canvas",
+                "label": "8v (48v)",
+                "width": 4379,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f26.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f26"
+                        },
+                        "width": 4379,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f26"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f27",
+                "@type": "sc:Canvas",
+                "label": "9r (49r)",
+                "width": 4380,
+                "height": 6191,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f27.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f27"
+                        },
+                        "width": 4380,
+                        "height": 6191
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f27"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f28",
+                "@type": "sc:Canvas",
+                "label": "9v (49v)",
+                "width": 4365,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f28.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f28"
+                        },
+                        "width": 4365,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f28"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f29",
+                "@type": "sc:Canvas",
+                "label": "10r (50r)",
+                "width": 4345,
+                "height": 6182,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f29.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f29"
+                        },
+                        "width": 4345,
+                        "height": 6182
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f29"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f30",
+                "@type": "sc:Canvas",
+                "label": "10v (50v)",
+                "width": 4317,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f30.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f30"
+                        },
+                        "width": 4317,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f30"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f31",
+                "@type": "sc:Canvas",
+                "label": "11r (51r)",
+                "width": 4286,
+                "height": 6162,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f31.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f31"
+                        },
+                        "width": 4286,
+                        "height": 6162
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f31"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f32",
+                "@type": "sc:Canvas",
+                "label": "11v (51v)",
+                "width": 4292,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f32.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f32"
+                        },
+                        "width": 4292,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f32"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f33",
+                "@type": "sc:Canvas",
+                "label": "12r (52r)",
+                "width": 4368,
+                "height": 6173,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f33.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f33"
+                        },
+                        "width": 4368,
+                        "height": 6173
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f33"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f34",
+                "@type": "sc:Canvas",
+                "label": "12v (52v)",
+                "width": 4311,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f34.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f34"
+                        },
+                        "width": 4311,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f34"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f35",
+                "@type": "sc:Canvas",
+                "label": "13r (53r)",
+                "width": 4330,
+                "height": 6193,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f35.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f35"
+                        },
+                        "width": 4330,
+                        "height": 6193
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f35"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f36",
+                "@type": "sc:Canvas",
+                "label": "13v (53v)",
+                "width": 4311,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f36.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f36"
+                        },
+                        "width": 4311,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f36"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f37",
+                "@type": "sc:Canvas",
+                "label": "14r (54r)",
+                "width": 4361,
+                "height": 6163,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f37.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f37"
+                        },
+                        "width": 4361,
+                        "height": 6163
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f37"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f38",
+                "@type": "sc:Canvas",
+                "label": "14v (54v)",
+                "width": 4288,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f38.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f38"
+                        },
+                        "width": 4288,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f38"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f39",
+                "@type": "sc:Canvas",
+                "label": "15r (55r)",
+                "width": 4313,
+                "height": 6163,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f39.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f39"
+                        },
+                        "width": 4313,
+                        "height": 6163
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f39"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f40",
+                "@type": "sc:Canvas",
+                "label": "15v (55v)",
+                "width": 4254,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f40.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f40"
+                        },
+                        "width": 4254,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f40"
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-21",
+                "@type": "sc:Canvas",
+                "label": "Lacune (56r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-22",
+                "@type": "sc:Canvas",
+                "label": "Lacune (56v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f41",
+                "@type": "sc:Canvas",
+                "label": "16r (57r)",
+                "width": 4313,
+                "height": 6148,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f41.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f41"
+                        },
+                        "width": 4313,
+                        "height": 6148
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f41"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f42",
+                "@type": "sc:Canvas",
+                "label": "16v (57v)",
+                "width": 4254,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f42.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f42"
+                        },
+                        "width": 4254,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f42"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f43",
+                "@type": "sc:Canvas",
+                "label": "17r (58r)",
+                "width": 4274,
+                "height": 6171,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f43.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f43"
+                        },
+                        "width": 4274,
+                        "height": 6171
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f43"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f44",
+                "@type": "sc:Canvas",
+                "label": "17v (58v)",
+                "width": 4254,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f44.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f44"
+                        },
+                        "width": 4254,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f44"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f45",
+                "@type": "sc:Canvas",
+                "label": "NP",
+                "width": 4275,
+                "height": 6171,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f45.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f45"
+                        },
+                        "width": 4275,
+                        "height": 6171
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f45"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f46",
+                "@type": "sc:Canvas",
+                "label": "NP",
+                "width": 4274,
+                "height": 6240,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f46.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f46"
+                        },
+                        "width": 4274,
+                        "height": 6240
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f46"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f47",
+                "@type": "sc:Canvas",
+                "label": "18r (59r)",
+                "width": 4286,
+                "height": 6166,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f47.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f47"
+                        },
+                        "width": 4286,
+                        "height": 6166
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f47"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f48",
+                "@type": "sc:Canvas",
+                "label": "18v (59v)",
+                "width": 4249,
+                "height": 6235,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f48.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f48"
+                        },
+                        "width": 4249,
+                        "height": 6235
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f48"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f49",
+                "@type": "sc:Canvas",
+                "label": "19r (60r)",
+                "width": 4263,
+                "height": 6130,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f49.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f49"
+                        },
+                        "width": 4263,
+                        "height": 6130
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f49"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f50",
+                "@type": "sc:Canvas",
+                "label": "19v (60v)",
+                "width": 4239,
+                "height": 6221,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f50.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f50"
+                        },
+                        "width": 4239,
+                        "height": 6221
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f50"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f51",
+                "@type": "sc:Canvas",
+                "label": "20r (61r)",
+                "width": 4236,
+                "height": 6162,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f51.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f51"
+                        },
+                        "width": 4236,
+                        "height": 6162
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f51"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f52",
+                "@type": "sc:Canvas",
+                "label": "20v (61v)",
+                "width": 4239,
+                "height": 6221,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f52.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f52"
+                        },
+                        "width": 4239,
+                        "height": 6221
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f52"
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-23",
+                "@type": "sc:Canvas",
+                "label": "Lacune (62r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-24",
+                "@type": "sc:Canvas",
+                "label": "Lacune (62v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-25",
+                "@type": "sc:Canvas",
+                "label": "Lacune (63r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-26",
+                "@type": "sc:Canvas",
+                "label": "Lacune (63v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f53",
+                "@type": "sc:Canvas",
+                "label": "21r (64r)",
+                "width": 4265,
+                "height": 6157,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f53.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f53"
+                        },
+                        "width": 4265,
+                        "height": 6157
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f53"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f54",
+                "@type": "sc:Canvas",
+                "label": "21v (64v)",
+                "width": 4239,
+                "height": 6269,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f54.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f54"
+                        },
+                        "width": 4239,
+                        "height": 6269
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f54"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f55",
+                "@type": "sc:Canvas",
+                "label": "22r (65r)",
+                "width": 4306,
+                "height": 6197,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f55.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f55"
+                        },
+                        "width": 4306,
+                        "height": 6197
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f55"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f56",
+                "@type": "sc:Canvas",
+                "label": "22v (65v)",
+                "width": 4211,
+                "height": 6217,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f56.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f56"
+                        },
+                        "width": 4211,
+                        "height": 6217
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f56"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f57",
+                "@type": "sc:Canvas",
+                "label": "23r (66r)",
+                "width": 4286,
+                "height": 6162,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f57.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f57"
+                        },
+                        "width": 4286,
+                        "height": 6162
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f57"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f58",
+                "@type": "sc:Canvas",
+                "label": "23v (66v)",
+                "width": 4202,
+                "height": 6217,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f58.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f58"
+                        },
+                        "width": 4202,
+                        "height": 6217
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f58"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f59",
+                "@type": "sc:Canvas",
+                "label": "24r (67r)",
+                "width": 4262,
+                "height": 6162,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f59.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f59"
+                        },
+                        "width": 4262,
+                        "height": 6162
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f59"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f60",
+                "@type": "sc:Canvas",
+                "label": "24v (67v)",
+                "width": 4185,
+                "height": 6210,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f60.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f60"
+                        },
+                        "width": 4185,
+                        "height": 6210
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f60"
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-27",
+                "@type": "sc:Canvas",
+                "label": "Lacune (68r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-28",
+                "@type": "sc:Canvas",
+                "label": "Lacune (68v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-29",
+                "@type": "sc:Canvas",
+                "label": "Lacune (69r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-30",
+                "@type": "sc:Canvas",
+                "label": "Lacune (69v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f61",
+                "@type": "sc:Canvas",
+                "label": "25r (70r)",
+                "width": 4276,
+                "height": 6140,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f61.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f61"
+                        },
+                        "width": 4276,
+                        "height": 6140
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f61"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f62",
+                "@type": "sc:Canvas",
+                "label": "25v (70v)",
+                "width": 4152,
+                "height": 6210,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f62.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f62"
+                        },
+                        "width": 4152,
+                        "height": 6210
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f62"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f63",
+                "@type": "sc:Canvas",
+                "label": "26r (71r)",
+                "width": 4288,
+                "height": 6194,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f63.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f63"
+                        },
+                        "width": 4288,
+                        "height": 6194
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f63"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f64",
+                "@type": "sc:Canvas",
+                "label": "26v (71v)",
+                "width": 4128,
+                "height": 6210,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f64.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f64"
+                        },
+                        "width": 4128,
+                        "height": 6210
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f64"
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_a.json",
+                "@type": "sc:Canvas",
+                "label": "a (72r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/nlr-lat-F-I-1_a.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_a.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/nlr/nlr-lat-F-I-1/nlr-lat-F-I-1_a.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/nlr/nlr-lat-F-I-1/nlr-lat-F-I-1_a.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_b.json",
+                "@type": "sc:Canvas",
+                "label": "b (72v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/nlr-lat-F-I-1_b.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/nlr-lat-F-I-1_b.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/nlr/nlr-lat-F-I-1/nlr-lat-F-I-1_b.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/nlr/nlr-lat-F-I-1/nlr-lat-F-I-1_b.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f65",
+                "@type": "sc:Canvas",
+                "label": "27r (73r)",
+                "width": 4340,
+                "height": 6194,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f65.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f65"
+                        },
+                        "width": 4340,
+                        "height": 6194
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f65"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f66",
+                "@type": "sc:Canvas",
+                "label": "27v (73v)",
+                "width": 4176,
+                "height": 6210,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f66.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f66"
+                        },
+                        "width": 4176,
+                        "height": 6210
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f66"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f67",
+                "@type": "sc:Canvas",
+                "label": "28r (74r)",
+                "width": 4375,
+                "height": 6243,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f67.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f67"
+                        },
+                        "width": 4375,
+                        "height": 6243
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f67"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f68",
+                "@type": "sc:Canvas",
+                "label": "28v (74v)",
+                "width": 4160,
+                "height": 6242,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f68.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f68"
+                        },
+                        "width": 4160,
+                        "height": 6242
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f68"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f69",
+                "@type": "sc:Canvas",
+                "label": "29r (75r)",
+                "width": 4359,
+                "height": 6243,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f69.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f69"
+                        },
+                        "width": 4359,
+                        "height": 6243
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f69"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f70",
+                "@type": "sc:Canvas",
+                "label": "29v (75v)",
+                "width": 4160,
+                "height": 6242,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f70.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f70"
+                        },
+                        "width": 4160,
+                        "height": 6242
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f70"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f71",
+                "@type": "sc:Canvas",
+                "label": "30r (76r)",
+                "width": 4308,
+                "height": 6207,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f71.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f71"
+                        },
+                        "width": 4308,
+                        "height": 6207
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f71"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f72",
+                "@type": "sc:Canvas",
+                "label": "30v (76v)",
+                "width": 4160,
+                "height": 6234,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f72.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f72"
+                        },
+                        "width": 4160,
+                        "height": 6234
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f72"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f73",
+                "@type": "sc:Canvas",
+                "label": "31r (77r)",
+                "width": 4339,
+                "height": 6207,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f73.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f73"
+                        },
+                        "width": 4339,
+                        "height": 6207
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f73"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f74",
+                "@type": "sc:Canvas",
+                "label": "31v (77v)",
+                "width": 4160,
+                "height": 6209,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f74.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f74"
+                        },
+                        "width": 4160,
+                        "height": 6209
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f74"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f75",
+                "@type": "sc:Canvas",
+                "label": "32r (78r)",
+                "width": 4339,
+                "height": 6207,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f75.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f75"
+                        },
+                        "width": 4339,
+                        "height": 6207
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f75"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f76",
+                "@type": "sc:Canvas",
+                "label": "32v (78v)",
+                "width": 4136,
+                "height": 6192,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f76.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f76"
+                        },
+                        "width": 4136,
+                        "height": 6192
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f76"
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-31",
+                "@type": "sc:Canvas",
+                "label": "Lacune (79r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-32",
+                "@type": "sc:Canvas",
+                "label": "Lacune (79v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f77",
+                "@type": "sc:Canvas",
+                "label": "33r (80r)",
+                "width": 4321,
+                "height": 6197,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f77.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f77"
+                        },
+                        "width": 4321,
+                        "height": 6197
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f77"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f78",
+                "@type": "sc:Canvas",
+                "label": "33v (80v)",
+                "width": 4104,
+                "height": 6166,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f78.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f78"
+                        },
+                        "width": 4104,
+                        "height": 6166
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f78"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f79",
+                "@type": "sc:Canvas",
+                "label": "34r (81r)",
+                "width": 4321,
+                "height": 6197,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f79.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f79"
+                        },
+                        "width": 4321,
+                        "height": 6197
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f79"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f80",
+                "@type": "sc:Canvas",
+                "label": "34v (81v)",
+                "width": 4136,
+                "height": 6224,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f80.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f80"
+                        },
+                        "width": 4136,
+                        "height": 6224
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f80"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f81",
+                "@type": "sc:Canvas",
+                "label": "35r (82r)",
+                "width": 4289,
+                "height": 6150,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f81.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f81"
+                        },
+                        "width": 4289,
+                        "height": 6150
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f81"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f82",
+                "@type": "sc:Canvas",
+                "label": "35v (82v)",
+                "width": 4299,
+                "height": 6188,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f82.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f82"
+                        },
+                        "width": 4299,
+                        "height": 6188
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f82"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f83",
+                "@type": "sc:Canvas",
+                "label": "36r (83r)",
+                "width": 4331,
+                "height": 6200,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f83.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f83"
+                        },
+                        "width": 4331,
+                        "height": 6200
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f83"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f84",
+                "@type": "sc:Canvas",
+                "label": "36v (83v)",
+                "width": 4306,
+                "height": 6211,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f84.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f84"
+                        },
+                        "width": 4306,
+                        "height": 6211
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f84"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f85",
+                "@type": "sc:Canvas",
+                "label": "37r (84r)",
+                "width": 4310,
+                "height": 6200,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f85.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f85"
+                        },
+                        "width": 4310,
+                        "height": 6200
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f85"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f86",
+                "@type": "sc:Canvas",
+                "label": "37v (84v)",
+                "width": 4327,
+                "height": 6233,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f86.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f86"
+                        },
+                        "width": 4327,
+                        "height": 6233
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f86"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f87",
+                "@type": "sc:Canvas",
+                "label": "38r (85r)",
+                "width": 4310,
+                "height": 6200,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f87.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f87"
+                        },
+                        "width": 4310,
+                        "height": 6200
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f87"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f88",
+                "@type": "sc:Canvas",
+                "label": "38v (85v)",
+                "width": 4334,
+                "height": 6245,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f88.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f88"
+                        },
+                        "width": 4334,
+                        "height": 6245
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f88"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f89",
+                "@type": "sc:Canvas",
+                "label": "39r (86r)",
+                "width": 4328,
+                "height": 6233,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f89.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f89"
+                        },
+                        "width": 4328,
+                        "height": 6233
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f89"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f90",
+                "@type": "sc:Canvas",
+                "label": "39v (86v)",
+                "width": 4344,
+                "height": 6237,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f90.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f90"
+                        },
+                        "width": 4344,
+                        "height": 6237
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f90"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f91",
+                "@type": "sc:Canvas",
+                "label": "40r (87r)",
+                "width": 4337,
+                "height": 6221,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f91.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f91"
+                        },
+                        "width": 4337,
+                        "height": 6221
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f91"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f92",
+                "@type": "sc:Canvas",
+                "label": "40v (87v)",
+                "width": 4340,
+                "height": 6217,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f92.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f92"
+                        },
+                        "width": 4340,
+                        "height": 6217
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f92"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f93",
+                "@type": "sc:Canvas",
+                "label": "41r (88r)",
+                "width": 4337,
+                "height": 6201,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f93.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f93"
+                        },
+                        "width": 4337,
+                        "height": 6201
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f93"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f94",
+                "@type": "sc:Canvas",
+                "label": "41v (88v)",
+                "width": 4348,
+                "height": 6271,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f94.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f94"
+                        },
+                        "width": 4348,
+                        "height": 6271
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f94"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f95",
+                "@type": "sc:Canvas",
+                "label": "42r (89r)",
+                "width": 4372,
+                "height": 6201,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f95.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f95"
+                        },
+                        "width": 4372,
+                        "height": 6201
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f95"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f96",
+                "@type": "sc:Canvas",
+                "label": "42v (89v)",
+                "width": 4348,
+                "height": 6271,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f96.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f96"
+                        },
+                        "width": 4348,
+                        "height": 6271
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f96"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f97",
+                "@type": "sc:Canvas",
+                "label": "43r (90r)",
+                "width": 4329,
+                "height": 6178,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f97.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f97"
+                        },
+                        "width": 4329,
+                        "height": 6178
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f97"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f98",
+                "@type": "sc:Canvas",
+                "label": "43v (90v)",
+                "width": 4348,
+                "height": 6222,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f98.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f98"
+                        },
+                        "width": 4348,
+                        "height": 6222
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f98"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f99",
+                "@type": "sc:Canvas",
+                "label": "44r (91r)",
+                "width": 4304,
+                "height": 6175,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f99.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f99"
+                        },
+                        "width": 4304,
+                        "height": 6175
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f99"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f100",
+                "@type": "sc:Canvas",
+                "label": "44v (91v)",
+                "width": 4373,
+                "height": 6222,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f100.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f100"
+                        },
+                        "width": 4373,
+                        "height": 6222
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f100"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f101",
+                "@type": "sc:Canvas",
+                "label": "45r (92r)",
+                "width": 4333,
+                "height": 6173,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f101.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f101"
+                        },
+                        "width": 4333,
+                        "height": 6173
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f101"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f102",
+                "@type": "sc:Canvas",
+                "label": "45v (92v)",
+                "width": 4379,
+                "height": 6280,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f102.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f102"
+                        },
+                        "width": 4379,
+                        "height": 6280
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f102"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f103",
+                "@type": "sc:Canvas",
+                "label": "46r (93r)",
+                "width": 4292,
+                "height": 6199,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f103.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f103"
+                        },
+                        "width": 4292,
+                        "height": 6199
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f103"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f104",
+                "@type": "sc:Canvas",
+                "label": "46v (93v)",
+                "width": 4353,
+                "height": 6271,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f104.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f104"
+                        },
+                        "width": 4353,
+                        "height": 6271
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f104"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f105",
+                "@type": "sc:Canvas",
+                "label": "47r (94r)",
+                "width": 4312,
+                "height": 6203,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f105.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f105"
+                        },
+                        "width": 4312,
+                        "height": 6203
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f105"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f106",
+                "@type": "sc:Canvas",
+                "label": "47v (94v)",
+                "width": 4353,
+                "height": 6256,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f106.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f106"
+                        },
+                        "width": 4353,
+                        "height": 6256
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f106"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f107",
+                "@type": "sc:Canvas",
+                "label": "48r (95r)",
+                "width": 4312,
+                "height": 6203,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f107.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f107"
+                        },
+                        "width": 4312,
+                        "height": 6203
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f107"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f108",
+                "@type": "sc:Canvas",
+                "label": "48v (95v)",
+                "width": 4353,
+                "height": 6282,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f108.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f108"
+                        },
+                        "width": 4353,
+                        "height": 6282
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f108"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f109",
+                "@type": "sc:Canvas",
+                "label": "49r (96r)",
+                "width": 4388,
+                "height": 6271,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f109.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f109"
+                        },
+                        "width": 4388,
+                        "height": 6271
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f109"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f110",
+                "@type": "sc:Canvas",
+                "label": "49v (96v)",
+                "width": 4365,
+                "height": 6273,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f110.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f110"
+                        },
+                        "width": 4365,
+                        "height": 6273
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f110"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f111",
+                "@type": "sc:Canvas",
+                "label": "50r (97r)",
+                "width": 4371,
+                "height": 6255,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f111.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f111"
+                        },
+                        "width": 4371,
+                        "height": 6255
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f111"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f112",
+                "@type": "sc:Canvas",
+                "label": "50v (97v)",
+                "width": 4353,
+                "height": 6248,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f112.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f112"
+                        },
+                        "width": 4353,
+                        "height": 6248
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f112"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f113",
+                "@type": "sc:Canvas",
+                "label": "51r (98r)",
+                "width": 4371,
+                "height": 6255,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f113.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f113"
+                        },
+                        "width": 4371,
+                        "height": 6255
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f113"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f114",
+                "@type": "sc:Canvas",
+                "label": "51v (98v)",
+                "width": 4372,
+                "height": 6265,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f114.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f114"
+                        },
+                        "width": 4372,
+                        "height": 6265
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f114"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f115",
+                "@type": "sc:Canvas",
+                "label": "52r (99r)",
+                "width": 4385,
+                "height": 6261,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f115.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f115"
+                        },
+                        "width": 4385,
+                        "height": 6261
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f115"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f116",
+                "@type": "sc:Canvas",
+                "label": "52v (99v)",
+                "width": 4372,
+                "height": 6265,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f116.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f116"
+                        },
+                        "width": 4372,
+                        "height": 6265
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f116"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f117",
+                "@type": "sc:Canvas",
+                "label": "53r (100r)",
+                "width": 4367,
+                "height": 6256,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f117.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f117"
+                        },
+                        "width": 4367,
+                        "height": 6256
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f117"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f118",
+                "@type": "sc:Canvas",
+                "label": "53v (100v)",
+                "width": 4348,
+                "height": 6265,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f118.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f118"
+                        },
+                        "width": 4348,
+                        "height": 6265
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f118"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f119",
+                "@type": "sc:Canvas",
+                "label": "54r (101r)",
+                "width": 4367,
+                "height": 6182,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f119.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f119"
+                        },
+                        "width": 4367,
+                        "height": 6182
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f119"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f120",
+                "@type": "sc:Canvas",
+                "label": "54v (101v)",
+                "width": 4348,
+                "height": 6238,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f120.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f120"
+                        },
+                        "width": 4348,
+                        "height": 6238
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f120"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f121",
+                "@type": "sc:Canvas",
+                "label": "55r (102r)",
+                "width": 4371,
+                "height": 6255,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f121.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f121"
+                        },
+                        "width": 4371,
+                        "height": 6255
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f121"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f122",
+                "@type": "sc:Canvas",
+                "label": "55v (102v)",
+                "width": 4348,
+                "height": 6216,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f122.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f122"
+                        },
+                        "width": 4348,
+                        "height": 6216
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f122"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f123",
+                "@type": "sc:Canvas",
+                "label": "56r (103r)",
+                "width": 4371,
+                "height": 6230,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f123.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f123"
+                        },
+                        "width": 4371,
+                        "height": 6230
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f123"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f124",
+                "@type": "sc:Canvas",
+                "label": "56v (103v)",
+                "width": 4382,
+                "height": 6256,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f124.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f124"
+                        },
+                        "width": 4382,
+                        "height": 6256
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f124"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f125",
+                "@type": "sc:Canvas",
+                "label": "57r (104r)",
+                "width": 4407,
+                "height": 6230,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f125.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f125"
+                        },
+                        "width": 4407,
+                        "height": 6230
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f125"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f126",
+                "@type": "sc:Canvas",
+                "label": "57v (104v)",
+                "width": 4382,
+                "height": 6256,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f126.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f126"
+                        },
+                        "width": 4382,
+                        "height": 6256
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f126"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f127",
+                "@type": "sc:Canvas",
+                "label": "58r (105r)",
+                "width": 4409,
+                "height": 6254,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f127.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f127"
+                        },
+                        "width": 4409,
+                        "height": 6254
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f127"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f128",
+                "@type": "sc:Canvas",
+                "label": "58v (105v)",
+                "width": 4382,
+                "height": 6256,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f128.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f128"
+                        },
+                        "width": 4382,
+                        "height": 6256
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f128"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f129",
+                "@type": "sc:Canvas",
+                "label": "59r (106r)",
+                "width": 4399,
+                "height": 6255,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f129.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f129"
+                        },
+                        "width": 4399,
+                        "height": 6255
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f129"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f130",
+                "@type": "sc:Canvas",
+                "label": "59v (106v)",
+                "width": 4382,
+                "height": 6256,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f130.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f130"
+                        },
+                        "width": 4382,
+                        "height": 6256
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f130"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f131",
+                "@type": "sc:Canvas",
+                "label": "60r (107r)",
+                "width": 4407,
+                "height": 6223,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f131.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f131"
+                        },
+                        "width": 4407,
+                        "height": 6223
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f131"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f132",
+                "@type": "sc:Canvas",
+                "label": "60v (107v)",
+                "width": 4382,
+                "height": 6229,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f132.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f132"
+                        },
+                        "width": 4382,
+                        "height": 6229
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f132"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f133",
+                "@type": "sc:Canvas",
+                "label": "61r (108r)",
+                "width": 4404,
+                "height": 6233,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f133.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f133"
+                        },
+                        "width": 4404,
+                        "height": 6233
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f133"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f134",
+                "@type": "sc:Canvas",
+                "label": "61v (108v)",
+                "width": 4391,
+                "height": 6229,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f134.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f134"
+                        },
+                        "width": 4391,
+                        "height": 6229
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f134"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f135",
+                "@type": "sc:Canvas",
+                "label": "62r (109r)",
+                "width": 4436,
+                "height": 6199,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f135.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f135"
+                        },
+                        "width": 4436,
+                        "height": 6199
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f135"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f136",
+                "@type": "sc:Canvas",
+                "label": "62v (109v)",
+                "width": 4411,
+                "height": 6250,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f136.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f136"
+                        },
+                        "width": 4411,
+                        "height": 6250
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f136"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f137",
+                "@type": "sc:Canvas",
+                "label": "63r (110r)",
+                "width": 4422,
+                "height": 6148,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f137.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f137"
+                        },
+                        "width": 4422,
+                        "height": 6148
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f137"
+                }]
+            },
+            {
+                "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f138",
+                "@type": "sc:Canvas",
+                "label": "63v (110v)",
+                "width": 4421,
+                "height": 6191,
+                "images": [{
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "resource": {
+                        "@id": "https://gallica.bnf.fr/ark:/12148/btv1b8438674r/f138.highres",
+                        "format": "image/jpg",
+                        "@type": "dctypes:Image",
+                        "service": {
+                            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+                            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+                            "@id": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/f138"
+                        },
+                        "width": 4421,
+                        "height": 6191
+                    },
+                    "on": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b8438674r/canvas/f138"
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001r.json",
+                "@type": "sc:Canvas",
+                "label": "1r (221r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_001r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_001r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_001r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001v.json",
+                "@type": "sc:Canvas",
+                "label": "1v (221v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_001v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_001v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_001v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_001v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002ar.json",
+                "@type": "sc:Canvas",
+                "label": "2ar (222r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_002ar.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002ar.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002ar.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002ar.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002av.json",
+                "@type": "sc:Canvas",
+                "label": "2av (222v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_002av.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002av.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002av.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002av.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-33",
+                "@type": "sc:Canvas",
+                "label": "Lacune (223r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-34",
+                "@type": "sc:Canvas",
+                "label": "Lacune (223v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-35",
+                "@type": "sc:Canvas",
+                "label": "Lacune (224r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-36",
+                "@type": "sc:Canvas",
+                "label": "Lacune (224v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-37",
+                "@type": "sc:Canvas",
+                "label": "Lacune (225r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-38",
+                "@type": "sc:Canvas",
+                "label": "Lacune (225v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-39",
+                "@type": "sc:Canvas",
+                "label": "Lacune (226r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-40",
+                "@type": "sc:Canvas",
+                "label": "Lacune (226v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-41",
+                "@type": "sc:Canvas",
+                "label": "Lacune (227r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-42",
+                "@type": "sc:Canvas",
+                "label": "Lacune (227v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-43",
+                "@type": "sc:Canvas",
+                "label": "Lacune (228r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-44",
+                "@type": "sc:Canvas",
+                "label": "Lacune (228v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002r.json",
+                "@type": "sc:Canvas",
+                "label": "2r (229r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_002r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002v.json",
+                "@type": "sc:Canvas",
+                "label": "2v (229v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_002v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_002v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_002v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003r.json",
+                "@type": "sc:Canvas",
+                "label": "3r (230r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_003r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_003r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_003r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003v.json",
+                "@type": "sc:Canvas",
+                "label": "3v (230v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_003v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_003v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_003v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_003v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004r.json",
+                "@type": "sc:Canvas",
+                "label": "4r (231r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_004r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_004r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_004r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004v.json",
+                "@type": "sc:Canvas",
+                "label": "4v (231v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_004v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_004v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_004v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_004v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-45",
+                "@type": "sc:Canvas",
+                "label": "Lacune (232r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-46",
+                "@type": "sc:Canvas",
+                "label": "Lacune (232v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005r.json",
+                "@type": "sc:Canvas",
+                "label": "5r (233r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_005r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_005r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_005r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005v.json",
+                "@type": "sc:Canvas",
+                "label": "5v (233v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_005v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_005v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_005v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_005v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-47",
+                "@type": "sc:Canvas",
+                "label": "Lacune (234r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-48",
+                "@type": "sc:Canvas",
+                "label": "Lacune (234v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006r.json",
+                "@type": "sc:Canvas",
+                "label": "6r (235r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_006r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_006r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_006r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006v.json",
+                "@type": "sc:Canvas",
+                "label": "6v (235v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_006v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_006v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_006v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_006v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007r.json",
+                "@type": "sc:Canvas",
+                "label": "7r (236r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_007r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_007r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_007r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007v.json",
+                "@type": "sc:Canvas",
+                "label": "7v (236v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_007v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_007v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_007v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_007v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-49",
+                "@type": "sc:Canvas",
+                "label": "Lacune (237r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-50",
+                "@type": "sc:Canvas",
+                "label": "Lacune (237v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008r.json",
+                "@type": "sc:Canvas",
+                "label": "8r (238r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_008r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_008r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_008r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008v.json",
+                "@type": "sc:Canvas",
+                "label": "8v (238v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_008v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_008v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_008v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_008v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-51",
+                "@type": "sc:Canvas",
+                "label": "Lacune (239r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-52",
+                "@type": "sc:Canvas",
+                "label": "Lacune (239v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_010r.json",
+                "@type": "sc:Canvas",
+                "label": "10r (240r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_010r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_010r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_010r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_010r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_010v.json",
+                "@type": "sc:Canvas",
+                "label": "10v (240v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_010v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_010v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_010v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_010v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011r.json",
+                "@type": "sc:Canvas",
+                "label": "11r (241r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_011r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_011r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_011r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011v.json",
+                "@type": "sc:Canvas",
+                "label": "11v (241v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_011v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_011v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_011v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_011v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-53",
+                "@type": "sc:Canvas",
+                "label": "Lacune (242r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-54",
+                "@type": "sc:Canvas",
+                "label": "Lacune (242v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012r.json",
+                "@type": "sc:Canvas",
+                "label": "12r (243r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_012r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_012r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_012r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012v.json",
+                "@type": "sc:Canvas",
+                "label": "12v (243v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_012v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_012v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_012v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_012v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013r.json",
+                "@type": "sc:Canvas",
+                "label": "13r (244r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_013r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_013r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_013r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013v.json",
+                "@type": "sc:Canvas",
+                "label": "13v (244v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_013v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_013v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_013v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_013v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009r.json",
+                "@type": "sc:Canvas",
+                "label": "9r (245r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_009r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_009r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_009r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009v.json",
+                "@type": "sc:Canvas",
+                "label": "9v (245v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_009v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_009v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_009v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_009v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-55",
+                "@type": "sc:Canvas",
+                "label": "Lacune (246r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-56",
+                "@type": "sc:Canvas",
+                "label": "Lacune (246v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014r.json",
+                "@type": "sc:Canvas",
+                "label": "14r (247r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_014r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_014r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_014r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014v.json",
+                "@type": "sc:Canvas",
+                "label": "14v (247v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_014v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_014v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_014v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_014v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015r.json",
+                "@type": "sc:Canvas",
+                "label": "15r (248r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_015r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_015r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_015r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015v.json",
+                "@type": "sc:Canvas",
+                "label": "15v (248v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_015v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_015v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_015v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_015v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-57",
+                "@type": "sc:Canvas",
+                "label": "Lacune (249r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-58",
+                "@type": "sc:Canvas",
+                "label": "Lacune (249v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_016r.json",
+                "@type": "sc:Canvas",
+                "label": "16r (250r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_016r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_016r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_016r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_016r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_016v.json",
+                "@type": "sc:Canvas",
+                "label": "16v (250v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_016v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_016v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_016v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_016v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017r.json",
+                "@type": "sc:Canvas",
+                "label": "17r (251r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_017r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_017r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_017r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017v.json",
+                "@type": "sc:Canvas",
+                "label": "17v (251v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_017v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_017v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_017v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_017v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018r.json",
+                "@type": "sc:Canvas",
+                "label": "18r (252r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_018r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_018r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_018r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018v.json",
+                "@type": "sc:Canvas",
+                "label": "18v (252v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_018v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_018v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_018v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_018v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019r.json",
+                "@type": "sc:Canvas",
+                "label": "19r (253r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_019r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_019r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_019r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019v.json",
+                "@type": "sc:Canvas",
+                "label": "19v (253v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_019v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_019v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_019v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_019v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020r.json",
+                "@type": "sc:Canvas",
+                "label": "20r (254r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_020r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_020r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_020r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020v.json",
+                "@type": "sc:Canvas",
+                "label": "20v (254v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_020v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_020v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_020v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_020v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021r.json",
+                "@type": "sc:Canvas",
+                "label": "21r (255r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_021r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_021r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_021r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021v.json",
+                "@type": "sc:Canvas",
+                "label": "21v (255v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_021v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_021v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_021v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_021v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022r.json",
+                "@type": "sc:Canvas",
+                "label": "22r (256r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_022r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_022r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_022r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022v.json",
+                "@type": "sc:Canvas",
+                "label": "22v (256v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_022v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_022v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_022v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_022v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-59",
+                "@type": "sc:Canvas",
+                "label": "Lacune (257r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-60",
+                "@type": "sc:Canvas",
+                "label": "Lacune (257v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023r.json",
+                "@type": "sc:Canvas",
+                "label": "23r (258r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_023r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_023r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_023r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023v.json",
+                "@type": "sc:Canvas",
+                "label": "23v (258v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_023v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_023v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_023v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_023v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024r.json",
+                "@type": "sc:Canvas",
+                "label": "24r (259r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_024r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_024r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_024r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024v.json",
+                "@type": "sc:Canvas",
+                "label": "24v (259v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_024v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_024v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_024v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_024v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025r.json",
+                "@type": "sc:Canvas",
+                "label": "25r (260r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_025r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_025r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_025r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025v.json",
+                "@type": "sc:Canvas",
+                "label": "25v (260v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_025v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_025v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_025v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_025v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026r.json",
+                "@type": "sc:Canvas",
+                "label": "26r (261r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_026r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_026r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_026r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026v.json",
+                "@type": "sc:Canvas",
+                "label": "26v (261v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_026v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_026v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_026v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_026v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-61",
+                "@type": "sc:Canvas",
+                "label": "Lacune (262r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-62",
+                "@type": "sc:Canvas",
+                "label": "Lacune (262v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-63",
+                "@type": "sc:Canvas",
+                "label": "Lacune (263r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-64",
+                "@type": "sc:Canvas",
+                "label": "Lacune (263v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-65",
+                "@type": "sc:Canvas",
+                "label": "Lacune (264r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-66",
+                "@type": "sc:Canvas",
+                "label": "Lacune (264v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-67",
+                "@type": "sc:Canvas",
+                "label": "Lacune (265r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-68",
+                "@type": "sc:Canvas",
+                "label": "Lacune (265v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-69",
+                "@type": "sc:Canvas",
+                "label": "Lacune (266r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-70",
+                "@type": "sc:Canvas",
+                "label": "Lacune (266v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-71",
+                "@type": "sc:Canvas",
+                "label": "Lacune (267r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-72",
+                "@type": "sc:Canvas",
+                "label": "Lacune (267v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-73",
+                "@type": "sc:Canvas",
+                "label": "Lacune (268r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-74",
+                "@type": "sc:Canvas",
+                "label": "Lacune (268v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027r.json",
+                "@type": "sc:Canvas",
+                "label": "27r (269r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_027r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_027r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_027r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027v.json",
+                "@type": "sc:Canvas",
+                "label": "27v (269v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_027v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_027v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_027v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_027v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-75",
+                "@type": "sc:Canvas",
+                "label": "Lacune (270r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-76",
+                "@type": "sc:Canvas",
+                "label": "Lacune (270v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028r.json",
+                "@type": "sc:Canvas",
+                "label": "28r (271r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_028r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_028r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_028r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028v.json",
+                "@type": "sc:Canvas",
+                "label": "28v (271v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_028v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_028v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_028v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_028v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029r.json",
+                "@type": "sc:Canvas",
+                "label": "29r (272r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_029r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_029r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_029r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029v.json",
+                "@type": "sc:Canvas",
+                "label": "29v (272v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_029v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_029v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_029v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_029v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030r.json",
+                "@type": "sc:Canvas",
+                "label": "30r (273r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_030r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_030r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_030r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030v.json",
+                "@type": "sc:Canvas",
+                "label": "30v (273v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_030v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_030v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_030v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_030v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031r.json",
+                "@type": "sc:Canvas",
+                "label": "31r (274r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_031r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_031r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_031r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031v.json",
+                "@type": "sc:Canvas",
+                "label": "31v (274v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_031v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_031v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_031v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_031v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032r.json",
+                "@type": "sc:Canvas",
+                "label": "32r (275r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_032r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_032r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_032r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032v.json",
+                "@type": "sc:Canvas",
+                "label": "32v (275v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_032v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_032v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_032v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_032v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033r.json",
+                "@type": "sc:Canvas",
+                "label": "33r (276r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_033r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_033r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_033r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033v.json",
+                "@type": "sc:Canvas",
+                "label": "33v (276v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_033v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_033v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_033v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_033v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034r.json",
+                "@type": "sc:Canvas",
+                "label": "34r (277r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_034r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_034r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_034r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034v.json",
+                "@type": "sc:Canvas",
+                "label": "34v (277v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_034v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_034v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_034v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_034v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035r.json",
+                "@type": "sc:Canvas",
+                "label": "35r (278r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_035r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_035r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_035r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035v.json",
+                "@type": "sc:Canvas",
+                "label": "35v (278v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_035v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_035v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_035v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_035v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036r.json",
+                "@type": "sc:Canvas",
+                "label": "36r (279r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_036r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_036r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_036r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036v.json",
+                "@type": "sc:Canvas",
+                "label": "36v (279v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_036v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_036v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_036v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_036v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037r.json",
+                "@type": "sc:Canvas",
+                "label": "37r (280r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_037r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_037r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_037r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037v.json",
+                "@type": "sc:Canvas",
+                "label": "37v (280v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_037v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_037v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_037v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_037v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038r.json",
+                "@type": "sc:Canvas",
+                "label": "38r (281r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_038r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_038r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_038r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038v.json",
+                "@type": "sc:Canvas",
+                "label": "38v (281v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_038v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_038v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_038v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_038v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039r.json",
+                "@type": "sc:Canvas",
+                "label": "39r (282r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_039r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_039r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_039r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039v.json",
+                "@type": "sc:Canvas",
+                "label": "39v (282v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_039v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_039v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_039v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_039v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040r.json",
+                "@type": "sc:Canvas",
+                "label": "40r (283r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_040r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_040r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_040r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040v.json",
+                "@type": "sc:Canvas",
+                "label": "40v (283v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_040v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_040v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_040v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_040v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041r.json",
+                "@type": "sc:Canvas",
+                "label": "41r (284r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_041r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_041r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_041r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041v.json",
+                "@type": "sc:Canvas",
+                "label": "41v (284v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_041v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_041v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_041v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_041v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042r.json",
+                "@type": "sc:Canvas",
+                "label": "42r (285r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_042r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_042r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_042r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042v.json",
+                "@type": "sc:Canvas",
+                "label": "42v (285v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_042v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_042v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_042v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_042v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043r.json",
+                "@type": "sc:Canvas",
+                "label": "43r (286r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_043r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_043r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_043r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043v.json",
+                "@type": "sc:Canvas",
+                "label": "43v (286v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_043v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_043v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_043v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_043v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044r.json",
+                "@type": "sc:Canvas",
+                "label": "44r (287r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_044r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_044r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_044r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044v.json",
+                "@type": "sc:Canvas",
+                "label": "44v (287v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_044v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_044v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_044v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_044v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-77",
+                "@type": "sc:Canvas",
+                "label": "Lacune (288r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-78",
+                "@type": "sc:Canvas",
+                "label": "Lacune (288v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046r.json",
+                "@type": "sc:Canvas",
+                "label": "46r (289r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_046r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_046r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_046r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046v.json",
+                "@type": "sc:Canvas",
+                "label": "46v (289v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_046v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_046v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_046v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_046v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047r.json",
+                "@type": "sc:Canvas",
+                "label": "47r (290r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_047r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_047r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_047r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047v.json",
+                "@type": "sc:Canvas",
+                "label": "47v (290v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_047v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_047v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_047v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_047v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048r.json",
+                "@type": "sc:Canvas",
+                "label": "48r (291r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_048r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_048r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_048r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048v.json",
+                "@type": "sc:Canvas",
+                "label": "48v (291v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_048v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_048v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_048v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_048v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049r.json",
+                "@type": "sc:Canvas",
+                "label": "49r (292r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_049r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_049r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_049r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049v.json",
+                "@type": "sc:Canvas",
+                "label": "49v (292v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_049v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_049v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_049v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_049v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045r.json",
+                "@type": "sc:Canvas",
+                "label": "45r (293r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_045r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_045r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_045r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045v.json",
+                "@type": "sc:Canvas",
+                "label": "45v (293v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_045v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_045v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_045v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_045v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050r.json",
+                "@type": "sc:Canvas",
+                "label": "50r (294r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_050r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_050r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_050r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050v.json",
+                "@type": "sc:Canvas",
+                "label": "50v (294v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_050v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_050v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_050v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_050v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051r.json",
+                "@type": "sc:Canvas",
+                "label": "51r (295r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_051r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_051r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_051r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051v.json",
+                "@type": "sc:Canvas",
+                "label": "51v (295v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_051v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_051v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_051v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_051v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052r.json",
+                "@type": "sc:Canvas",
+                "label": "52r (296r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_052r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_052r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_052r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052v.json",
+                "@type": "sc:Canvas",
+                "label": "52v (296v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_052v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_052v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_052v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_052v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-79",
+                "@type": "sc:Canvas",
+                "label": "Lacune (297r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-80",
+                "@type": "sc:Canvas",
+                "label": "Lacune (297v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-81",
+                "@type": "sc:Canvas",
+                "label": "Lacune (298r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-82",
+                "@type": "sc:Canvas",
+                "label": "Lacune (298v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-83",
+                "@type": "sc:Canvas",
+                "label": "Lacune (299r)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://demos.biblissima-condorcet.fr/iiif/metadata/florus-dispersus/canvas/canvas-84",
+                "@type": "sc:Canvas",
+                "label": "Lacune (299v)",
+                "width": 860,
+                "height": 1200
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053r.json",
+                "@type": "sc:Canvas",
+                "label": "53r (300r)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_053r.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053r.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_053r.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_053r.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            },
+            {
+                "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053v.json",
+                "@type": "sc:Canvas",
+                "label": "53v (300v)",
+                "height": 6496,
+                "width": 4872,
+                "images": [{
+                    "@id": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/annotation/bge-lat0016_053v.json",
+                    "@type": "oa:Annotation",
+                    "motivation": "sc:painting",
+                    "on": "http://www.e-codices.unifr.ch/metadata/iiif/sl-0001/canvas/bge-lat0016_053v.json",
+                    "resource": {
+                        "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_053v.jp2/full/full/0/default.jpg",
+                        "@type": "dctypes:Image",
+                        "format": "image/jpeg",
+                        "height": 6496,
+                        "width": 4872,
+                        "service": {
+                            "@context": "http://iiif.io/api/image/2/context.json",
+                            "@id": "http://www.e-codices.unifr.ch/loris/bge/bge-lat0016/bge-lat0016_053v.jp2",
+                            "profile": "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+                        }
+                    }
+                }]
+            }
+        ]
+    }]
+}

--- a/__tests__/src/components/WindowViewer.test.js
+++ b/__tests__/src/components/WindowViewer.test.js
@@ -5,13 +5,14 @@ import { WindowViewer } from '../../../src/components/WindowViewer';
 import OSDViewer from '../../../src/containers/OpenSeadragonViewer';
 import ViewerNavigation from '../../../src/containers/ViewerNavigation';
 import fixture from '../../fixtures/version-2/019.json';
+import emptyCanvasFixture from '../../fixtures/version-2/emptyCanvas.json';
 
-const mockManifest = {
+let mockManifest = {
   id: 123,
   manifestation: manifesto.create(fixture),
 };
 
-const mockWindow = {
+let mockWindow = {
   canvasIndex: 0,
   view: 'single',
 };
@@ -120,5 +121,54 @@ describe('WindowViewer', () => {
       },
     });
     expect(wrapper.instance().canvasGroupings.groupings().length).toEqual(2);
+  });
+
+  describe('componentDidMount', () => {
+    it('does not call fetchInfoResponse for a canvas that has no images', () => {
+      const mockFnCanvas0 = jest.fn();
+      const mockFnCanvas2 = jest.fn();
+      mockManifest = {
+        id: 123,
+        manifestation: manifesto.create(emptyCanvasFixture),
+      };
+      mockWindow = {
+        canvasIndex: 0,
+        view: 'single',
+      };
+      wrapper = createWrapper(
+        { manifest: mockManifest, fetchInfoResponse: mockFnCanvas0, window: mockWindow },
+      );
+      expect(mockFnCanvas0).toHaveBeenCalledTimes(1);
+
+      wrapper = createWrapper(
+        {
+          manifest: mockManifest,
+          fetchInfoResponse: mockFnCanvas2,
+          window: { canvasIndex: 2, view: 'single' },
+        },
+      );
+      expect(mockFnCanvas2).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('componentDidUpdate', () => {
+    it('does not call fetchInfoResponse for a canvas that has no images', () => {
+      const mockFn = jest.fn();
+      mockManifest = {
+        id: 123,
+        manifestation: manifesto.create(emptyCanvasFixture),
+      };
+      mockWindow = {
+        canvasIndex: 2,
+        view: 'single',
+      };
+      wrapper = createWrapper(
+        { manifest: mockManifest, fetchInfoResponse: mockFn, window: mockWindow },
+      );
+
+      wrapper.setProps({ window: { canvasIndex: 3, view: 'single' } });
+
+      expect(mockFn).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/__tests__/src/lib/ManifestoCanvas.test.js
+++ b/__tests__/src/lib/ManifestoCanvas.test.js
@@ -2,6 +2,7 @@ import manifesto from 'manifesto.js';
 import ManifestoCanvas from '../../../src/lib/ManifestoCanvas';
 import fixture from '../../fixtures/version-2/019.json';
 import imagev1Fixture from '../../fixtures/version-2/Osbornfa1.json';
+import emptyCanvasFixture from '../../fixtures/version-2/emptyCanvas.json';
 
 describe('ManifestoCanvas', () => {
   let instance;
@@ -27,6 +28,14 @@ describe('ManifestoCanvas', () => {
       );
       expect(imagev1Instance.imageInformationUri).toEqual('https://images.britishart.yale.edu/iiif/b38081da-8991-4464-a71e-d9891226a35f/info.json');
     });
+
+    it('is undefined if a canvas is empty (e.g. has no images)', () => {
+      const emptyCanvasInstance = new ManifestoCanvas(
+        manifesto.create(emptyCanvasFixture).getSequences()[0].getCanvases()[3],
+      );
+
+      expect(emptyCanvasInstance.imageInformationUri).toBeUndefined();
+    });
   });
   describe('aspectRatio', () => {
     it('calculates a width / height aspectRatio', () => {
@@ -43,6 +52,14 @@ describe('ManifestoCanvas', () => {
       expect(instance.thumbnail()).toEqual(
         'https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/100,/0/default.jpg',
       );
+    });
+
+    it('returns undefined if there are no images to generate a thumbnail from', () => {
+      const emptyCanvasInstance = new ManifestoCanvas(
+        manifesto.create(emptyCanvasFixture).getSequences()[0].getCanvases()[3],
+      );
+
+      expect(emptyCanvasInstance.thumbnail()).toBeUndefined();
     });
   });
 });

--- a/src/components/CanvasThumbnail.js
+++ b/src/components/CanvasThumbnail.js
@@ -22,7 +22,7 @@ export class CanvasThumbnail extends Component {
   handleIntersection(event) {
     const { imageUrl } = this.props;
     const { loaded } = this.state;
-    if (loaded || !event.isIntersecting) return;
+    if (loaded || !event.isIntersecting || !imageUrl) return;
     const image = new Image();
     image.src = imageUrl;
     this.setState({
@@ -32,13 +32,37 @@ export class CanvasThumbnail extends Component {
   }
 
   /**
+   * Return a the image URL if it is loaded and valid, otherwise return a placeholder
+  */
+  imageSrc() {
+    const { isValid } = this.props;
+    const { loaded, image } = this.state;
+
+    if (loaded && isValid && image && image.src) {
+      return image.src;
+    }
+
+    return CanvasThumbnail.defaultImgPlaceholder;
+  }
+
+  /**
+   *
+  */
+  imageStyles() {
+    const { height, style } = this.props;
+    const { image } = this.state;
+
+    return {
+      height,
+      width: (image && image.src) ? '100%' : '110px',
+      ...style,
+    };
+  }
+
+  /**
    */
   render() {
-    const {
-      height, isValid, onClick, style,
-    } = this.props;
-    const { loaded, image } = this.state;
-    const imgStyle = { height, width: '100%', ...style };
+    const { onClick } = this.props;
     return (
       <>
         <IntersectionObserver onChange={this.handleIntersection}>
@@ -47,8 +71,8 @@ export class CanvasThumbnail extends Component {
             onClick={onClick}
             onKeyPress={onClick}
             role="presentation"
-            src={loaded && isValid ? image.src : CanvasThumbnail.defaultImgPlaceholder}
-            style={imgStyle}
+            src={this.imageSrc()}
+            style={this.imageStyles()}
           />
         </IntersectionObserver>
       </>

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -30,7 +30,10 @@ export class WindowViewer extends Component {
 
     if (!this.infoResponseIsInStore()) {
       this.currentCanvases().forEach((canvas) => {
-        fetchInfoResponse(new ManifestoCanvas(canvas).imageInformationUri);
+        const { imageInformationUri } = new ManifestoCanvas(canvas);
+        if (imageInformationUri) {
+          fetchInfoResponse(imageInformationUri);
+        }
       });
     }
   }
@@ -45,7 +48,10 @@ export class WindowViewer extends Component {
       || (prevProps.window.canvasIndex !== window.canvasIndex && !this.infoResponseIsInStore())
     ) {
       this.currentCanvases().forEach((canvas) => {
-        fetchInfoResponse(new ManifestoCanvas(canvas).imageInformationUri);
+        const { imageInformationUri } = new ManifestoCanvas(canvas);
+        if (imageInformationUri) {
+          fetchInfoResponse(imageInformationUri);
+        }
       });
     }
     // If the view changes, create a new instance

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -25,6 +25,15 @@ export default class ManifestoCanvas {
   /**
    */
   get imageInformationUri() {
+    if (!(
+      this.canvas.getImages()[0]
+      && this.canvas.getImages()[0].getResource()
+      && this.canvas.getImages()[0].getResource().getServices()[0]
+      && this.canvas.getImages()[0].getResource().getServices()[0].id
+    )) {
+      return undefined;
+    }
+
     return `${
       this.canvas.getImages()[0].getResource().getServices()[0].id.replace(/\/$/, '')
     }/info.json`;
@@ -36,6 +45,11 @@ export default class ManifestoCanvas {
    */
   thumbnail(height = 150) {
     const width = Math.floor(height * this.aspectRatio);
+
+    if (!this.imageInformationUri) {
+      return undefined;
+    }
+
     return this.canonicalImageUri.replace(/\/full\/.*\/0\//, `/full/${width},/0/`);
   }
 }


### PR DESCRIPTION
Closes #1772 

Note:  As indicated in https://github.com/ProjectMirador/mirador/issues/1772#issuecomment-467960244 this PR simply fixes the WSOD issue and allows the canvas w/o an image to be selected from the thumbnail navigation panel.

Example Manifest: https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json (which is in our list of manifests loaded under the label `Codex Florus dispersus`)

