### PR TITLE
Set the WindowTopMenu MUI-Menu container to the node (by windowId).

### DIFF
--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -19,7 +19,13 @@ export class WindowTopMenu extends Component {
 
     return (
       <>
-        <Menu id={`window-menu_${windowId}`} anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+        <Menu
+          id={`window-menu_${windowId}`}
+          container={document.getElementById(windowId)}
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+        >
           <ListItem>
             <WindowViewSettings windowId={windowId} />
           </ListItem>


### PR DESCRIPTION
This is an alternate approach to fix #1785.  Setting an MUI container prop the result of `document.getElementById` is [not](https://github.com/ProjectMirador/mirador/blob/63b6edb45a9257edb56426af72201fff1a4d75df/src/components/WindowSideBar.js#L33) [unheard](https://github.com/ProjectMirador/mirador/blob/63b6edb45a9257edb56426af72201fff1a4d75df/src/components/WindowSideBar.js#L51) of.

However; this causes an issue w/ side-by-side windows where one window will overlap the modal.  I poked at some z-indexes briefly w/ no luck, but this might be the easiest way to address this bug if we can get the modal to display properly.

<img width="716" alt="window-overlay" src="https://user-images.githubusercontent.com/96776/53652855-b2dbec00-3bfe-11e9-816a-49d1bf000250.png">
