### PR TITLE
Add a 100% height and auto overflow to workspace add div so that it …

### DIFF
--- a/__tests__/integration/mirador/basic.test.js
+++ b/__tests__/integration/mirador/basic.test.js
@@ -11,6 +11,7 @@ describe('Basic end to end Mirador', () => {
     await expect(page).toClick('.mirador-add-resource-button');
     await expect(page).toFill('#manifestURL', 'http://localhost:5000/api/sn904cj3439');
     await expect(page).toClick('#fetchBtn');
+    await expect(page).toClick('button[aria-label="Close Menu"]'); // Close menu so new item is visible
     await expect(page).toMatchElement('[data-manifestid="http://localhost:5000/api/sn904cj3439"] button');
     await expect(page).toClick('[data-manifestid="http://localhost:5000/api/sn904cj3439"] button');
     await expect(page).toMatchElement(

--- a/__tests__/integration/mirador/window_actions.test.js
+++ b/__tests__/integration/mirador/window_actions.test.js
@@ -8,6 +8,7 @@ describe('Window actions', () => {
     await expect(page).toFill('#manifestURL', 'http://localhost:5000/api/sn904cj3439');
     await expect(page).toClick('#fetchBtn');
 
+    await expect(page).toClick('button[aria-label="Close Menu"]'); // Close menu so new item is visible
     await expect(page).toMatchElement('[data-manifestid="http://localhost:5000/api/sn904cj3439"] button');
     await expect(page).toClick('[data-manifestid="http://localhost:5000/api/sn904cj3439"] button');
 

--- a/__tests__/integration/mirador/window_sidebar.test.js
+++ b/__tests__/integration/mirador/window_sidebar.test.js
@@ -9,6 +9,7 @@ describe('Window Sidebars', () => {
     await expect(page).toFill('#manifestURL', 'http://localhost:5000/api/001');
     await expect(page).toClick('#fetchBtn');
 
+    await expect(page).toClick('button[aria-label="Close Menu"]'); // Close menu so new item is visible
     await expect(page).toMatchElement('[data-manifestid="http://localhost:5000/api/001"] button');
     await expect(page).toClick('[data-manifestid="http://localhost:5000/api/001"] button');
   });

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -42,6 +42,8 @@
   }
 
   &-workspace-add {
+    height: 100%;
+    overflow: auto;
     padding-left: 6px;
     padding-right: 6px;
     padding-top: 92px;


### PR DESCRIPTION
…can be scrollable (while maintaining the button/panels absolute positioning).

Closes #1929 

![workspace-add-after](https://user-images.githubusercontent.com/96776/53827627-665f1c00-3f30-11e9-973e-9a6feed0bcff.gif)
