### PR TITLE
A couple random fixes

### DIFF
--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -87,7 +87,7 @@ export class WorkspaceAdd extends React.Component {
           >
             <AppBar position="absolute" color="secondary" onClick={() => (this.setAddResourcesVisibility(false))}>
               <Toolbar>
-                <IconButton className={classes.menuButton} color="secondary" aria-label={t('closeMenu')}>
+                <IconButton className={classes.menuButton} color="inherit" aria-label={t('closeMenu')}>
                   <ExpandMoreIcon />
                 </IconButton>
                 <Typography variant="h2" noWrap color="inherit" className={classes.typographyBody}>

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -26,10 +26,10 @@ export class WorkspaceExport extends Component {
    */
   render() {
     const {
-      handleClose, open, children, t,
+      container, handleClose, open, children, t,
     } = this.props;
     return (
-      <Dialog id="workspace-settings" open={open} onClose={handleClose}>
+      <Dialog id="workspace-settings" container={container} open={open} onClose={handleClose}>
         <DialogTitle id="form-dialog-title">{t('downloadExport')}</DialogTitle>
         <DialogContent>
           {children}
@@ -43,6 +43,7 @@ export class WorkspaceExport extends Component {
 }
 
 WorkspaceExport.propTypes = {
+  container: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
   children: PropTypes.node,
@@ -51,6 +52,7 @@ WorkspaceExport.propTypes = {
 };
 
 WorkspaceExport.defaultProps = {
+  container: null,
   open: false,
   children: null,
   t: key => key,

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -83,11 +83,13 @@ export class WorkspaceMenu extends Component {
       exportWorkspace,
     } = this.state;
 
+    const container = document.querySelector(`#${containerId} .${ns('viewer')}`);
+
     return (
       <>
         <Menu
           id="workspace-menu"
-          container={document.querySelector(`#${containerId} .${ns('viewer')}`)}
+          container={container}
           anchorEl={anchorEl}
           open={Boolean(anchorEl)}
           onClose={handleClose}
@@ -153,10 +155,12 @@ export class WorkspaceMenu extends Component {
         />
         <WorkspaceSettings
           open={Boolean(settings.open)}
+          container={container}
           handleClose={this.handleMenuItemClose('settings')}
         />
         <WorkspaceExport
           open={Boolean(exportWorkspace.open)}
+          container={container}
           handleClose={this.handleMenuItemClose('exportWorkspace')}
         />
       </>

--- a/src/components/WorkspaceSettings.js
+++ b/src/components/WorkspaceSettings.js
@@ -40,10 +40,10 @@ export class WorkspaceSettings extends Component {
    */
   render() {
     const {
-      handleClose, open, children, theme, t,
+      container, handleClose, open, children, theme, t,
     } = this.props;
     return (
-      <Dialog id="workspace-settings" open={open} onClose={handleClose}>
+      <Dialog id="workspace-settings" container={container} open={open} onClose={handleClose}>
         <DialogTitle id="form-dialog-title">{t('settings')}</DialogTitle>
         <DialogContent>
           {children}
@@ -68,6 +68,7 @@ export class WorkspaceSettings extends Component {
 }
 
 WorkspaceSettings.propTypes = {
+  container: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool, // eslint-disable-line react/forbid-prop-types
   children: PropTypes.node,
@@ -77,6 +78,7 @@ WorkspaceSettings.propTypes = {
 };
 
 WorkspaceSettings.defaultProps = {
+  container: null,
   open: false,
   children: null,
   t: key => key,

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -23,8 +23,8 @@
   &-workspace-viewport {
     bottom: 0;
     left: 0;
-    overflow: hidden;
     margin: 0;
+    overflow: hidden;
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
This PR includes 3 fixes (and can pull any out into separate PRs or drop all-together if we don't want them).

* Updates a css order issue so the linter stops complaining
* Changes the icon color for the Add Manifest UI so it is visible again
* Fixes the Workspace menu dialogs in full-screen mode (by passing containers around)
  * I guess this is the one that feels the most controversial. Happy to re-work this or  🔪it.

## Icon Before
<img width="659" alt="icon-before" src="https://user-images.githubusercontent.com/96776/53830636-c86f4f80-3f37-11e9-9fdc-feeca39215f2.png">

## Icon After
<img width="841" alt="icon-after" src="https://user-images.githubusercontent.com/96776/53830638-c86f4f80-3f37-11e9-9f0d-4a8ae62de6a5.png">

