### PR TITLE
remove vestigial named-asset-importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "babel-eslint": "10.0.1",
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.4",
-    "babel-plugin-named-asset-import": "^0.3.1",
     "codecov": "^3.1.0",
     "concurrently": "^4.0.1",
     "css-loader": "^2.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,18 +24,6 @@ const babelLoaderConfig = {
   include: paths.appSrc, // CRL
   loader: require.resolve('babel-loader'),
   options: {
-    plugins: [
-      [
-        require.resolve('babel-plugin-named-asset-import'),
-        {
-          loaderMap: {
-            svg: {
-              ReactComponent: '@svgr/webpack?-prettier,-svgo![path]',
-            },
-          },
-        },
-      ],
-    ],
     cacheDirectory: true,
     // Save disk space when time isn't as important
     cacheCompression: true,


### PR DESCRIPTION
I can't find our usage of this babel plugin or what the use case is for it. Can we remove it or somehow figure out what this is for?