### PR TITLE
add prepublishOnly step for release/publish process to build distribu…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "webpack --mode=production",
     "build:dev": "webpack --mode=development",
     "build:watch": "webpack --watch --mode=development",
+    "prepublishOnly": "rm -rf ./dist && npm run test",
     "size": "size-limit",
     "start": "npm run build:dev && concurrently \"npm run build:watch\" \"npm run server -- -p 4444\"",
     "server:json": "node ./scripts/json-server/server.js >> ./scripts/json-server/json-server.log"


### PR DESCRIPTION
…tion

Fixes #2005 

With https://github.com/ProjectMirador/mirador/wiki/How-to-release-a-version-of-Mirador

To test this for yourself, you can run:
```sh
$ npm publish --dry-run
```