### PR TITLE
Add canvas labels to thumbnail navigation

### DIFF
--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -13,6 +13,7 @@ function createWrapper(props) {
       canvasGroupings={
         new CanvasGroupings(manifesto.create(manifestJson).getSequences()[0].getCanvases())
       }
+      classes={{}}
       window={{
         id: 'foobar',
         canvasIndex: 1,
@@ -53,7 +54,7 @@ describe('ThumbnailNavigation', () => {
     expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas'));
   });
   it('when clicked, updates the current canvas', () => {
-    renderedGrid.find('.mirador-thumbnail-nav-canvas-0 WithStyles(GridListTile)').simulate('click');
+    renderedGrid.find('.mirador-thumbnail-nav-canvas-0 WithStyles(GridListTile) WithStyles(Button)').simulate('click');
     expect(setCanvas).toHaveBeenCalledWith('foobar', 0);
   });
   it('sets up calculated width based off of height of area and dimensions of canvas', () => {

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import Grid from 'react-virtualized/dist/commonjs/Grid';
 import Button from '@material-ui/core/Button';
-import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';
 import Typography from '@material-ui/core/Typography';
@@ -79,6 +78,7 @@ export class ThumbnailNavigation extends Component {
 
             return (
               <GridListTile
+                component="div"
                 key={canvas.index}
               >
                 <Button
@@ -150,27 +150,25 @@ export class ThumbnailNavigation extends Component {
         className={ns('thumb-navigation')}
         style={{ height: `${config.thumbnailNavigation.height}px` }}
       >
-        <GridList>
-          <AutoSizer
-            defaultHeight={100}
-            defaultWidth={400}
-          >
-            {({ height, width }) => (
-              <Grid
-                cellRenderer={this.cellRenderer}
-                columnCount={canvasGroupings.groupings().length}
-                columnWidth={this.calculateScaledWidth}
-                height={config.thumbnailNavigation.height}
-                rowCount={1}
-                rowHeight={config.thumbnailNavigation.height}
-                scrollToAlignment="center"
-                scrollToColumn={this.scrollToColumn()}
-                width={width}
-                ref={this.gridRef}
-              />
-            )}
-          </AutoSizer>
-        </GridList>
+        <AutoSizer
+          defaultHeight={100}
+          defaultWidth={400}
+        >
+          {({ height, width }) => (
+            <Grid
+              cellRenderer={this.cellRenderer}
+              columnCount={canvasGroupings.groupings().length}
+              columnWidth={this.calculateScaledWidth}
+              height={config.thumbnailNavigation.height}
+              rowCount={1}
+              rowHeight={config.thumbnailNavigation.height}
+              scrollToAlignment="center"
+              scrollToColumn={this.scrollToColumn()}
+              width={width}
+              ref={this.gridRef}
+            />
+          )}
+        </AutoSizer>
       </div>
     );
   }

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -2,7 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import Grid from 'react-virtualized/dist/commonjs/Grid';
+import Button from '@material-ui/core/Button';
+import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
+import GridListTileBar from '@material-ui/core/GridListTileBar';
+import Typography from '@material-ui/core/Typography';
+import { getCanvasLabel } from '../state/selectors';
 import { CanvasThumbnail } from './CanvasThumbnail';
 import ManifestoCanvas from '../lib/ManifestoCanvas';
 import ns from '../config/css-ns';
@@ -52,7 +57,7 @@ export class ThumbnailNavigation extends Component {
       columnIndex, key, style,
     } = options;
     const {
-      window, setCanvas, config, canvasGroupings, t,
+      classes, window, setCanvas, config, canvasGroupings, t,
     } = this.props;
     const currentGroupings = canvasGroupings.groupings()[columnIndex];
     return (
@@ -74,20 +79,29 @@ export class ThumbnailNavigation extends Component {
 
             return (
               <GridListTile
-                component="div"
                 key={canvas.index}
-                onClick={() => setCanvas(window.id, currentGroupings[0].index)}
-                style={{
-                  position: 'absolute', left: (style.width - 8) * i / 2, top: 2,
-                }}
               >
-                <CanvasThumbnail
-                  imageUrl={manifestoCanvas.thumbnail(null, height)}
-                  isValid={manifestoCanvas.hasValidDimensions}
-                  maxHeight={config.thumbnailNavigation.height}
-                  maxWidth={style.width}
-                  aspectRatio={manifestoCanvas.aspectRatio}
-                />
+                <Button
+                  className={classes.thumbnailButton}
+                  onClick={() => setCanvas(window.id, currentGroupings[0].index)}
+                >
+                  <CanvasThumbnail
+                    imageUrl={manifestoCanvas.thumbnail(null, height)}
+                    isValid={manifestoCanvas.hasValidDimensions}
+                    maxHeight={config.thumbnailNavigation.height}
+                    maxWidth={style.width}
+                    aspectRatio={manifestoCanvas.aspectRatio}
+                  />
+
+                  <GridListTileBar
+                    classes={{ root: classes.canvasLabel }}
+                    title={(
+                      <Typography classes={{ root: classes.title }} variant="caption">
+                        {getCanvasLabel(canvas, canvas.index)}
+                      </Typography>
+                    )}
+                  />
+                </Button>
               </GridListTile>
             );
           })}
@@ -136,31 +150,34 @@ export class ThumbnailNavigation extends Component {
         className={ns('thumb-navigation')}
         style={{ height: `${config.thumbnailNavigation.height}px` }}
       >
-        <AutoSizer
-          defaultHeight={100}
-          defaultWidth={400}
-        >
-          {({ height, width }) => (
-            <Grid
-              cellRenderer={this.cellRenderer}
-              columnCount={canvasGroupings.groupings().length}
-              columnWidth={this.calculateScaledWidth}
-              height={config.thumbnailNavigation.height}
-              rowCount={1}
-              rowHeight={config.thumbnailNavigation.height}
-              scrollToAlignment="center"
-              scrollToColumn={this.scrollToColumn()}
-              width={width}
-              ref={this.gridRef}
-            />
-          )}
-        </AutoSizer>
+        <GridList>
+          <AutoSizer
+            defaultHeight={100}
+            defaultWidth={400}
+          >
+            {({ height, width }) => (
+              <Grid
+                cellRenderer={this.cellRenderer}
+                columnCount={canvasGroupings.groupings().length}
+                columnWidth={this.calculateScaledWidth}
+                height={config.thumbnailNavigation.height}
+                rowCount={1}
+                rowHeight={config.thumbnailNavigation.height}
+                scrollToAlignment="center"
+                scrollToColumn={this.scrollToColumn()}
+                width={width}
+                ref={this.gridRef}
+              />
+            )}
+          </AutoSizer>
+        </GridList>
       </div>
     );
   }
 }
 
 ThumbnailNavigation.propTypes = {
+  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   canvasGroupings: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   setCanvas: PropTypes.func.isRequired,

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
 import miradorWithPlugins from '../lib/miradorWithPlugins';
 import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
@@ -25,9 +26,23 @@ const mapDispatchToProps = {
   setCanvas: actions.setCanvas,
 };
 
+const styles = {
+  canvasLabel: {
+    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+    textAlign: 'left',
+  },
+  title: {
+    color: 'white',
+  },
+  thumbnailButton: {
+    padding: '0',
+  },
+};
+
 const enhance = compose(
   withTranslation(),
   connect(mapStateToProps, mapDispatchToProps),
+  withStyles(styles),
   miradorWithPlugins,
   // further HOC go here
 );

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -95,10 +95,8 @@
   }
 
   &-thumb-navigation {
-
     .mirador-thumbnail-nav-canvas {
-      border: 1px solid $black;
-      color: $white;
+      border: 3px solid transparent;
       cursor: pointer;
       height: 100%;
 


### PR DESCRIPTION
Part of #1932

![thumbnail-buttons](https://user-images.githubusercontent.com/96776/53920013-8968f900-4020-11e9-84d0-b1b36f607c3d.gif)
