### PR TITLE
Address menu icons and position

### DIFF
--- a/__tests__/src/components/NestedMenu.test.js
+++ b/__tests__/src/components/NestedMenu.test.js
@@ -26,6 +26,12 @@ describe('NestedMenu', () => {
     expect(wrapper.find('WithStyles(ListItemIcon)').children().text()).toEqual('GivenIcon');
   });
 
+  it('does not render a ListItemIcon if no icon prop is passed', () => {
+    wrapper = createWrapper({ icon: null });
+
+    expect(wrapper.find('WithStyles(ListItemIcon)').length).toBe(0);
+  });
+
   it('renders the given label wrapped in a MUI Typography', () => {
     wrapper = createWrapper();
 

--- a/__tests__/src/components/NestedMenu.test.js
+++ b/__tests__/src/components/NestedMenu.test.js
@@ -54,6 +54,12 @@ describe('NestedMenu', () => {
     expect(wrapper.state().nestedMenuIsOpen).toBe(false);
   });
 
+  it('spreads options to the MenuItem', () => {
+    wrapper = createWrapper({ divider: true });
+
+    expect(wrapper.find('WithStyles(MenuItem)').props().divider).toBe(true);
+  });
+
   it('renders the appropriate expand/collapse icon based on the menu open state', () => {
     wrapper = createWrapper();
 

--- a/__tests__/src/components/WindowTopMenu.test.js
+++ b/__tests__/src/components/WindowTopMenu.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import ListItem from '@material-ui/core/ListItem';
 import Menu from '@material-ui/core/Menu';
-import Divider from '@material-ui/core/Divider';
 import WindowThumbnailSettings from '../../../src/containers/WindowThumbnailSettings';
 import WindowViewSettings from '../../../src/containers/WindowViewSettings';
 import { WindowTopMenu } from '../../../src/components/WindowTopMenu';
@@ -27,7 +26,6 @@ describe('WindowTopMenu', () => {
     expect(wrapper.find(ListItem).length).toBe(2);
     expect(wrapper.find(WindowThumbnailSettings).length).toBe(1);
     expect(wrapper.find(WindowViewSettings).length).toBe(1);
-    expect(wrapper.find(Divider).length).toBe(2);
   });
 
   it('passes windowId to <WindowThumbnailSettings/>', () => {

--- a/__tests__/src/components/WindowTopMenuButton.test.js
+++ b/__tests__/src/components/WindowTopMenuButton.test.js
@@ -10,7 +10,7 @@ function createWrapper(props) {
   return shallow(
     <WindowTopMenuButton
       windowId="xyz"
-      classes={{}}
+      classes={{ ctrlBtnSelected: 'ctrlBtnSelected' }}
       t={str => str}
       {...props}
     />,
@@ -50,5 +50,14 @@ describe('WindowTopMenuButton', () => {
 
     wrapper.instance().handleMenuClose();
     expect(wrapper.find(WindowTopMenu).first().props().anchorEl).toBe(null);
+  });
+
+  it('the button has a class indicating that it is "selected" once it is clicked', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.ctrlBtnSelected').length).toBe(0);
+    wrapper.find('WithStyles(IconButton)').simulate('click', { currentTarget: 'anElement' });
+    expect(wrapper.find('.ctrlBtnSelected').length).toBe(1);
+    wrapper.find('WithStyles(IconButton)').simulate('click', {});
+    expect(wrapper.find('.ctrlBtnSelected').length).toBe(0);
   });
 });

--- a/__tests__/src/components/WorkspaceMenuButton.test.js
+++ b/__tests__/src/components/WorkspaceMenuButton.test.js
@@ -6,7 +6,7 @@ describe('WorkspaceMenuButton', () => {
   let wrapper;
   beforeEach(() => {
     wrapper = shallow(
-      <WorkspaceMenuButton classes={{}} />,
+      <WorkspaceMenuButton classes={{ ctrlBtnSelected: 'ctrlBtnSelected' }} />,
     );
   });
 
@@ -16,5 +16,13 @@ describe('WorkspaceMenuButton', () => {
   it('when clicked, updates the state', () => {
     wrapper.find('WithStyles(IconButton)').simulate('click', {});
     // TODO: this is currently a no-op
+  });
+
+  it('the button has a class indicating that it is "selected" once it is clicked', () => {
+    expect(wrapper.find('.ctrlBtnSelected').length).toBe(0);
+    wrapper.find('WithStyles(IconButton)').simulate('click', { currentTarget: 'anElement' });
+    expect(wrapper.find('.ctrlBtnSelected').length).toBe(1);
+    wrapper.find('WithStyles(IconButton)').simulate('click', {});
+    expect(wrapper.find('.ctrlBtnSelected').length).toBe(0);
   });
 });

--- a/src/components/NestedMenu.js
+++ b/src/components/NestedMenu.js
@@ -46,7 +46,9 @@ export class NestedMenu extends Component {
     return (
       <>
         <MenuItem onClick={this.handleMenuClick}>
-          <ListItemIcon>{icon}</ListItemIcon>
+          {icon
+            && (<ListItemIcon>{icon}</ListItemIcon>)
+          }
           {/* ListItemText adds left padding and we want this to line-up with menu items */}
           <ListItemText style={{ paddingLeft: 0 }}>
             <Typography varient="inherit">{label}</Typography>
@@ -67,6 +69,10 @@ export class NestedMenu extends Component {
 
 NestedMenu.propTypes = {
   children: PropTypes.element.isRequired,
-  icon: PropTypes.element.isRequired,
+  icon: PropTypes.element,
   label: PropTypes.string.isRequired,
+};
+
+NestedMenu.defaultProps = {
+  icon: null,
 };

--- a/src/components/NestedMenu.js
+++ b/src/components/NestedMenu.js
@@ -38,14 +38,16 @@ export class NestedMenu extends Component {
   }
 
   /**
-   * Returns the rendered component
+   * Returns the rendered component.  Spreads unused props to MenuItem
   */
   render() {
     const { nestedMenuIsOpen } = this.state;
-    const { children, icon, label } = this.props;
+    const {
+      children, icon, label, ...otherProps
+    } = this.props;
     return (
       <>
-        <MenuItem onClick={this.handleMenuClick}>
+        <MenuItem onClick={this.handleMenuClick} {...otherProps}>
           {icon
             && (<ListItemIcon>{icon}</ListItemIcon>)
           }

--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -26,6 +26,15 @@ export class WindowTopMenu extends Component {
           id={`window-menu_${windowId}`}
           container={document.querySelector(`#${containerId} .${ns('viewer')}`)}
           anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          getContentAnchorEl={null}
           open={Boolean(anchorEl)}
           onClose={handleClose}
         >

--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import ListItem from '@material-ui/core/ListItem';
 import Menu from '@material-ui/core/Menu';
-import Divider from '@material-ui/core/Divider';
 import PropTypes from 'prop-types';
 import WindowThumbnailSettings from '../containers/WindowThumbnailSettings';
 import WindowViewSettings from '../containers/WindowViewSettings';
@@ -38,14 +37,12 @@ export class WindowTopMenu extends Component {
           open={Boolean(anchorEl)}
           onClose={handleClose}
         >
-          <ListItem>
+          <ListItem divider>
             <WindowViewSettings windowId={windowId} />
           </ListItem>
-          <Divider />
-          <ListItem>
+          <ListItem divider>
             <WindowThumbnailSettings windowId={windowId} />
           </ListItem>
-          <Divider />
         </Menu>
       </>
     );

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import MoreVertIcon from '@material-ui/icons/MoreVertSharp';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import WindowTopMenu from '../containers/WindowTopMenu';
 
@@ -50,7 +51,7 @@ export class WindowTopMenuButton extends Component {
         <IconButton
           color="inherit"
           aria-label={t('windowMenu')}
-          className={classes.ctrlBtn}
+          className={classNames(classes.ctrlBtn, (anchorEl ? classes.ctrlBtnSelected : null))}
           aria-haspopup="true"
           onClick={this.handleMenuClick}
           aria-owns={anchorEl ? `window-menu_${windowId}` : undefined}

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -1,15 +1,11 @@
 import React, { Component } from 'react';
 import Menu from '@material-ui/core/Menu';
 import Divider from '@material-ui/core/Divider';
-import LanguageIcon from '@material-ui/icons/Language';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
-import LoupeIcon from '@material-ui/icons/Loupe';
 import MenuItem from '@material-ui/core/MenuItem';
 import Typography from '@material-ui/core/Typography';
 import SaveAltIcon from '@material-ui/icons/SaveAltSharp';
 import SettingsIcon from '@material-ui/icons/SettingsSharp';
-import ViewHeadlineIcon from '@material-ui/icons/ViewHeadline';
-import ViewQuiltIcon from '@material-ui/icons/ViewQuilt';
 import PropTypes from 'prop-types';
 import LanguageSettings from '../containers/LanguageSettings';
 import { NestedMenu } from './NestedMenu';
@@ -115,20 +111,13 @@ export class WorkspaceMenu extends Component {
             onClick={(e) => { this.handleMenuItemClick('windowList', e); handleClose(e); }}
             aria-owns={windowList.anchorEl ? 'window-list-menu' : undefined}
           >
-            <ListItemIcon>
-              <ViewHeadlineIcon />
-            </ListItemIcon>
             <Typography varient="inherit">{t('listAllOpenWindows')}</Typography>
           </MenuItem>
-          <Divider />
           <MenuItem
             aria-haspopup="true"
             onClick={(e) => { this.handleZoomToggleClick(e); handleClose(e); }}
             aria-owns={toggleZoom.anchorEl ? 'toggle-zoom-menu' : undefined}
           >
-            <ListItemIcon>
-              <LoupeIcon />
-            </ListItemIcon>
             <Typography varient="inherit">
               { showZoomControls ? t('hideZoomControls') : t('showZoomControls') }
             </Typography>
@@ -138,13 +127,10 @@ export class WorkspaceMenu extends Component {
             onClick={(e) => { this.handleMenuItemClick('workspaceSelection', e); handleClose(e); }}
             aria-owns={workspaceSelection.anchorEl ? 'workspace-selection' : undefined}
           >
-            <ListItemIcon>
-              <ViewQuiltIcon />
-            </ListItemIcon>
             <Typography varient="inherit">{t('selectWorkspaceMenu')}</Typography>
           </MenuItem>
 
-          <NestedMenu icon={<LanguageIcon />} label={t('language')}>
+          <NestedMenu label={t('language')}>
             <LanguageSettings afterSelect={handleClose} />
           </NestedMenu>
 

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -99,6 +99,14 @@ export class WorkspaceMenu extends Component {
           id="workspace-menu"
           container={container}
           anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
           open={Boolean(anchorEl)}
           onClose={handleClose}
         >

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import Menu from '@material-ui/core/Menu';
-import Divider from '@material-ui/core/Divider';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import MenuItem from '@material-ui/core/MenuItem';
 import Typography from '@material-ui/core/Typography';
@@ -130,11 +129,10 @@ export class WorkspaceMenu extends Component {
             <Typography varient="inherit">{t('selectWorkspaceMenu')}</Typography>
           </MenuItem>
 
-          <NestedMenu label={t('language')}>
+          <NestedMenu label={t('language')} divider>
             <LanguageSettings afterSelect={handleClose} />
           </NestedMenu>
 
-          <Divider />
           <MenuItem
             aria-haspopup="true"
             onClick={(e) => { this.handleMenuItemClick('settings', e); handleClose(e); }}

--- a/src/components/WorkspaceMenuButton.js
+++ b/src/components/WorkspaceMenuButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/MenuSharp';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import WorkspaceMenu from '../containers/WorkspaceMenu';
 
 /**
@@ -51,7 +52,7 @@ export class WorkspaceMenuButton extends Component {
           color="default"
           id="menuBtn"
           aria-label={t('workspaceMenu')}
-          className={classes.ctrlBtn}
+          className={classNames(classes.ctrlBtn, (anchorEl ? classes.ctrlBtnSelected : null))}
           aria-haspopup="true"
           onClick={this.handleMenuClick}
           aria-owns={anchorEl ? 'workspace-menu' : undefined}

--- a/src/containers/WindowTopMenuButton.js
+++ b/src/containers/WindowTopMenuButton.js
@@ -13,6 +13,9 @@ const styles = theme => ({
   ctrlBtn: {
     margin: theme.spacing.unit,
   },
+  ctrlBtnSelected: {
+    backgroundColor: theme.palette.action.selected,
+  },
 });
 
 const enhance = compose(

--- a/src/containers/WorkspaceMenuButton.js
+++ b/src/containers/WorkspaceMenuButton.js
@@ -13,6 +13,9 @@ const styles = theme => ({
   ctrlBtn: {
     margin: theme.spacing.unit,
   },
+  ctrlBtnSelected: {
+    backgroundColor: theme.palette.action.selected,
+  },
 });
 
 const enhance = compose(


### PR DESCRIPTION
Closes of #1936 

## Tasks
- [x] Address location of menus
- [x] ~~Address default focus in menus~~ _(Spinning off into new issue #2115)_
  -  This is intentionally done by the MUI library, and I _believe_ it is for keyboard a11y.  It appears that you need to have focus on a visible element w/i the menu in order to be able to use arrow-key navigation.  There is some interesting discussion in mui-org/material-ui#5186 explaining some of the rationale.  (Note, adding the display:none `MenuItem` at the beginning of the list gives the desired behavior visually, but we lose any keyboard arrow navigation).
  - It might be possible to do something with [MenuList composition](https://material-ui.com/demos/menus/#menulist-composition), but that seems like it'll get a bit complicated, and think it may be best to spin that off into a separate PR, as it seems like the other issues addressed here are a good step forward.
- [x] Make dividers non-focusable
- [x] Make the icon that triggers a menu remain "selected"

### Before
<img width="281" alt="before" src="https://user-images.githubusercontent.com/96776/54042377-cea33d00-417e-11e9-9f3d-bbd5ae09f7fe.png">
<img width="451" alt="top-before" src="https://user-images.githubusercontent.com/96776/54044385-abc75780-4183-11e9-9e2c-b9f226733489.png">

### After
<img width="329" alt="after" src="https://user-images.githubusercontent.com/96776/54042375-ce0aa680-417e-11e9-88b2-30f155d99fd9.png">
<img width="499" alt="top-after" src="https://user-images.githubusercontent.com/96776/54044386-ac5fee00-4183-11e9-8179-3909f35ee65b.png">