### PR TITLE
Adds basic xywh annotations for single canvas viewing

### DIFF
--- a/__tests__/src/lib/AnnotationResource.test.js
+++ b/__tests__/src/lib/AnnotationResource.test.js
@@ -53,11 +53,11 @@ describe('AnnotationResource', () => {
   describe('fragmentSelector', () => {
     it('simple string', () => {
       expect(new AnnotationResource({ on: 'www.example.com/#xywh=10,10,100,200' })
-        .fragmentSelector).toEqual(['10', '10', '100', '200']);
+        .fragmentSelector).toEqual([10, 10, 100, 200]);
     });
     it('more complex selector', () => {
       expect(new AnnotationResource({ on: { selector: { value: 'www.example.com/#xywh=10,10,100,200' } } })
-        .fragmentSelector).toEqual(['10', '10', '100', '200']);
+        .fragmentSelector).toEqual([10, 10, 100, 200]);
     });
   });
 });

--- a/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
+++ b/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
@@ -1,0 +1,122 @@
+import OpenSeadragon from 'openseadragon';
+import OpenSeadragonCanvasOverlay from '../../../src/lib/OpenSeadragonCanvasOverlay';
+
+jest.mock('openseadragon');
+
+describe('OpenSeadragonCanvasOverlay', () => {
+  let canvasOverlay;
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="canvas"></div>';
+    OpenSeadragon.mockClear();
+    OpenSeadragon.mockImplementation(() => ({
+      canvas: document.getElementById('canvas'),
+      container: {
+        clientHeight: 100,
+        clientWidth: 200,
+      },
+      viewport: {
+        getBounds: jest.fn(() => ({
+          x: 40, y: 80, width: 200, height: 300,
+        })),
+        getZoom: jest.fn(() => (0.75)),
+      },
+      world: {
+        getItemAt: jest.fn(() => ({
+          source: {
+            dimensions: {
+              x: 1000,
+              y: 2000,
+            },
+          },
+          viewportToImageZoom: jest.fn(() => (0.075)),
+        })),
+      },
+    }));
+    canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon());
+  });
+  describe('constructor', () => {
+    it('sets up initial values and canvas', () => {
+      expect(canvasOverlay.containerHeight).toEqual(0);
+      expect(canvasOverlay.containerWidth).toEqual(0);
+      expect(canvasOverlay.canvasDiv.outerHTML).toEqual(
+        '<div style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"><canvas></canvas></div>',
+      );
+    });
+  });
+  describe('context2d', () => {
+    it('calls getContext on canvas', () => {
+      const contextMock = jest.fn();
+      canvasOverlay.canvas = {
+        getContext: contextMock,
+      };
+      canvasOverlay.context2d; // eslint-disable-line no-unused-expressions
+      expect(contextMock).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('clear', () => {
+    it('calls getContext and clearRect on canvas', () => {
+      const clearRect = jest.fn();
+      const contextMock = jest.fn(() => ({
+        clearRect,
+      }));
+      canvasOverlay.canvas = {
+        getContext: contextMock,
+      };
+      canvasOverlay.clear();
+      expect(contextMock).toHaveBeenCalledTimes(1);
+      expect(clearRect).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('resize', () => {
+    it('sets various values based off of image and container sizes', () => {
+      canvasOverlay.resize();
+      expect(canvasOverlay.containerHeight).toEqual(100);
+      expect(canvasOverlay.containerWidth).toEqual(200);
+      expect(canvasOverlay.imgAspectRatio).toEqual(0.5);
+    });
+    it('when image is undefined returns early', () => {
+      OpenSeadragon.mockClear();
+      OpenSeadragon.mockImplementation(() => ({
+        canvas: document.getElementById('canvas'),
+        container: {
+          clientHeight: 100,
+          clientWidth: 200,
+        },
+        viewport: {
+          getBounds: jest.fn(() => (new OpenSeadragon.Rect(0, 0, 200, 200))),
+        },
+        world: {
+          getItemAt: jest.fn(),
+        },
+      }));
+      canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon());
+      canvasOverlay.resize();
+      expect(canvasOverlay.imgHeight).toEqual(undefined);
+      expect(canvasOverlay.imgWidth).toEqual(undefined);
+    });
+  });
+  describe('canvasUpdate', () => {
+    it('sets appropriate sizes and calls update argument', () => {
+      const scale = jest.fn();
+      const setAttribute = jest.fn();
+      const setTransform = jest.fn();
+      const translate = jest.fn();
+      const contextMock = jest.fn(() => ({
+        scale,
+        setTransform,
+        translate,
+      }));
+      canvasOverlay.canvas = {
+        getContext: contextMock,
+        setAttribute,
+      };
+      const update = jest.fn();
+      canvasOverlay.resize();
+      canvasOverlay.canvasUpdate(update);
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(scale).toHaveBeenCalledWith(0.075, 0.075);
+      expect(translate).toHaveBeenCalledWith(-39.96, -26.65333333333333);
+      expect(setTransform).toHaveBeenCalledWith(1, 0, 0, 1, 0, 0);
+    });
+  });
+});

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -126,6 +126,7 @@ export class WindowViewer extends Component {
       <>
         <OSDViewer
           tileSources={this.tileInfoFetchedFromStore()}
+          currentCanvases={this.currentCanvases()}
           windowId={window.id}
         >
           <ViewerNavigation window={window} canvases={this.canvases} />

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -7,6 +7,7 @@ import * as actions from '../state/actions';
 import {
   getCanvasLabel,
   getSelectedCanvas,
+  getSelectedCanvasAnnotations,
 } from '../state/selectors';
 
 /**
@@ -14,11 +15,17 @@ import {
  * @memberof Window
  * @private
  */
-const mapStateToProps = ({ viewers, windows, manifests }, { windowId }) => ({
+const mapStateToProps = ({
+  viewers, windows, manifests, annotations,
+}, { windowId, currentCanvases }) => ({
   viewer: viewers[windowId],
   label: getCanvasLabel(
     getSelectedCanvas({ windows, manifests }, windowId),
     windows[windowId].canvasIndex,
+  ),
+  annotations: getSelectedCanvasAnnotations(
+    { annotations },
+    currentCanvases.map(canvas => canvas.id),
   ),
 });
 

--- a/src/lib/AnnotationResource.js
+++ b/src/lib/AnnotationResource.js
@@ -37,9 +37,9 @@ export default class AnnotationResource {
     const { on } = this.resource;
     switch (typeof on) {
       case 'string':
-        return on.match(/xywh=(.*)$/)[1].split(',');
+        return on.match(/xywh=(.*)$/)[1].split(',').map(str => parseInt(str, 10));
       case 'object':
-        return on.selector.value.match(/xywh=(.*)$/)[1].split(',');
+        return on.selector.value.match(/xywh=(.*)$/)[1].split(',').map(str => parseInt(str, 10));
       default:
         return null;
     }

--- a/src/lib/OpenSeadragonCanvasOverlay.js
+++ b/src/lib/OpenSeadragonCanvasOverlay.js
@@ -1,0 +1,100 @@
+import OpenSeadragon from 'openseadragon';
+
+/**
+ * OpenSeadragonCanvasOverlay - adapted from https://github.com/altert/OpenSeadragonCanvasOverlay
+ * used rather than an "onRedraw" function we tap into our own method. Existing
+ * repository is not published as an npm package.
+ * Code ported from https://github.com/altert/OpenSeadragonCanvasOverlay
+ * carries a BSD 3-Clause license originally authored by @altert from
+ * https://github.com/altert/OpenseadragonFabricjsOverlay
+ */
+export default class OpenSeadragonCanvasOverlay {
+  /**
+   * constructor - sets up the Canvas overlay container
+   */
+  constructor(viewer) {
+    this.viewer = viewer;
+
+    this.containerWidth = 0;
+    this.containerHeight = 0;
+
+    this.canvasDiv = document.createElement('div');
+    this.canvasDiv.style.position = 'absolute';
+    this.canvasDiv.style.left = 0;
+    this.canvasDiv.style.top = 0;
+    this.canvasDiv.style.width = '100%';
+    this.canvasDiv.style.height = '100%';
+    this.viewer.canvas.appendChild(this.canvasDiv);
+
+    this.canvas = document.createElement('canvas');
+    this.canvasDiv.appendChild(this.canvas);
+    this.imgAspectRatio = 1;
+  }
+
+  /** */
+  get context2d() {
+    return this.canvas.getContext('2d');
+  }
+
+  /** */
+  clear() {
+    this.canvas.getContext('2d').clearRect(0, 0, this.containerWidth, this.containerHeight);
+  }
+
+  /**
+   * resize - resizes the added Canvas overlay.
+   */
+  resize() {
+    if (this.containerWidth !== this.viewer.container.clientWidth) {
+      this.containerWidth = this.viewer.container.clientWidth;
+      this.canvasDiv.setAttribute('width', this.containerWidth);
+      this.canvas.setAttribute('width', this.containerWidth);
+    }
+
+    if (this.containerHeight !== this.viewer.container.clientHeight) {
+      this.containerHeight = this.viewer.container.clientHeight;
+      this.canvasDiv.setAttribute('height', this.containerHeight);
+      this.canvas.setAttribute('height', this.containerHeight);
+    }
+
+    this.viewportOrigin = new OpenSeadragon.Point(0, 0);
+    const boundsRect = this.viewer.viewport.getBounds(true);
+    this.viewportOrigin.x = boundsRect.x;
+    this.viewportOrigin.y = boundsRect.y * this.imgAspectRatio;
+
+    this.viewportWidth = boundsRect.width;
+    this.viewportHeight = boundsRect.height * this.imgAspectRatio;
+    const image1 = this.viewer.world.getItemAt(0);
+    if (!image1) return;
+    this.imgWidth = image1.source.dimensions.x;
+    this.imgHeight = image1.source.dimensions.y;
+    this.imgAspectRatio = this.imgWidth / this.imgHeight;
+  }
+
+  /**
+   * canvasUpdate - sets up the dimensions for the canvas update to mimick image
+   * 0 dimensions. Then call provided update function.
+   * @param {Function} update
+   */
+  canvasUpdate(update) {
+    const viewportZoom = this.viewer.viewport.getZoom(true);
+    const image1 = this.viewer.world.getItemAt(0);
+    if (!image1) return;
+    const zoom = image1.viewportToImageZoom(viewportZoom);
+
+    const x = (
+      (this.viewportOrigin.x / this.imgWidth - this.viewportOrigin.x) / this.viewportWidth
+    ) * this.containerWidth;
+    const y = (
+      (this.viewportOrigin.y / this.imgHeight - this.viewportOrigin.y) / this.viewportHeight
+    ) * this.containerHeight;
+
+    if (this.clearBeforeRedraw) this.clear();
+    this.canvas.getContext('2d').translate(x, y);
+    this.canvas.getContext('2d').scale(zoom, zoom);
+
+    update();
+
+    this.canvas.getContext('2d').setTransform(1, 0, 0, 1, 0, 0);
+  }
+}


### PR DESCRIPTION
Fixes #2015 

![singlecanvasannos](https://user-images.githubusercontent.com/1656824/54137007-75d3de80-43e2-11e9-8796-bd86b5e521ab.gif)


Split off additional work needed:
 - Display annotations on canvases in BookView #2133
 - TBD, will work w/ @ggeisler, @camillevilla, and @jvine to make sure the next tickets needed are split off appropriately