### PR TITLE
When sidebar menu is toggled, info panel is displayed by default

### DIFF
--- a/__tests__/integration/mirador/companion_windows.test.js
+++ b/__tests__/integration/mirador/companion_windows.test.js
@@ -8,7 +8,8 @@ describe('Companion Windows', () => {
     await expect(page).toClick('button[aria-label="Toggle window sidebar"]');
 
     await page.waitFor(1000);
-    await expect(page).toClick('button[aria-label="Open information companion window"]');
+    await expect(page).toMatchElement('.mirador-companion-window-left.mirador-window-sidebar-info-panel');
+    await expect(page).toMatchElement('button[aria-label="Open information companion window"][aria-selected="true"]');
 
     await expect(page).not.toMatchElement('.mirador-companion-window-right.mirador-window-sidebar-info-panel');
 

--- a/__tests__/src/actions/window.test.js
+++ b/__tests__/src/actions/window.test.js
@@ -15,20 +15,24 @@ describe('window actions', () => {
           id: 'helloworld',
           canvasIndex: 1,
           collectionIndex: 0,
-          companionWindowIds: [],
           manifestId: null,
           maximized: false,
           rangeId: null,
           thumbnailNavigationPosition: 'bottom',
           x: 2700,
           y: 2700,
+          sideBarPanel: 'info',
           width: 400,
           height: 400,
           rotation: null,
           view: 'single',
         },
+        companionWindows: [{ position: 'left', content: 'info' }],
       };
-      expect(actions.addWindow(options)).toEqual(expectedAction);
+      const action = actions.addWindow(options);
+      expect(action).toMatchObject(expectedAction);
+      expect(action.window.companionWindowIds.length).toEqual(1);
+      expect(action.window.companionWindowIds[0]).toEqual(action.companionWindows[0].id);
     });
   });
 

--- a/__tests__/src/reducers/companionWindows.test.js
+++ b/__tests__/src/reducers/companionWindows.test.js
@@ -20,6 +20,22 @@ describe('companionWindowsReducer', () => {
     });
   });
 
+  describe('ADD_WINDOW', () => {
+    it('adds default companion window(s)', () => {
+      const action = {
+        type: ActionTypes.ADD_WINDOW,
+        companionWindows: [{ id: 'banana', position: 'left', content: 'info' }, { id: 'Banane', position: 'right', content: 'canvas_navigation' }],
+      };
+      const beforeState = {};
+      const expectedState = {
+        banana: { id: 'banana', position: 'left', content: 'info' },
+        Banane: { id: 'Banane', position: 'right', content: 'canvas_navigation' },
+      };
+      expect(companionWindowsReducer(beforeState, action)).toEqual(expectedState);
+    });
+  });
+
+
   describe('UPDATE_COMPANION_WINDOW', () => {
     it('updates an existing companion window', () => {
       const action = {

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -37,7 +37,7 @@ export function addWindow(options) {
     view: 'single',
     maximized: false,
   };
-  return { type: ActionTypes.ADD_WINDOW, window: { ...defaultOptions, ...options }, companionWindow: { id: cwDefault, position: 'left', content: 'info' } };
+  return { type: ActionTypes.ADD_WINDOW, window: { ...defaultOptions, ...options }, companionWindows: [{ id: cwDefault, position: 'left', content: 'info' }] };
 }
 
 /**

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -19,6 +19,7 @@ export function focusWindow(windowId) {
  * @memberof ActionCreators
  */
 export function addWindow(options) {
+  const cwDefault = `cw-${uuid()}`;
   const defaultOptions = {
     id: `window-${uuid()}`,
     canvasIndex: 0,
@@ -30,12 +31,13 @@ export function addWindow(options) {
     height: 400,
     x: 2700,
     y: 2700,
-    companionWindowIds: [],
+    companionWindowIds: [cwDefault],
+    sideBarPanel: 'info',
     rotation: null,
     view: 'single',
     maximized: false,
   };
-  return { type: ActionTypes.ADD_WINDOW, window: { ...defaultOptions, ...options } };
+  return { type: ActionTypes.ADD_WINDOW, window: { ...defaultOptions, ...options }, companionWindow: { id: cwDefault, position: 'left', content: 'info' } };
 }
 
 /**

--- a/src/state/reducers/companionWindows.js
+++ b/src/state/reducers/companionWindows.js
@@ -9,6 +9,9 @@ export function companionWindowsReducer(state = {}, action) {
     case ActionTypes.ADD_COMPANION_WINDOW:
       return setIn(state, [action.id], action.payload);
 
+    case ActionTypes.ADD_WINDOW:
+      return setIn(state, [action.companionWindow.id], action.companionWindow);
+
     case ActionTypes.UPDATE_COMPANION_WINDOW:
       return updateIn(state, [action.id], orig => merge(orig, action.payload));
 

--- a/src/state/reducers/companionWindows.js
+++ b/src/state/reducers/companionWindows.js
@@ -10,7 +10,10 @@ export function companionWindowsReducer(state = {}, action) {
       return setIn(state, [action.id], action.payload);
 
     case ActionTypes.ADD_WINDOW:
-      return setIn(state, [action.companionWindow.id], action.companionWindow);
+      return action.companionWindows.reduce((newState, cw) => {
+        newState[cw.id] = cw; // eslint-disable-line no-param-reassign
+        return newState;
+      }, state);
 
     case ActionTypes.UPDATE_COMPANION_WINDOW:
       return updateIn(state, [action.id], orig => merge(orig, action.payload));


### PR DESCRIPTION
Closes #2059

Behavior changes:
- When a user clicks on the sidebar toggle the info panel is displayed by default

![new-sidebar-behavior](https://user-images.githubusercontent.com/5402927/54149828-504fd080-43f4-11e9-855b-d10fb9109e99.gif)

@jvine @ggeisler I believe this is the last piece in #1853, so this feature might be ready for another round of design review.