### PR TITLE
remove dead code

### DIFF
--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -90,10 +90,6 @@ export const windowsReducer = (state = {}, action) => {
           y: action.payload.size.y,
         },
       };
-    case ActionTypes.NEXT_CANVAS:
-      return setCanvasIndex(state, action.windowId, currentIndex => currentIndex + 1);
-    case ActionTypes.PREVIOUS_CANVAS:
-      return setCanvasIndex(state, action.windowId, currentIndex => currentIndex - 1);
     case ActionTypes.SET_CANVAS:
       return setCanvasIndex(state, action.windowId, currentIndex => action.canvasIndex);
     case ActionTypes.ADD_COMPANION_WINDOW:


### PR DESCRIPTION
The two removed cases are obsolete, as the correlating ActionTypes do not exist anymore.