### PR TITLE
add basic gallery view to windows

### DIFF
--- a/__tests__/src/components/GalleryView.test.js
+++ b/__tests__/src/components/GalleryView.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import manifesto from 'manifesto.js';
+import manifestJson from '../../fixtures/version-2/019.json';
+import { GalleryView } from '../../../src/components/GalleryView';
+
+/** create wrapper */
+function createWrapper(props) {
+  return shallow(
+    <GalleryView
+      window={{ id: '1234', canvasIndex: 0 }}
+      manifest={{ manifestation: manifesto.create(manifestJson) }}
+      setCanvas={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe('GalleryView', () => {
+  let setCanvas;
+  let wrapper;
+  beforeEach(() => {
+    setCanvas = jest.fn();
+    wrapper = createWrapper({ setCanvas });
+  });
+  it('renders the component', () => {
+    expect(wrapper.find('.mirador-gallery-container').length).toBe(1);
+  });
+  it('renders gallery items for all canvases', () => {
+    expect(wrapper.find('.mirador-gallery-view-item').length).toBe(3);
+  });
+  it('sets a mirador-current-canvas class on current canvas', () => {
+    expect(wrapper.find('.mirador-gallery-view-item.mirador-current-canvas'));
+  });
+  it('renders the canvas labels for each canvas in canvas items', () => {
+    expect(wrapper.find('WithStyles(Typography)').length).toBe(3);
+  });
+  it('gives special class to current canvas item', () => {
+    wrapper.find('.mirador-gallery-view-item').first().simulate('click');
+    expect(setCanvas).toHaveBeenCalledWith('1234', 0);
+    expect(wrapper.find('WithStyles(Typography)').length).toBe(3);
+  });
+  describe('instance methods', () => {
+    it('calculates containerClasses', () => {
+      wrapper = createWrapper({ setCanvas });
+      expect(wrapper.instance().containerClasses(0)).toBe('mirador-gallery-view-item current-canvas');
+      expect(wrapper.instance().containerClasses(1)).toBe('mirador-gallery-view-item ');
+    });
+  });
+});

--- a/__tests__/src/components/PrimaryWindow.test.js
+++ b/__tests__/src/components/PrimaryWindow.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { PrimaryWindow } from '../../../src/components/PrimaryWindow';
 import WindowSideBar from '../../../src/containers/WindowSideBar';
 import WindowViewer from '../../../src/containers/WindowViewer';
+import GalleryView from '../../../src/containers/GalleryView';
 
 /** create wrapper */
 function createWrapper(props) {
@@ -28,5 +29,11 @@ describe('PrimaryWindow', () => {
     const manifest = { id: 456, isFetching: false };
     const wrapper = createWrapper({ manifest });
     expect(wrapper.find(WindowViewer)).toHaveLength(1);
+  });
+  it('should render <GalleryView> if manifest is present and view is gallery', () => {
+    const manifest = { id: 456, isFetching: false };
+    const window = { id: 'window-2', view: 'gallery' };
+    const wrapper = createWrapper({ manifest, window });
+    expect(wrapper.find(GalleryView)).toHaveLength(1);
   });
 });

--- a/__tests__/src/components/WindowViewSettings.test.js
+++ b/__tests__/src/components/WindowViewSettings.test.js
@@ -23,9 +23,10 @@ describe('WindowViewSettings', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(ListSubheader).length).toBe(1);
     const labels = wrapper.find(FormControlLabel);
-    expect(labels.length).toBe(2);
+    expect(labels.length).toBe(3);
     expect(labels.at(0).props().value).toBe('single');
     expect(labels.at(1).props().value).toBe('book');
+    expect(labels.at(2).props().value).toBe('gallery');
   });
 
   it('should set the correct label active (by setting the secondary color)', () => {
@@ -35,6 +36,9 @@ describe('WindowViewSettings', () => {
 
     wrapper = createWrapper({ windowViewType: 'book' });
     expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).toEqual('secondary');
+
+    wrapper = createWrapper({ windowViewType: 'gallery' });
+    expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).toEqual('secondary');
   });
 
   it('updates state when the view config selection changes', () => {
@@ -44,6 +48,8 @@ describe('WindowViewSettings', () => {
     expect(setWindowViewType).toHaveBeenCalledWith('xyz', 'single');
     wrapper.find(MenuItem).at(1).simulate('click');
     expect(setWindowViewType).toHaveBeenCalledWith('xyz', 'book');
+    wrapper.find(MenuItem).at(2).simulate('click');
+    expect(setWindowViewType).toHaveBeenCalledWith('xyz', 'gallery');
   });
 
   it('sets the selected ref to a MenuItem in the component (when mounting)', () => {

--- a/__tests__/src/lib/CanvasGroupings.test.js
+++ b/__tests__/src/lib/CanvasGroupings.test.js
@@ -52,5 +52,11 @@ describe('CanvasGroupings', () => {
         expect(subject.getCanvases(2)).toEqual([1, 2]);
       });
     });
+    describe('gallery', () => {
+      it('selects by index', () => {
+        const subject = new CanvasGroupings([0, 1, 2, 3]);
+        expect(subject.getCanvases(2)).toEqual([2]);
+      });
+    });
   });
 });

--- a/src/components/GalleryView.js
+++ b/src/components/GalleryView.js
@@ -1,0 +1,81 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import ManifestoCanvas from '../lib/ManifestoCanvas';
+import { getCanvasLabel, getManifestCanvases } from '../state/selectors';
+import { CanvasThumbnail } from './CanvasThumbnail';
+import ns from '../config/css-ns';
+
+
+/**
+ * Represents a WindowViewer in the mirador workspace. Responsible for mounting
+ * OSD and Navigation
+ */
+export class GalleryView extends Component {
+  /**
+   * @param {Object} props
+   */
+  constructor(props) {
+    super(props);
+
+    const { manifest } = this.props;
+    this.canvases = manifest.manifestation.getSequences()[0].getCanvases();
+  }
+
+  /**
+   * container classes
+   */
+  containerClasses(currentCanvas) {
+    const { window } = this.props;
+    const currentClass = (currentCanvas === window.canvasIndex) ? 'current-canvas' : '';
+    return `${ns('gallery-view-item')} ${currentClass}`;
+  }
+
+  /**
+   * Renders things
+   */
+  render() {
+    const { window, manifest, setCanvas } = this.props;
+    return (
+      <>
+        <section
+          className={ns('gallery-container')}
+          id={`${window.id}-gallery`}
+        >
+          {
+            getManifestCanvases(manifest).map((canvas) => {
+              const manifestoCanvas = new ManifestoCanvas(canvas);
+              return (
+                <div
+                  key={canvas.index}
+                  className={this.containerClasses(canvas.index)}
+                  onClick={() => setCanvas(window.id, canvas.index)}
+                  onKeyUp={() => setCanvas(window.id, canvas.index)}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <CanvasThumbnail
+                    imageUrl={manifestoCanvas.thumbnail(null, 100)}
+                    isValid={manifestoCanvas.hasValidDimensions}
+                    maxHeight={120}
+                    maxWidth={100}
+                    aspectRatio={manifestoCanvas.aspectRatio}
+                  />
+                  <Typography variant="caption">
+                    {getCanvasLabel(canvas, canvas.index)}
+                  </Typography>
+                </div>
+              );
+            })
+          }
+        </section>
+      </>
+    );
+  }
+}
+
+GalleryView.propTypes = {
+  manifest: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  setCanvas: PropTypes.func.isRequired,
+};

--- a/src/components/PrimaryWindow.js
+++ b/src/components/PrimaryWindow.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import WindowSideBar from '../containers/WindowSideBar';
 import WindowViewer from '../containers/WindowViewer';
+import GalleryView from '../containers/GalleryView';
 import CompanionArea from '../containers/CompanionArea';
 import ns from '../config/css-ns';
 
@@ -18,6 +19,14 @@ export class PrimaryWindow extends Component {
   renderViewer() {
     const { manifest, window } = this.props;
     if (manifest && manifest.isFetching === false) {
+      if (window.view === 'gallery') {
+        return (
+          <GalleryView
+            window={window}
+            manifest={manifest}
+          />
+        );
+      }
       return (
         <WindowViewer
           window={window}

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -6,6 +6,7 @@ import ListSubheader from '@material-ui/core/ListSubheader';
 import SingleIcon from '@material-ui/icons/CropOriginalSharp';
 import PropTypes from 'prop-types';
 import BookViewIcon from './icons/BookViewIcon';
+import GalleryViewIcon from './icons/GalleryViewIcon';
 
 /**
  *
@@ -80,6 +81,15 @@ export class WindowViewSettings extends Component {
             classes={{ label: windowViewType === 'book' ? classes.selectedLabel : undefined }}
             control={<BookViewIcon color={windowViewType === 'book' ? 'secondary' : undefined} />}
             label={t('book')}
+            labelPlacement="bottom"
+          />
+        </MenuItem>
+        <MenuItem className={classes.MenuItem} onClick={() => { this.handleChange('gallery'); handleClose(); }}>
+          <FormControlLabel
+            value="gallery"
+            classes={{ label: windowViewType === 'gallery' ? classes.selectedLabel : undefined }}
+            control={<GalleryViewIcon color={windowViewType === 'gallery' ? 'secondary' : undefined} />}
+            label={t('gallery')}
             labelPlacement="bottom"
           />
         </MenuItem>

--- a/src/components/icons/GalleryViewIcon.js
+++ b/src/components/icons/GalleryViewIcon.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+/**
+ * GalleryViewIcon ~
+ */
+export default function GalleryViewIcon(props) {
+  return (
+    <SvgIcon {...props}>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <path d="M19.974,2H2V19.974H19.974V2ZM7.392,18.177H3.8V14.582H7.392Zm0-5.392H3.8V9.19H7.392Zm0-5.392H3.8V3.8H7.392Zm5.392,10.785H9.19V14.582h3.595Zm0-5.392H9.19V9.19h3.595Zm0-5.392H9.19V3.8h3.595Zm5.392,10.785H14.582V14.582h3.595Zm0-5.392H14.582V9.19h3.595Zm0-5.392H14.582V3.8h3.595Z" transform="translate(1 1)" />
+      </svg>
+    </SvgIcon>
+  );
+}

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -40,8 +40,8 @@ export default {
       },
       caption: {
         fontSize: "0.772rem",
-        letterSpacing: "0.13em",
-        lineHeight: "1.1rem",
+        letterSpacing: "0.033em",
+        lineHeight: "1.6rem",
       },
       body1Next: {
         fontSize: "1rem",

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -41,7 +41,6 @@ export default {
       caption: {
         fontSize: "0.772rem",
         letterSpacing: "0.13em",
-        textAlign: 'center',
         lineHeight: "1.1rem",
       },
       body1Next: {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -40,8 +40,9 @@ export default {
       },
       caption: {
         fontSize: "0.772rem",
-        letterSpacing: "0.033em",
-        lineHeight: "1.6rem",
+        letterSpacing: "0.13em",
+        textAlign: 'center',
+        lineHeight: "1.1rem",
       },
       body1Next: {
         fontSize: "1rem",

--- a/src/containers/GalleryView.js
+++ b/src/containers/GalleryView.js
@@ -1,0 +1,31 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import * as actions from '../state/actions';
+import { withPlugins } from '../extend';
+import { GalleryView } from '../components/GalleryView';
+
+/**
+ * mapStateToProps - to hook up connect
+ * @memberof WindowViewer
+ * @private
+ */
+const mapStateToProps = state => (
+  {}
+);
+
+/**
+ * mapDispatchToProps - used to hook up connect to action creators
+ * @memberof WindowViewer
+ * @private
+ */
+const mapDispatchToProps = {
+  setCanvas: actions.setCanvas,
+};
+
+const enhance = compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  withPlugins('GalleryView'),
+  // further HOC go here
+);
+
+export default enhance(GalleryView);

--- a/src/lib/CanvasGroupings.js
+++ b/src/lib/CanvasGroupings.js
@@ -29,7 +29,7 @@ export default class CanvasGroupings {
     if (this._groupings) { // eslint-disable-line no-underscore-dangle
       return this._groupings; // eslint-disable-line no-underscore-dangle
     }
-    if (this.viewType === 'single') {
+    if (this.viewType !== 'book') {
       return this.canvases.map(canvas => [canvas]);
     }
     const groupings = [];

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -28,6 +28,7 @@
     "exitFullScreen": "Exit full screen",
     "expandSidePanel": "Expand side panel",
     "fetchManifest": "Add",
+    "gallery": "Gallery",
     "hideZoomControls": "Hide zoom controls",
     "item": "Item: {{label}}",
     "language": "Language",

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -136,6 +136,7 @@ export function getSelectedCanvas(state, windowId) {
 export function getSelectedCanvases(state, windowId) {
   const manifest = getWindowManifest(state, windowId);
   const { canvasIndex, view } = state.windows[windowId];
+  console.debug();
 
   return manifest
     && manifest.manifestation

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -120,6 +120,10 @@
     cursor: pointer;
     transition: 0.1s transform ease-out;
 
+    span {
+      textAlign: 'center',
+    }
+
     &.current-canvas {
       border: 2px solid deepskyblue;
       padding: 3px;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -101,6 +101,47 @@
     position: relative;
   }
 
+  &-gallery-container {
+    flex: 1;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    padding: 50px 0 50px 20px;
+  }
+
+  &-gallery-view-item {
+    display: inline-block;
+    max-width: 100px;
+    height: 160px;
+    overflow: hidden;
+    text-overflow: elipsis;
+    margin: 10px 5px;
+    padding: 5px;
+    box-sizing: border-box;
+    cursor: pointer;
+    transition: 0.1s transform ease-out;
+
+    &.current-canvas {
+      border: 2px solid deepskyblue;
+      padding: 3px;
+    }
+
+    &:hover {
+      transition: 0.1s transform ease-out;
+      transform: scale(1.05);
+      border: 2px solid deepskyblue;
+      padding: 3px;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    img {
+      display: block;
+      margin: 0 auto;
+    }
+  }
+
   &-osd-container {
     flex: 1;
     position: relative;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -121,7 +121,7 @@
     transition: 0.1s transform ease-out;
 
     span {
-      textAlign: 'center',
+      text-align: 'center',
     }
 
     &.current-canvas {


### PR DESCRIPTION
![gallery view](https://user-images.githubusercontent.com/145874/54215062-877dba80-44a4-11e9-95eb-893c9ee49b62.gif)

### Acceptance Criteria
- [x] User can select "Gallery" from window topbar
  - [x] Uses CustomGalleryView SVG from #1947 
  `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19.974,2H2V19.974H19.974V2ZM7.392,18.177H3.8V14.582H7.392Zm0-5.392H3.8V9.19H7.392Zm0-5.392H3.8V3.8H7.392Zm5.392,10.785H9.19V14.582h3.595Zm0-5.392H9.19V9.19h3.595Zm0-5.392H9.19V3.8h3.595Zm5.392,10.785H14.582V14.582h3.595Zm0-5.392H14.582V9.19h3.595Zm0-5.392H14.582V3.8h3.595Z" transform="translate(1 1)"/></svg>`
  - [x] Wraps icon in MUI `<SvgIcon>` for theme-ability. See approach in #1967 used for other custom SVGs
- [x] Uses a vanilla HTML implementation (not something canvas-based, like [OSD Collection mode](https://openseadragon.github.io/examples/tilesource-collection/) per discussion with tech lead and design team) so that content will be keyboard navigable
- Clicking on a canvas
  - [x] Provides a visual indicator around selected canvas (see mockup)
  - [x] Updates `canvasIndex` 
  - [x] viewer stays in Gallery view (i.e. this is a departure from Mirador 2 gallery behavior)
- [x] Switching to an alternate view (single, book) opens to the selected canvas
- [ ] Add tests
## Questions @ggeisler @jvine 
- **"No selected canvas" UI State**  - In the [original ticket](https://github.com/ProjectMirador/mirador/issues/2032), there are some gifs that describe a state in which there is no selected canvas. At least as currently implemented, this state is never reached by the application. Do we still want to account for this?
- **Accessibility roles** - I added a `role="button"` to the gallery items, but I wasn't sure about further guidance on this. Could be ticketed elsewhere.
- **Caption Typography** - In its current state, I edited the caption typography. Not sure if we want to include that here or just remove the labels entirely. There are a few design considerations around how labels are elided, and how they affect the layout (especially the height) of the items in the view.
- **Layout Considerations** - There were quite a few layout considerations I ran into, and some manual testing and experimentations with various manifest types with disparate canvas aspect ratios would be useful. I ran into these kinds of things several years ago and wrote of some code and diagrams pertaining to them in [this repo](https://github.com/sul-dlss/iiif-layout-functions/blob/master/README.md). See also the issues for diagrams that contain more questions.