### PR TITLE
2034 optimize sidebar structure for keyboard support

### DIFF
--- a/__tests__/src/components/WindowSideBar.test.js
+++ b/__tests__/src/components/WindowSideBar.test.js
@@ -1,17 +1,86 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import Drawer from '@material-ui/core/Drawer';
-import WindowSideBarButtons from '../../../src/containers/WindowSideBarButtons';
-import { WindowSideBar } from '../../../src/components/WindowSideBar';
+import { mount } from 'enzyme';
+import { WindowSideBarButtons } from '../../../src/components/WindowSideBarButtons';
 
-describe('WindowSideBar', () => {
+/** create wrapper */
+function createWrapper(props) {
+  return mount(
+    <WindowSideBarButtons
+      addCompanionWindow={() => {}}
+      {...props}
+    />,
+  );
+}
+
+/**
+ * Assert which tab is focussed
+ */
+function assertTabFocused(wrapper, tabIndex) {
+  const tabs = wrapper.find('button[role="tab"]');
+
+  tabs.forEach((tab, index) => {
+    if (index === tabIndex) {
+      expect(tab.find('button').instance()).toEqual(document.activeElement);
+    }
+  });
+}
+
+describe('WindowSideBarButtons (shallow)', () => {
+  const windowId = 'test123';
   let wrapper;
+
   beforeEach(() => {
-    wrapper = shallow(<WindowSideBar windowId="1" classes={{}} />);
+    wrapper = createWrapper({ windowId });
   });
 
   it('renders without an error', () => {
-    expect(wrapper.find(Drawer).length).toBe(1);
-    expect(wrapper.find(WindowSideBarButtons).length).toBe(1);
+    expect(wrapper.find('WithStyles(Tabs)').length).toBe(1);
+  });
+
+  it('triggers the addCompanionWindow prop on click', () => {
+    const addCompanionWindow = jest.fn();
+    wrapper = createWrapper({ addCompanionWindow, windowId });
+
+    wrapper.find('WithStyles(Tabs)').props().onChange({ target: { removeAttribute: () => {}, setAttribute: () => {} } }, 'info');
+    expect(addCompanionWindow).toHaveBeenCalledTimes(1);
+    expect(addCompanionWindow).toHaveBeenCalledWith('info');
+  });
+
+  it('has a badge indicating if the annotations panel has annotations', () => {
+    let tab;
+    wrapper = createWrapper({ hasAnnotations: true, windowId });
+    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]');
+    expect(tab.find('WithStyles(Badge)').props().invisible).toBe(false);
+
+    wrapper = createWrapper({ hasAnnotations: false, windowId });
+    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]');
+
+    expect(tab.find('WithStyles(Badge)').props().invisible).toBe(true);
+  });
+
+  describe('handleKeyUp', () => {
+    it('the first tab is focussed by default', () => {
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the next tab when pressing the down arrow', () => {
+      wrapper.find('button[role="tab"]').at(0).simulate('keyUp', { key: 'ArrowDown' });
+      assertTabFocused(wrapper, 1);
+    });
+
+    it('the focuses on the previous tab when pressing the up arrow', () => {
+      wrapper.find('button[role="tab"]').at(1).simulate('keyUp', { key: 'ArrowUp' });
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the first tab when pressing the down arrow from the last tab', () => {
+      wrapper.find('button[role="tab"]').last().simulate('keyUp', { key: 'ArrowDown' });
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the last tab when pressing the up arrow from the first tab', () => {
+      wrapper.find('button[role="tab"]').first().simulate('keyUp', { key: 'ArrowUp' });
+      assertTabFocused(wrapper, 2); // Assuming 3 tabs
+    });
   });
 });

--- a/__tests__/src/components/WindowSideBarButtons.test.js
+++ b/__tests__/src/components/WindowSideBarButtons.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { WindowSideBarButtons } from '../../../src/components/WindowSideBarButtons';
 
 /** create wrapper */
 function createWrapper(props) {
-  return shallow(
+  return mount(
     <WindowSideBarButtons
       addCompanionWindow={() => {}}
       {...props}
@@ -12,14 +12,24 @@ function createWrapper(props) {
   );
 }
 
-describe('WindowSideBarButtons', () => {
+/**
+ * Assert which tab is focussed
+ */
+function assertTabFocused(wrapper, tabIndex) {
+  const tabs = wrapper.find('button[role="tab"]');
+
+  tabs.forEach((tab, index) => {
+    if (index === tabIndex) {
+      expect(tab.find('button').instance()).toEqual(document.activeElement);
+    }
+  });
+}
+
+describe('WindowSideBarButtons (shallow)', () => {
   const windowId = 'test123';
   let wrapper;
 
   beforeEach(() => {
-    document.body.innerHTML = `<div id="${windowId}-sidebar-buttons" >`
-    + '<button role="tab" aria-selected="true" />'
-    + '</div>';
     wrapper = createWrapper({ windowId });
   });
 
@@ -31,7 +41,7 @@ describe('WindowSideBarButtons', () => {
     const addCompanionWindow = jest.fn();
     wrapper = createWrapper({ addCompanionWindow, windowId });
 
-    wrapper.find('WithStyles(Tabs)').simulate('change', { target: { removeAttribute: () => {}, setAttribute: () => {} } }, 'info');
+    wrapper.find('WithStyles(Tabs)').props().onChange({ target: { removeAttribute: () => {}, setAttribute: () => {} } }, 'info');
     expect(addCompanionWindow).toHaveBeenCalledTimes(1);
     expect(addCompanionWindow).toHaveBeenCalledWith('info');
   });
@@ -39,12 +49,38 @@ describe('WindowSideBarButtons', () => {
   it('has a badge indicating if the annotations panel has annotations', () => {
     let tab;
     wrapper = createWrapper({ hasAnnotations: true, windowId });
-    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]').dive().dive();
+    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]');
     expect(tab.find('WithStyles(Badge)').props().invisible).toBe(false);
 
     wrapper = createWrapper({ hasAnnotations: false, windowId });
-    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]').dive().dive();
+    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]');
 
     expect(tab.find('WithStyles(Badge)').props().invisible).toBe(true);
+  });
+
+  describe('handleKeyUp', () => {
+    it('the first tab is focussed by default', () => {
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the next tab when pressing the down arrow', () => {
+      wrapper.find('button[role="tab"]').at(0).simulate('keyUp', { key: 'ArrowDown' });
+      assertTabFocused(wrapper, 1);
+    });
+
+    it('the focuses on the previous tab when pressing the up arrow', () => {
+      wrapper.find('button[role="tab"]').at(1).simulate('keyUp', { key: 'ArrowUp' });
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the first tab when pressing the down arrow from the last tab', () => {
+      wrapper.find('button[role="tab"]').last().simulate('keyUp', { key: 'ArrowDown' });
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the last tab when pressing the up arrow from the first tab', () => {
+      wrapper.find('button[role="tab"]').first().simulate('keyUp', { key: 'ArrowUp' });
+      assertTabFocused(wrapper, 2); // Assuming 3 tabs
+    });
   });
 });

--- a/__tests__/src/components/WindowSideBarButtons.test.js
+++ b/__tests__/src/components/WindowSideBarButtons.test.js
@@ -13,9 +13,14 @@ function createWrapper(props) {
 }
 
 describe('WindowSideBarButtons', () => {
+  const windowId = 'test123';
   let wrapper;
+
   beforeEach(() => {
-    wrapper = createWrapper();
+    document.body.innerHTML = `<div id="${windowId}-sidebar-buttons" >`
+    + '<button role="tab" aria-selected="true" />'
+    + '</div>';
+    wrapper = createWrapper({ windowId });
   });
 
   it('renders without an error', () => {
@@ -24,20 +29,20 @@ describe('WindowSideBarButtons', () => {
 
   it('triggers the addCompanionWindow prop on click', () => {
     const addCompanionWindow = jest.fn();
-    wrapper = createWrapper({ addCompanionWindow });
+    wrapper = createWrapper({ addCompanionWindow, windowId });
 
-    wrapper.find('WithStyles(Tabs)').simulate('change', {}, 'info');
+    wrapper.find('WithStyles(Tabs)').simulate('change', { target: { removeAttribute: () => {}, setAttribute: () => {} } }, 'info');
     expect(addCompanionWindow).toHaveBeenCalledTimes(1);
     expect(addCompanionWindow).toHaveBeenCalledWith('info');
   });
 
   it('has a badge indicating if the annotations panel has annotations', () => {
     let tab;
-    wrapper = createWrapper({ hasAnnotations: true });
+    wrapper = createWrapper({ hasAnnotations: true, windowId });
     tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]').dive().dive();
     expect(tab.find('WithStyles(Badge)').props().invisible).toBe(false);
 
-    wrapper = createWrapper({ hasAnnotations: false });
+    wrapper = createWrapper({ hasAnnotations: false, windowId });
     tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]').dive().dive();
 
     expect(tab.find('WithStyles(Badge)').props().invisible).toBe(true);

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -35,7 +35,8 @@ export class WindowSideBarButtons extends Component {
   componentDidMount() {
     // eslint-disable-next-line react/no-find-dom-node
     this.tabs = Array.from(ReactDOM.findDOMNode(this.tabRef).getElementsByTagName('button'));
-    this.tabBar = this.tabs[0].parent;
+    console.log(this.tabs[0]);
+    this.tabBar = this.tabs[0].parentElement;
     this.selectTab(this.tabs[0]);
   }
 

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -13,14 +13,22 @@ import CanvasIndexIcon from './icons/CanvasIndexIcon';
  *
  */
 export class WindowSideBarButtons extends Component {
+  /**
+   * selects the given tab
+   * @param {*} tab the tab to activate
+   */
+  static activateTab(tab) {
+    tab.removeAttribute('tabindex');
+    tab.setAttribute('aria-selected', 'true');
+  }
+
   /** */
   constructor(props) {
     super(props);
+    const { windowId } = this.props;
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleTabRef = this.handleTabRef.bind(this);
-
+    this.windowId = `${windowId}-sidebar-buttons`;
     this.keys = {
       down: 40,
       end: 35,
@@ -33,21 +41,17 @@ export class WindowSideBarButtons extends Component {
    *
    */
   componentDidMount() {
-    // eslint-disable-next-line react/no-find-dom-node
-    this.tabs = Array.from(ReactDOM.findDOMNode(this.tabRef).getElementsByTagName('button'));
-    console.log(this.tabs[0]);
+    this.tabs = Array.from(document.querySelectorAll(`#${this.windowId} button[role=tab]`));
     this.tabBar = this.tabs[0].parentElement;
-    this.selectTab(this.tabs[0]);
-  }
 
-  /**
-  * ref handler for the tab
-  * @param {*} node
-  */
-  handleTabRef(node) {
-    if (node != null) {
-      this.tabRef = node;
-    }
+    /*
+      the change event isn't fired, when the tabs component is initialized,
+      so we have to perform the required actions on our own
+    */
+    const selectedTab = document.querySelectorAll('[aria-selected="true"]')[0];
+    this.selectTab(selectedTab);
+    this.deactivateTabs(this.tabs.indexOf(selectedTab));
+    selectedTab.focus();
   }
 
   /**
@@ -56,17 +60,18 @@ export class WindowSideBarButtons extends Component {
   */
   handleChange(event, value) {
     const { addCompanionWindow } = this.props;
-    this.selectTab(event.target);
+    const tab = event.target;
+
+    this.selectTab(tab);
     addCompanionWindow(value);
   }
 
   /**
-   * select the given tab
+   *
    * @param {*} tab
    */
   selectTab(tab) {
-    tab.removeAttribute('tabindex');
-    tab.setAttribute('aria-selected', 'true');
+    WindowSideBarButtons.activateTab(tab);
     this.deactivateTabs(this.tabs.indexOf(tab));
   }
 
@@ -101,23 +106,6 @@ export class WindowSideBarButtons extends Component {
   }
 
   /**
-   *
-   * @param {object} event the keyDown event
-   */
-  handleKeyDown(event) {
-    switch (event.keyCode) {
-      case this.keys.home:
-        event.preventDefault();
-        return this.focusFirstTab();
-      case this.keys.end:
-        event.preventDefault();
-        return this.focusLastTab();
-      default:
-        return null;
-    }
-  }
-
-  /**
    * focus the first tab
    */
   focusFirstTab() {
@@ -125,7 +113,7 @@ export class WindowSideBarButtons extends Component {
   }
 
   /**
-   *
+   * focus the previous tab
    * @param {object} tab the currently selected tab
    */
   focusPreviousTab(tab) {
@@ -141,7 +129,7 @@ export class WindowSideBarButtons extends Component {
   }
 
   /**
-   *
+   * focus the next tab
    * @param {object} tab the currently selected tab
    */
   focusNextTab(tab) {
@@ -231,6 +219,7 @@ WindowSideBarButtons.propTypes = {
   hasAnnotations: PropTypes.bool,
   sideBarPanel: PropTypes.string,
   t: PropTypes.func,
+  windowId: PropTypes.string.isRequired,
 };
 
 WindowSideBarButtons.defaultProps = {

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -24,10 +24,8 @@ export class WindowSideBarButtons extends Component {
   /** */
   constructor(props) {
     super(props);
-    const { windowId } = this.props;
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
-    this.windowId = `${windowId}-sidebar-buttons`;
     this.keys = {
       down: 40,
       end: 35,
@@ -40,7 +38,7 @@ export class WindowSideBarButtons extends Component {
    *
    */
   componentDidMount() {
-    this.tabs = Array.from(document.querySelectorAll(`#${this.windowId} button[role=tab]`));
+    this.tabs = Array.from(document.querySelectorAll(`#${this.containerId} button[role=tab]`));
     this.tabBar = this.tabs[0].parentElement;
 
     /*
@@ -171,7 +169,6 @@ export class WindowSideBarButtons extends Component {
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
           onKeyUp={this.handleKeyUp}
-          onKeyDown={this.handleKeyDown}
           value="info"
         />
         <Tab
@@ -186,7 +183,6 @@ export class WindowSideBarButtons extends Component {
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
           onKeyUp={this.handleKeyUp}
-          onKeyDown={this.handleKeyDown}
           value="canvas_navigation"
         />
         <Tab
@@ -203,7 +199,6 @@ export class WindowSideBarButtons extends Component {
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
           onKeyUp={this.handleKeyUp}
-          onKeyDown={this.handleKeyDown}
           value="annotations"
         />
       </Tabs>
@@ -217,7 +212,6 @@ WindowSideBarButtons.propTypes = {
   hasAnnotations: PropTypes.bool,
   sideBarPanel: PropTypes.string,
   t: PropTypes.func,
-  windowId: PropTypes.string.isRequired,
 };
 
 WindowSideBarButtons.defaultProps = {

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Badge from '@material-ui/core/Badge';
 import Tabs from '@material-ui/core/Tabs';
@@ -48,7 +47,7 @@ export class WindowSideBarButtons extends Component {
       the change event isn't fired, when the tabs component is initialized,
       so we have to perform the required actions on our own
     */
-    const selectedTab = document.querySelectorAll('[aria-selected="true"]')[0];
+    const selectedTab = this.tabs.find(t => (t.getAttribute('aria-selected')) === 'true');
     this.selectTab(selectedTab);
     this.deactivateTabs(this.tabs.indexOf(selectedTab));
     selectedTab.focus();
@@ -61,7 +60,6 @@ export class WindowSideBarButtons extends Component {
   handleChange(event, value) {
     const { addCompanionWindow } = this.props;
     const tab = event.target;
-
     this.selectTab(tab);
     addCompanionWindow(value);
   }

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -156,7 +156,7 @@ export class WindowSideBarButtons extends Component {
         indicatorColor="secondary"
         textColor="secondary"
         aria-orientation="vertical"
-        ref={this.handleTabRef}
+        ref={ref => this.setTabsRef(ref)}
       >
         <Tab
           classes={{ root: classes.tab, selected: classes.tabSelected }}

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -27,6 +27,13 @@ export class WindowSideBarButtons extends Component {
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
     this.keys = {
+      down: 'ArrowDown',
+      end: 'End',
+      home: 'Home',
+      up: 'ArrowUp',
+    };
+
+    this.chars = {
       down: 40,
       end: 35,
       home: 36,
@@ -89,16 +96,15 @@ export class WindowSideBarButtons extends Component {
    * @param {object} event the keyUp event
    */
   handleKeyUp(event) {
-    switch (event.keyCode) {
-      case this.keys.up:
-        event.preventDefault();
-        return this.focusPreviousTab(event.target);
-      case this.keys.down:
-        event.preventDefault();
-        return this.focusNextTab(event.target);
-      default:
-        return null;
+    if (event.key === this.keys.up || event.which === this.chars.up) {
+      event.preventDefault();
+      return this.focusPreviousTab(event.target);
     }
+    if (event.key === this.keys.down || event.which === this.chars.down) {
+      event.preventDefault();
+      return this.focusNextTab(event.target);
+    }
+    return null;
   }
 
   /**

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -18,7 +18,11 @@ export class WindowSideBarButtons extends Component {
    */
   static selectPreviousTab(event) {
     const { previousSibling } = event.target;
-    previousSibling && previousSibling.focus();
+    if (previousSibling) {
+      previousSibling.focus();
+    } else {
+      event.target.parentNode.lastChild.focus();
+    }
   }
 
   /**
@@ -27,7 +31,11 @@ export class WindowSideBarButtons extends Component {
    */
   static selectNextTab(event) {
     const { nextSibling } = event.target;
-    nextSibling && nextSibling.focus();
+    if (nextSibling) {
+      nextSibling.focus();
+    } else {
+      event.target.parentNode.firstChild.focus();
+    }
   }
 
   /**

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -54,7 +54,6 @@ export class WindowSideBarButtons extends Component {
     */
     const selectedTab = this.tabs.find(t => (t.getAttribute('aria-selected')) === 'true');
     this.selectTab(selectedTab);
-    this.deactivateTabs(this.tabs.indexOf(selectedTab));
     selectedTab.focus();
   }
 
@@ -71,7 +70,7 @@ export class WindowSideBarButtons extends Component {
 
   /**
    *
-   * @param {*} tab
+   * @param {*} tab the tab to select
    */
   selectTab(tab) {
     WindowSideBarButtons.activateTab(tab);
@@ -79,7 +78,7 @@ export class WindowSideBarButtons extends Component {
   }
 
   /**
-   * @param {number} omit index to omit
+   * @param {number} omit tab index to omit
    */
   deactivateTabs(omit = -1) {
     this.tabs.map((v, k) => {

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -12,13 +12,51 @@ import CanvasIndexIcon from './icons/CanvasIndexIcon';
  *
  */
 export class WindowSideBarButtons extends Component {
+  /**
+   *
+   * @param {object} event
+   */
+  static selectPreviousTab(event) {
+    const { previousSibling } = event.target;
+    previousSibling && previousSibling.focus();
+  }
+
+  /**
+   *
+   * @param {object} event
+   */
+  static selectNextTab(event) {
+    const { nextSibling } = event.target;
+    nextSibling && nextSibling.focus();
+  }
+
+  /**
+   *
+   * @param {object} event the onKeyDown event
+   */
+  static handleKeyPress(event) {
+    switch (event.keyCode) {
+      case 38: // arrow up
+        event.preventDefault();
+        return WindowSideBarButtons.selectPreviousTab(event);
+      case 40: // arrow down
+        event.preventDefault();
+        return WindowSideBarButtons.selectNextTab(event);
+      default:
+        return null;
+    }
+  }
+
   /** */
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
   }
 
-  /** */
+  /**
+   * @param {object} event the change event
+   * @param {string} value the tab's value
+  */
   handleChange(event, value) {
     const { addCompanionWindow } = this.props;
 
@@ -56,6 +94,7 @@ export class WindowSideBarButtons extends Component {
             </Tooltip>
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
+          onKeyDown={WindowSideBarButtons.handleKeyPress}
           value="info"
         />
         <Tab
@@ -69,6 +108,7 @@ export class WindowSideBarButtons extends Component {
             </Tooltip>
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
+          onKeyDown={WindowSideBarButtons.handleKeyPress}
           value="canvas_navigation"
         />
         <Tab
@@ -84,6 +124,7 @@ export class WindowSideBarButtons extends Component {
             </Tooltip>
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
+          onKeyDown={WindowSideBarButtons.handleKeyPress}
           value="annotations"
         />
       </Tabs>

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -13,22 +13,20 @@ import CanvasIndexIcon from './icons/CanvasIndexIcon';
  *
  */
 export class WindowSideBarButtons extends Component {
-  /**
-   * sets the focus on the given tab
-   */
-  static focusTab(tab) {
-    tab.focus();
-    tab.setAttribute('aria-selected', 'true');
-    tab.setAttribute('tabindex', '0');
-  }
-
   /** */
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
-    this.handleKeyPress = this.handleKeyPress.bind(this);
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleTabRef = this.handleTabRef.bind(this);
-    this.tabValues = ['info', 'canvas_navigation', 'annotations'];
+
+    this.keys = {
+      down: 40,
+      end: 35,
+      home: 36,
+      up: 38,
+    };
   }
 
   /**
@@ -38,10 +36,11 @@ export class WindowSideBarButtons extends Component {
     // eslint-disable-next-line react/no-find-dom-node, prefer-destructuring
     this.tabBar = ReactDOM.findDOMNode(this.tabRef).childNodes[0].childNodes[0].childNodes[0];
     this.tabs = Array.from(this.tabBar.childNodes);
+    this.selectTab(this.tabs[0]);
   }
 
   /**
-  *
+  * ref handler for the tab
   * @param {*} node
   */
   handleTabRef(node) {
@@ -56,15 +55,24 @@ export class WindowSideBarButtons extends Component {
   */
   handleChange(event, value) {
     const { addCompanionWindow } = this.props;
-    this.deactivateTabs(event, this.tabValues.indexOf(value));
+    this.selectTab(event.target);
     addCompanionWindow(value);
   }
 
   /**
-   * @param {object} event
+   * select the given tab
+   * @param {*} tab
+   */
+  selectTab(tab) {
+    tab.removeAttribute('tabindex');
+    tab.setAttribute('aria-selected', 'true');
+    this.deactivateTabs(this.tabs.indexOf(tab));
+  }
+
+  /**
    * @param {number} omit index to omit
    */
-  deactivateTabs(tab, omit = -1) {
+  deactivateTabs(omit = -1) {
     this.tabs.map((v, k) => {
       if (k !== omit) {
         v.setAttribute('tabindex', '-1');
@@ -76,14 +84,14 @@ export class WindowSideBarButtons extends Component {
 
   /**
    *
-   * @param {object} event the onKeyDown event
+   * @param {object} event the keyUp event
    */
-  handleKeyPress(event) {
+  handleKeyUp(event) {
     switch (event.keyCode) {
-      case 38: // arrow up
+      case this.keys.up:
         event.preventDefault();
         return this.focusPreviousTab(event.target);
-      case 40: // arrow down
+      case this.keys.down:
         event.preventDefault();
         return this.focusNextTab(event.target);
       default:
@@ -93,20 +101,51 @@ export class WindowSideBarButtons extends Component {
 
   /**
    *
-   * @param {object} event
+   * @param {object} event the keyDown event
    */
-  focusPreviousTab(tab) {
-    const previousTab = tab.previousSibling || this.tabBar.lastChild;
-    WindowSideBarButtons.focusTab(previousTab);
+  handleKeyDown(event) {
+    switch (event.keyCode) {
+      case this.keys.home:
+        event.preventDefault();
+        return this.focusFirstTab();
+      case this.keys.end:
+        event.preventDefault();
+        return this.focusLastTab();
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * focus the first tab
+   */
+  focusFirstTab() {
+    this.tabBar.firstChild.focus();
   }
 
   /**
    *
-   * @param {object} event
+   * @param {object} tab the currently selected tab
+   */
+  focusPreviousTab(tab) {
+    const previousTab = tab.previousSibling || this.tabBar.lastChild;
+    previousTab.focus();
+  }
+
+  /**
+   * focus the last tab
+   */
+  focusLastTab() {
+    this.tabBar.lastChild.focus();
+  }
+
+  /**
+   *
+   * @param {object} tab the currently selected tab
    */
   focusNextTab(tab) {
     const nextTab = tab.nextSibling || this.tabBar.firstChild;
-    WindowSideBarButtons.focusTab(nextTab);
+    nextTab.focus();
   }
 
   /**
@@ -144,7 +183,8 @@ export class WindowSideBarButtons extends Component {
             </Tooltip>
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
-          onKeyDown={this.handleKeyPress}
+          onKeyUp={this.handleKeyUp}
+          onKeyDown={this.handleKeyDown}
           value="info"
         />
         <Tab
@@ -158,7 +198,8 @@ export class WindowSideBarButtons extends Component {
             </Tooltip>
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
-          onKeyDown={this.handleKeyPress}
+          onKeyUp={this.handleKeyUp}
+          onKeyDown={this.handleKeyDown}
           value="canvas_navigation"
         />
         <Tab
@@ -174,7 +215,8 @@ export class WindowSideBarButtons extends Component {
             </Tooltip>
           )}
           TouchRippleProps={{ classes: { child: classes.tabRipple } }}
-          onKeyDown={this.handleKeyPress}
+          onKeyUp={this.handleKeyUp}
+          onKeyDown={this.handleKeyDown}
           value="annotations"
         />
       </Tabs>

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -33,9 +33,9 @@ export class WindowSideBarButtons extends Component {
    *
    */
   componentDidMount() {
-    // eslint-disable-next-line react/no-find-dom-node, prefer-destructuring
-    this.tabBar = ReactDOM.findDOMNode(this.tabRef).childNodes[0].childNodes[0].childNodes[0];
-    this.tabs = Array.from(this.tabBar.childNodes);
+    // eslint-disable-next-line react/no-find-dom-node
+    this.tabs = Array.from(ReactDOM.findDOMNode(this.tabRef).getElementsByTagName('button'));
+    this.tabBar = this.tabs[0].parent;
     this.selectTab(this.tabs[0]);
   }
 

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Badge from '@material-ui/core/Badge';
 import Tabs from '@material-ui/core/Tabs';
@@ -45,16 +46,25 @@ export class WindowSideBarButtons extends Component {
    *
    */
   componentDidMount() {
-    this.tabs = Array.from(document.querySelectorAll(`#${this.containerId} button[role=tab]`));
-    this.tabBar = this.tabs[0].parentElement;
+    this.tabBar = ReactDOM.findDOMNode(this.tabsRef); // eslint-disable-line react/no-find-dom-node
+    this.tabs = Array.from(this.tabBar.querySelectorAll('button[role=tab]'));
 
     /*
       the change event isn't fired, when the tabs component is initialized,
       so we have to perform the required actions on our own
     */
-    const selectedTab = this.tabs.find(t => (t.getAttribute('aria-selected')) === 'true');
+    const selectedTab = this.tabs.find(t => (t.getAttribute('aria-selected')) === 'true') || this.tabs[0];
     this.selectTab(selectedTab);
     selectedTab.focus();
+  }
+
+  /**
+   * Set the ref to the parent tabs element
+   */
+  setTabsRef(ref) {
+    if (this.tabsRef) return;
+
+    this.tabsRef = ref;
   }
 
   /**
@@ -107,26 +117,12 @@ export class WindowSideBarButtons extends Component {
   }
 
   /**
-   * focus the first tab
-   */
-  focusFirstTab() {
-    this.tabBar.firstChild.focus();
-  }
-
-  /**
    * focus the previous tab
    * @param {object} tab the currently selected tab
    */
   focusPreviousTab(tab) {
-    const previousTab = tab.previousSibling || this.tabBar.lastChild;
+    const previousTab = tab.previousSibling || this.tabs[this.tabs.length - 1];
     previousTab.focus();
-  }
-
-  /**
-   * focus the last tab
-   */
-  focusLastTab() {
-    this.tabBar.lastChild.focus();
   }
 
   /**
@@ -134,7 +130,7 @@ export class WindowSideBarButtons extends Component {
    * @param {object} tab the currently selected tab
    */
   focusNextTab(tab) {
-    const nextTab = tab.nextSibling || this.tabBar.firstChild;
+    const nextTab = tab.nextSibling || this.tabs[0];
     nextTab.focus();
   }
 

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -29,17 +29,8 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  * @private
  */
 const mapStateToProps = (state, { windowId }) => ({
-<<<<<<< HEAD
   hasAnnotations: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting'], windowId }).length > 0,
   sideBarPanel: (getCompanionWindowForPosition(state, { position: 'left', windowId }) || {}).content,
-=======
-  hasAnnotations: getAnnotationResourcesByMotivation(
-    getSelectedTargetAnnotations(state, (getSelectedCanvas(state, windowId) || {}).id),
-    ['oa:commenting', 'sc:painting'],
-  ).length > 0,
-  sideBarPanel: (getCompanionWindowForPosition(state, windowId, 'left') || {}).content,
-  windowId,
->>>>>>> #2034 refactoring
 });
 
 /** */

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -29,8 +29,17 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  * @private
  */
 const mapStateToProps = (state, { windowId }) => ({
+<<<<<<< HEAD
   hasAnnotations: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting'], windowId }).length > 0,
   sideBarPanel: (getCompanionWindowForPosition(state, { position: 'left', windowId }) || {}).content,
+=======
+  hasAnnotations: getAnnotationResourcesByMotivation(
+    getSelectedTargetAnnotations(state, (getSelectedCanvas(state, windowId) || {}).id),
+    ['oa:commenting', 'sc:painting'],
+  ).length > 0,
+  sideBarPanel: (getCompanionWindowForPosition(state, windowId, 'left') || {}).content,
+  windowId,
+>>>>>>> #2034 refactoring
 });
 
 /** */


### PR DESCRIPTION
After trying to to encapsulate the methods for the keyboard navigation, I've come to the conclusion, that the tab navigation is way too special, to re-use the implementation for other navigation controls. I ended up with a container for event handlers and a big handler clutter in the using component, so I reverted the changes.