### PR TITLE
Selector and API enhancements to support annotation work

### DIFF
--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -19,7 +19,8 @@ import {
   getManifestProvider,
   getManifestTitle,
   getManifestThumbnail,
-  getSelectedCanvasAnnotations,
+  getSelectedTargetAnnotations,
+  getSelectedTargetsAnnotations,
   getWindowViewType,
   getIdAndLabelOfCanvases,
   getCompanionWindowsOfWindow,
@@ -325,7 +326,7 @@ describe('getDestructuredMetadata', () => {
   });
 });
 
-describe('getSelectedCanvasAnnotations', () => {
+describe('getSelectedTargetAnnotations', () => {
   it('returns annotations for the given canvasId that have resources', () => {
     const state = {
       annotations: {
@@ -337,15 +338,42 @@ describe('getSelectedCanvasAnnotations', () => {
       },
     };
 
-    expect(getSelectedCanvasAnnotations(state, 'abc123').length).toEqual(1);
+    expect(getSelectedTargetAnnotations(state, 'abc123').length).toEqual(1);
   });
 
   it('returns an empty array if there are no annotations', () => {
     const state = { annotations: { xyz321: {} } };
     const expected = [];
 
-    expect(getSelectedCanvasAnnotations({}, 'abc123')).toEqual(expected);
-    expect(getSelectedCanvasAnnotations(state, 'abc123')).toEqual(expected);
+    expect(getSelectedTargetAnnotations({}, 'abc123')).toEqual(expected);
+    expect(getSelectedTargetAnnotations(state, 'abc123')).toEqual(expected);
+  });
+});
+
+describe('getSelectedTargetsAnnotations', () => {
+  it('returns annotations for multiple canvasIds', () => {
+    const state = {
+      annotations: {
+        abc123: {
+          annoId1: { '@id': 'annoId1', json: { resources: ['aResource'] } },
+          annoId2: { '@id': 'annoId2' },
+          annoId3: { '@id': 'annoId3', json: { resources: [] } },
+        },
+        def456: {
+          annoId4: { '@id': 'annoId4', json: { resources: ['helloWorld'] } },
+        },
+      },
+    };
+
+    expect(getSelectedTargetsAnnotations(state, ['abc123', 'def456']).length).toEqual(2);
+  });
+
+  it('returns an empty array if there are no annotations', () => {
+    const state = { annotations: { xyz321: {} } };
+    const expected = [];
+
+    expect(getSelectedTargetsAnnotations({}, ['abc123'])).toEqual(expected);
+    expect(getSelectedTargetsAnnotations(state, ['abc123'])).toEqual(expected);
   });
 });
 

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -8,7 +8,7 @@ import * as actions from '../state/actions';
 import {
   getCanvasLabel,
   getSelectedCanvas,
-  getSelectedCanvasAnnotations,
+  getSelectedTargetsAnnotations,
 } from '../state/selectors';
 
 /**
@@ -24,7 +24,7 @@ const mapStateToProps = ({
     getSelectedCanvas({ windows, manifests }, windowId),
     windows[windowId].canvasIndex,
   ),
-  annotations: getSelectedCanvasAnnotations(
+  annotations: getSelectedTargetsAnnotations(
     { annotations },
     currentCanvases.map(canvas => canvas.id),
   ),

--- a/src/containers/WindowSideBarAnnotationsPanel.js
+++ b/src/containers/WindowSideBarAnnotationsPanel.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import {
   getIdAndContentOfResources,
   getSelectedCanvas,
-  getSelectedCanvasAnnotations,
+  getSelectedTargetAnnotations,
   getAnnotationResourcesByMotivation,
 } from '../state/selectors';
 import { WindowSideBarAnnotationsPanel } from '../components/WindowSideBarAnnotationsPanel';
@@ -17,7 +17,7 @@ import { WindowSideBarAnnotationsPanel } from '../components/WindowSideBarAnnota
 const mapStateToProps = (state, { windowId }) => ({
   annotations: getIdAndContentOfResources(
     getAnnotationResourcesByMotivation(
-      getSelectedCanvasAnnotations(state, getSelectedCanvas(state, windowId).id),
+      getSelectedTargetAnnotations(state, getSelectedCanvas(state, windowId).id),
       ['oa:commenting', 'sc:painting'],
     ),
   ),

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -7,7 +7,7 @@ import * as actions from '../state/actions';
 import {
   getCompanionWindowForPosition,
   getSelectedCanvas,
-  getSelectedCanvasAnnotations,
+  getSelectedTargetAnnotations,
   getAnnotationResourcesByMotivation,
 } from '../state/selectors';
 import { WindowSideBarButtons } from '../components/WindowSideBarButtons';
@@ -32,7 +32,7 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  */
 const mapStateToProps = (state, { windowId }) => ({
   hasAnnotations: getAnnotationResourcesByMotivation(
-    getSelectedCanvasAnnotations(state, (getSelectedCanvas(state, windowId) || {}).id),
+    getSelectedTargetAnnotations(state, (getSelectedCanvas(state, windowId) || {}).id),
     ['oa:commenting', 'sc:painting'],
   ).length > 0,
   sideBarPanel: (getCompanionWindowForPosition(state, windowId, 'left') || {}).content,

--- a/src/lib/Annotation.js
+++ b/src/lib/Annotation.js
@@ -2,8 +2,9 @@ import AnnotationResource from './AnnotationResource';
 /** */
 export default class Annotation {
   /** */
-  constructor(json) {
+  constructor(json, target) {
     this.json = json;
+    this.target = target;
   }
 
   /** */

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -126,17 +126,32 @@ export function getSelectedCanvas(state, windowId) {
 }
 
 /**
-* Return the current canvas' (selected in a window) annotations
+* Return annotations for an array of targets
 * @param {object} state
-* @param {String} windowId
+* @param {Array} targets
 * @return {Array}
 */
-export function getSelectedCanvasAnnotations(state, canvasId) {
-  const annotations = state.annotations && state.annotations[canvasId];
+export function getSelectedTargetsAnnotations(state, targets) {
+  const annotations = state.annotations
+    && targets.map(target => getSelectedTargetAnnotations(state, target));
+  if (!annotations) return [];
+
+  return flatten(annotations);
+}
+
+/**
+* Return a single target's annotations
+* @param {object} state
+* @param {String} target
+* @return {Array}
+*/
+export function getSelectedTargetAnnotations(state, target) {
+  const annotations = state.annotations && state.annotations[target];
+
   if (!annotations) return [];
 
   return filter(
-    Object.keys(annotations).map(id => new Annotation(annotations[id].json)),
+    Object.keys(annotations).map(id => new Annotation(annotations[id].json, target)),
     annotation => annotation
                   && annotation.present(),
   );


### PR DESCRIPTION
Work that has come out of discussion for #2133 and #2134 . Enhances the annotation selection api while also enabling `Annotation` to have a `target` instance property.