### PR TITLE
Enables annotations to be translatable by CanvasWorld location

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -71,22 +71,6 @@ describe('OpenSeadragonViewer', () => {
       ).toHaveBeenCalledWith(expect.any(OpenSeadragon.Rect), true);
     });
   });
-  describe('boundsFromTileSources', () => {
-    it('generates bounds from a set of tileSources', () => {
-      expect(wrapper.instance().boundsFromTileSources()).toEqual(expect.arrayContaining(
-        [0, 0, 249, 200],
-      ));
-    });
-  });
-  describe('boundingRectFromTileSource', () => {
-    it('creates a bounding area for the current tileSource offset if needed', () => {
-      expect(wrapper.instance().boundingRectFromTileSource(
-        { '@id': 'http://bar', width: 150, height: 201 }, 1,
-      )).toEqual(expect.arrayContaining(
-        [100, 0, 149, 200],
-      ));
-    });
-  });
 
   describe('componentDidMount', () => {
     let panTo;

--- a/__tests__/src/lib/CanvasWorld.test.js
+++ b/__tests__/src/lib/CanvasWorld.test.js
@@ -1,0 +1,45 @@
+import manifesto from 'manifesto.js';
+import fixture from '../../fixtures/version-2/019.json';
+import CanvasWorld from '../../../src/lib/CanvasWorld';
+
+const canvases = manifesto.create(fixture).getSequences()[0].getCanvases();
+const canvasSubset = [canvases[1], canvases[2]];
+
+describe('CanvasWorld', () => {
+  describe('constructor', () => {
+    it('sets canvases', () => {
+      expect(new CanvasWorld([1]).canvases).toEqual([1]);
+    });
+  });
+  describe('worldBounds', () => {
+    it('calculates a world bounds for the given canvases', () => {
+      expect(new CanvasWorld([canvases[1]]).worldBounds()).toEqual([0, 0, 6501, 4421]);
+      expect(new CanvasWorld(canvasSubset).worldBounds()).toEqual([0, 0, 9153, 4288]);
+    });
+  });
+  describe('canvasToWorldCoordinates', () => {
+    it('converts canvas coordinates to world offset by location', () => {
+      expect(new CanvasWorld([canvases[1]]).canvasToWorldCoordinates(0))
+        .toEqual([0, 0, 6501, 4421]);
+      expect(new CanvasWorld(canvasSubset).canvasToWorldCoordinates(1))
+        .toEqual([6305, 0, 2848, 4288]);
+    });
+  });
+  describe('offsetByCanvas', () => {
+    it('calculates an offset that can be used to translate annotations', () => {
+      expect(
+        new CanvasWorld(canvasSubset).offsetByCanvas('https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1'),
+      ).toEqual({ x: 0, y: 0 });
+      expect(
+        new CanvasWorld(canvasSubset).offsetByCanvas('https://purl.stanford.edu/rz176rt6531/iiif/canvas/rz176rt6531_1'),
+      ).toEqual({ x: 6501, y: 0 });
+    });
+  });
+  describe('indexOfTarget', () => {
+    it('returns the index of a target in canvases', () => {
+      expect(
+        new CanvasWorld(canvasSubset).indexOfTarget('https://purl.stanford.edu/rz176rt6531/iiif/canvas/rz176rt6531_1'),
+      ).toEqual(1);
+    });
+  });
+});

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -11,6 +11,7 @@ import {
   getIdAndContentOfResources,
   getLanguagesFromConfigWithCurrent,
   getSelectedCanvas,
+  getSelectedCanvases,
   getWindowManifest,
   getManifestLogo,
   getManifestCanvases,
@@ -281,6 +282,56 @@ describe('getSelectedCanvas', () => {
 
   it('should return undefined when there is no manifestation to get a canvas from', () => {
     const selectedCanvas = getSelectedCanvas(noManifestationState, 'a');
+
+    expect(selectedCanvas).toBeUndefined();
+  });
+});
+
+describe('getSelectedCanvases', () => {
+  const state = {
+    windows: {
+      a: {
+        id: 'a',
+        manifestId: 'x',
+        canvasIndex: 1,
+        view: 'book',
+      },
+    },
+    manifests: {
+      x: {
+        id: 'x',
+        manifestation: manifesto.create(manifestFixture019),
+      },
+    },
+  };
+
+  const noManifestationState = {
+    windows: {
+      a: {
+        id: 'a',
+        manifestId: 'x',
+        canvasIndex: 1,
+      },
+    },
+    manifests: {
+      x: {
+        id: 'x',
+      },
+    },
+  };
+
+  it('should return canvas groupings based on the canvas index stored window state', () => {
+    const selectedCanvases = getSelectedCanvases(state, 'a');
+
+    expect(selectedCanvases.length).toEqual(2);
+    expect(selectedCanvases.map(canvas => canvas.id)).toEqual([
+      'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
+      'https://purl.stanford.edu/rz176rt6531/iiif/canvas/rz176rt6531_1',
+    ]);
+  });
+
+  it('should return undefined when there is no manifestation to get a canvas from', () => {
+    const selectedCanvas = getSelectedCanvases(noManifestationState, 'a');
 
     expect(selectedCanvas).toBeUndefined();
   });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -133,8 +133,8 @@ export class OpenSeadragonViewer extends Component {
     const { currentCanvases } = this.props;
     const context = this.osdCanvasOverlay.context2d;
     annotations.forEach((annotation) => {
-      const offset = new CanvasWorld(currentCanvases).offsetByCanvas(annotation.target);
       annotation.resources.forEach((resource) => {
+        const offset = new CanvasWorld(currentCanvases).offsetByCanvas(resource.targetId);
         const fragment = resource.fragmentSelector;
         fragment[0] += offset.x;
         context.strokeStyle = 'yellow';

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -4,6 +4,7 @@ import Paper from '@material-ui/core/Paper';
 import OpenSeadragon from 'openseadragon';
 import ns from '../config/css-ns';
 import OpenSeadragonCanvasOverlay from '../lib/OpenSeadragonCanvasOverlay';
+import CanvasWorld from '../lib/CanvasWorld';
 
 /**
  * Represents a OpenSeadragonViewer in the mirador workspace. Responsible for mounting
@@ -61,7 +62,9 @@ export class OpenSeadragonViewer extends Component {
    * When the viewport state changes, pan or zoom the OSD viewer as appropriate
    */
   componentDidUpdate(prevProps) {
-    const { tileSources, viewer, annotations } = this.props;
+    const {
+      tileSources, viewer, annotations, currentCanvases,
+    } = this.props;
     if (!this.annotationsMatch(prevProps.annotations)) {
       this.updateCanvas = () => {
         this.osdCanvasOverlay.clear();
@@ -78,7 +81,7 @@ export class OpenSeadragonViewer extends Component {
         tileSources.map((tileSource, i) => this.addTileSource(tileSource, i)),
       ).then(() => {
         if (tileSources[0]) {
-          this.fitBounds(...this.boundsFromTileSources(), true);
+          this.fitBounds(...new CanvasWorld(currentCanvases).worldBounds(), true);
         }
       });
     } else if (viewer) {
@@ -127,72 +130,24 @@ export class OpenSeadragonViewer extends Component {
    * annotationsToContext - converts anontations to a canvas context
    */
   annotationsToContext(annotations) {
+    const { currentCanvases } = this.props;
     const context = this.osdCanvasOverlay.context2d;
     annotations.forEach((annotation) => {
+      const offset = new CanvasWorld(currentCanvases).offsetByCanvas(annotation.target);
       annotation.resources.forEach((resource) => {
+        const fragment = resource.fragmentSelector;
+        fragment[0] += offset.x;
         context.strokeStyle = 'yellow';
         context.lineWidth = 10;
-        context.strokeRect(...resource.fragmentSelector);
+        context.strokeRect(...fragment);
       });
     });
-  }
-
-  /**
-   * boundsFromTileSources - calculates the overall width/height
-   * based on 0 -> n tileSources
-   */
-  boundsFromTileSources() {
-    const { tileSources } = this.props;
-    const heights = [];
-    const dimensions = [];
-    tileSources.forEach((tileSource) => {
-      heights.push(tileSource.height);
-      dimensions.push({
-        width: tileSource.width,
-        height: tileSource.height,
-      });
-    });
-    const minHeight = Math.min(...heights);
-    let scaledWidth = 0;
-    dimensions.forEach((dim) => {
-      const aspectRatio = dim.width / dim.height;
-      scaledWidth += Math.floor(minHeight * aspectRatio);
-    });
-    return [
-      0,
-      0,
-      scaledWidth,
-      minHeight,
-    ];
-  }
-
-  /**
-   * boundingRectFromTileSource - Creates a bounding rectangle
-   * in the Viewports space, using the current tileSource and the tileSource
-   * total area. Limitation, can only handle tileSources with a length of 1 or 2
-   */
-  boundingRectFromTileSource(tileSource, i) {
-    const { tileSources } = this.props;
-    const wholeBounds = this.boundsFromTileSources();
-    const { width } = tileSources[i];
-    const { height } = tileSources[i];
-    const aspectRatio = width / height;
-    const scaledWidth = Math.floor(wholeBounds[3] * aspectRatio);
-    let x = 0;
-    if (i === 1) {
-      x = wholeBounds[2] - scaledWidth;
-    }
-    return [
-      x,
-      0,
-      scaledWidth,
-      wholeBounds[3],
-    ];
   }
 
   /**
    */
   addTileSource(tileSource, i = 0) {
+    const { currentCanvases } = this.props;
     return new Promise((resolve, reject) => {
       if (!this.viewer) {
         return;
@@ -200,7 +155,7 @@ export class OpenSeadragonViewer extends Component {
       this.viewer.addTiledImage({
         tileSource,
         fitBounds: new OpenSeadragon.Rect(
-          ...this.boundingRectFromTileSource(tileSource, i),
+          ...new CanvasWorld(currentCanvases).canvasToWorldCoordinates(i),
         ),
         success: event => resolve(event),
         error: event => reject(event),
@@ -287,6 +242,7 @@ export class OpenSeadragonViewer extends Component {
 OpenSeadragonViewer.defaultProps = {
   annotations: [],
   children: null,
+  currentCanvases: [],
   tileSources: [],
   viewer: null,
   label: null,
@@ -296,6 +252,7 @@ OpenSeadragonViewer.defaultProps = {
 OpenSeadragonViewer.propTypes = {
   annotations: PropTypes.arrayOf(PropTypes.object),
   children: PropTypes.element,
+  currentCanvases: PropTypes.arrayOf(PropTypes.object),
   tileSources: PropTypes.arrayOf(PropTypes.object),
   viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   updateViewport: PropTypes.func.isRequired,

--- a/src/containers/WindowSideBarAnnotationsPanel.js
+++ b/src/containers/WindowSideBarAnnotationsPanel.js
@@ -7,8 +7,8 @@ import * as actions from '../state/actions';
 import {
   getIdAndContentOfResources,
   getSelectedAnnotationIds,
-  getSelectedCanvas,
-  getSelectedTargetAnnotations,
+  getSelectedCanvases,
+  getSelectedTargetsAnnotations,
   getAnnotationResourcesByMotivation,
 } from '../state/selectors';
 import { WindowSideBarAnnotationsPanel } from '../components/WindowSideBarAnnotationsPanel';
@@ -20,11 +20,14 @@ import { WindowSideBarAnnotationsPanel } from '../components/WindowSideBarAnnota
  */
 const mapStateToProps = (state, { windowId }) => ({
   selectedAnnotationIds: getSelectedAnnotationIds(
-    state, windowId, [getSelectedCanvas(state, windowId).id],
+    state, windowId, getSelectedCanvases(state, windowId).map(canvas => canvas.id),
   ),
   annotations: getIdAndContentOfResources(
     getAnnotationResourcesByMotivation(
-      getSelectedTargetAnnotations(state, getSelectedCanvas(state, windowId).id),
+      getSelectedTargetsAnnotations(
+        state,
+        getSelectedCanvases(state, windowId).map(canvas => canvas.id),
+      ),
       ['oa:commenting', 'sc:painting'],
     ),
   ),

--- a/src/lib/CanvasWorld.js
+++ b/src/lib/CanvasWorld.js
@@ -1,0 +1,79 @@
+/**
+ * CanvasWorld
+ */
+export default class CanvasWorld {
+  /**
+   * @param {Array} canvases - Array of Manifesto:Canvas objects to create a
+   * world from.
+   */
+  constructor(canvases) {
+    this.canvases = canvases;
+  }
+
+  /**
+   * canvasToWorldCoordinates - calculates the canvas coordinates respective to
+   * the world.
+   */
+  canvasToWorldCoordinates(i) {
+    const wholeBounds = this.worldBounds();
+    const canvas = this.canvases[i];
+    const aspectRatio = canvas.getWidth() / canvas.getHeight();
+    const scaledWidth = Math.floor(wholeBounds[3] * aspectRatio);
+    let x = 0;
+    if (i === 1) {
+      x = wholeBounds[2] - scaledWidth;
+    }
+    return [
+      x,
+      0,
+      scaledWidth,
+      wholeBounds[3],
+    ];
+  }
+
+  /** */
+  indexOfTarget(canvasTarget) {
+    return this.canvases.map(canvas => canvas.id).indexOf(canvasTarget);
+  }
+
+  /**
+   * offsetByCanvas - calculates the offset for a given canvas target. Currently
+   * assumes a horrizontal only layout.
+   */
+  offsetByCanvas(canvasTarget) {
+    const offset = { x: 0, y: 0 };
+    let i;
+    for (i = 0; i < this.indexOfTarget(canvasTarget); i += 1) {
+      offset.x += this.canvases[i].getWidth();
+    }
+    return offset;
+  }
+
+  /**
+   * worldBounds - calculates the "World" bounds. World in this case is canvases
+   * lined up horizontally starting from left to right.
+   */
+  worldBounds() {
+    const heights = [];
+    const dimensions = [];
+    this.canvases.forEach((canvas) => {
+      heights.push(canvas.getHeight());
+      dimensions.push({
+        width: canvas.getWidth(),
+        height: canvas.getHeight(),
+      });
+    });
+    const minHeight = Math.min(...heights);
+    let scaledWidth = 0;
+    dimensions.forEach((dim) => {
+      const aspectRatio = dim.width / dim.height;
+      scaledWidth += Math.floor(minHeight * aspectRatio);
+    });
+    return [
+      0,
+      0,
+      scaledWidth,
+      minHeight,
+    ];
+  }
+}

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -3,6 +3,7 @@ import flatten from 'lodash/flatten';
 import { LanguageMap } from 'manifesto.js';
 import Annotation from '../../lib/Annotation';
 import ManifestoCanvas from '../../lib/ManifestoCanvas';
+import CanvasGroupings from '../../lib/CanvasGroupings';
 
 /**
 * Return the manifest that belongs to a certain window.
@@ -124,6 +125,26 @@ export function getSelectedCanvas(state, windowId) {
       .getSequences()[0]
       .getCanvasByIndex(canvasIndex);
 }
+
+/**
+* Return the current canvases selected in a window
+* For book view returns 2, for single returns 1
+* @param {object} state
+* @param {String} windowId
+* @return {Array}
+*/
+export function getSelectedCanvases(state, windowId) {
+  const manifest = getWindowManifest(state, windowId);
+  const { canvasIndex, view } = state.windows[windowId];
+
+  return manifest
+    && manifest.manifestation
+    && new CanvasGroupings(
+      manifest.manifestation.getSequences()[0].getCanvases(),
+      view,
+    ).getCanvases(canvasIndex);
+}
+
 
 /**
 * Return annotations for an array of targets


### PR DESCRIPTION
This fixes #2133 by enabling translation of annotations. Adds a
refactor of world calculations for an OpenSeadragon canvas for
future extensibility.

![bookview annos](https://user-images.githubusercontent.com/1656824/54548066-ae3c6500-496c-11e9-8eb1-5b9dbda693c8.gif)

## Updated 
![bookview annos](https://user-images.githubusercontent.com/1656824/54556851-696df980-497f-11e9-9251-8c22fa5025c8.gif)
