### PR TITLE
Enable window close and window maximize to be configurable from settings

### DIFF
--- a/__tests__/src/components/WindowTopBar.test.js
+++ b/__tests__/src/components/WindowTopBar.test.js
@@ -71,4 +71,12 @@ describe('WindowTopBar', () => {
     const wrapper = createWrapper({ maximizeWindow });
     expect(wrapper.find(MiradorMenuButton).at(1).props().onClick).toBe(maximizeWindow);
   });
+
+  it('close button is configurable', () => {
+    expect(createWrapper({ allowClose: false }).find('.mirador-window-close').length).toEqual(0);
+  });
+
+  it('fullscreen button is configurable', () => {
+    expect(createWrapper({ allowMaximize: false }).find('.mirador-window-maximize').length).toEqual(0);
+  });
 });

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -25,7 +25,7 @@ export class WindowTopBar extends Component {
   render() {
     const {
       removeWindow, windowId, classes, toggleWindowSideBar, t, manifestTitle,
-      maximizeWindow, maximized, minimizeWindow, focused,
+      maximizeWindow, maximized, minimizeWindow, focused, allowClose, allowMaximize,
     } = this.props;
     return (
       <AppBar position="relative">
@@ -42,22 +42,26 @@ export class WindowTopBar extends Component {
           </Typography>
           <WindowTopBarButtons windowId={windowId} />
           <WindowTopMenuButton className={ns('window-menu-btn')} windowId={windowId} />
-          <MiradorMenuButton
-            aria-label={(maximized ? t('minimizeWindow') : t('maximizeWindow'))}
-            className={ns('window-maximize')}
-            color="inherit"
-            onClick={(maximized ? minimizeWindow : maximizeWindow)}
-          >
-            {(maximized ? <FullscreenExitIcon /> : <FullscreenIcon />)}
-          </MiradorMenuButton>
-          <MiradorMenuButton
-            aria-label={t('closeWindow')}
-            className={ns('window-close')}
-            color="inherit"
-            onClick={removeWindow}
-          >
-            <CloseIcon />
-          </MiradorMenuButton>
+          {allowMaximize && (
+            <MiradorMenuButton
+              aria-label={(maximized ? t('minimizeWindow') : t('maximizeWindow'))}
+              className={ns('window-maximize')}
+              color="inherit"
+              onClick={(maximized ? minimizeWindow : maximizeWindow)}
+            >
+              {(maximized ? <FullscreenExitIcon /> : <FullscreenIcon />)}
+            </MiradorMenuButton>
+          )}
+          {allowClose && (
+            <MiradorMenuButton
+              aria-label={t('closeWindow')}
+              className={ns('window-close')}
+              color="inherit"
+              onClick={removeWindow}
+            >
+              <CloseIcon />
+            </MiradorMenuButton>
+          )}
         </Toolbar>
       </AppBar>
     );
@@ -65,6 +69,8 @@ export class WindowTopBar extends Component {
 }
 
 WindowTopBar.propTypes = {
+  allowClose: PropTypes.bool,
+  allowMaximize: PropTypes.bool,
   manifestTitle: PropTypes.string,
   maximizeWindow: PropTypes.func,
   maximized: PropTypes.bool,
@@ -78,6 +84,8 @@ WindowTopBar.propTypes = {
 };
 
 WindowTopBar.defaultProps = {
+  allowClose: true,
+  allowMaximize: true,
   manifestTitle: '',
   maximizeWindow: () => {},
   maximized: false,

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -125,6 +125,8 @@ export default {
   translations: {
   },
   window: {
+    allowClose: true,
+    allowMaximize: true,
     defaultView: 'single',
   },
   windows: [],

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -12,6 +12,8 @@ const mapStateToProps = (state, { windowId }) => ({
   manifestTitle: getManifestTitle(getWindowManifest(state, windowId)),
   maximized: state.windows[windowId].maximized,
   focused: state.workspace.focusedWindowId === windowId,
+  allowClose: state.config.window.allowClose,
+  allowFullscreen: state.config.window.allowFullscreen,
 });
 
 /**


### PR DESCRIPTION
This wasn't originally ticketed, but I thought it would be a useful add for our embedded scenario (while I was browsing our ready column)