### PR TITLE
Make the canvas list style selector a "without label" type and style…

### DIFF
--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -96,13 +96,14 @@ export class WindowSideBarCanvasPanel extends Component {
         id={id}
         windowId={windowId}
         titleControls={(
-          <FormControl variant="filled">
+          <FormControl>
             <Select
+              displayEmpty
               value={variant}
               onChange={this.handleVariantChange}
               name="variant"
-              variant="filled"
-              input={<FilledInput name="variant" />}
+              classes={{ select: classes.select }}
+              className={classes.selectEmpty}
             >
               <MenuItem value="compact"><Typography variant="body2">{ t('compactList') }</Typography></MenuItem>
               <MenuItem value="thumbnail"><Typography variant="body2">{ t('thumbnailList') }</Typography></MenuItem>

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -38,6 +38,14 @@ const styles = theme => ({
     borderBottom: '0.5px solid rgba(0,0,0,0.12)',
     paddingRight: theme.spacing.unit,
   },
+  select: {
+    '&:focus': {
+      backgroundColor: theme.palette.background.paper,
+    },
+  },
+  selectEmpty: {
+    backgroundColor: theme.palette.background.paper,
+  },
 });
 
 const enhance = compose(


### PR DESCRIPTION
…appropriately.

Closes #2181 

### Before
<img width="682" alt="before" src="https://user-images.githubusercontent.com/96776/54564908-3b41e700-498a-11e9-896e-9f81bc75571d.png">

### After
<img width="679" alt="Screen Shot 2019-03-18 at 2 43 02 PM" src="https://user-images.githubusercontent.com/96776/54565691-2a927080-498c-11e9-80d8-670c51847be6.png">
