### PR TITLE
Add a language picker to the info panel when the manifest metadata is multilingual

### DIFF
--- a/__tests__/src/components/LocalePicker.test.js
+++ b/__tests__/src/components/LocalePicker.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { LocalePicker } from '../../../src/components/LocalePicker';
+
+/**
+ * Helper function to create a shallow wrapper around LanguageSettings
+ */
+function createWrapper(props) {
+  return shallow(
+    <LocalePicker
+      availableLocales={[]}
+      locale={undefined}
+      setLocale={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe('LocalePicker', () => {
+  let wrapper;
+
+  it('hides the control if there are not locales to switch to', () => {
+    wrapper = createWrapper({ availableLocales: ['en'] });
+
+    expect(wrapper.find('WithStyles(WithFormControlContext(Select))').length).toBe(0);
+  });
+
+  it('renders a select with the current value', () => {
+    wrapper = createWrapper({ availableLocales: ['en', 'de'], locale: 'en' });
+
+    expect(wrapper.find('WithStyles(WithFormControlContext(Select))').length).toBe(1);
+    expect(wrapper.find('WithStyles(WithFormControlContext(Select))').props().value).toBe('en');
+  });
+
+  it('renders a select with a list item for each language passed in props', () => {
+    wrapper = createWrapper({ availableLocales: ['en', 'de'] });
+
+    expect(wrapper.find('WithStyles(MenuItem)').length).toBe(2);
+  });
+
+
+  it('triggers setLocale prop when clicking a list item', () => {
+    const setLocale = jest.fn();
+
+    wrapper = createWrapper({
+      availableLocales: ['en', 'de'],
+      setLocale,
+    });
+    wrapper.find('WithStyles(WithFormControlContext(Select))').simulate('change', { target: { value: 'de' } });
+
+    expect(setLocale).toHaveBeenCalledTimes(1);
+    expect(setLocale).toHaveBeenCalledWith('de');
+  });
+});

--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -4,6 +4,7 @@ import manifestFixture002 from '../../fixtures/version-2/002.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import manifestFixtureWithAProvider from '../../fixtures/version-3/with_a_provider.json';
 import {
+  getDefaultManifestLocale,
   getDestructuredMetadata,
   getManifest,
   getManifestLogo,
@@ -14,6 +15,7 @@ import {
   getManifestThumbnail,
   getManifestMetadata,
   getManifestUrl,
+  getMetadataLocales,
 } from '../../../src/state/selectors/manifests';
 
 
@@ -216,5 +218,47 @@ describe('getManifestMetadata', () => {
     const received = getDestructuredMetadata(iiifResource);
 
     expect(received).toEqual([]);
+  });
+});
+
+describe('getDefaultManifestLocale', () => {
+  it('gets the default locale for the manifest', () => {
+    const state = { manifests: { x: { json: manifestFixture002 } } };
+    const received = getDefaultManifestLocale(state, { manifestId: 'x' });
+    expect(received).toEqual('en');
+  });
+});
+
+describe('getMetadataLocales', () => {
+  it('gets the locales preseent in the manifest metadata', () => {
+    const manifest = {
+      '@context': 'http://iiif.io/api/presentation/2/context.json',
+      '@id':
+       'http://iiif.io/api/presentation/2.1/example/fixtures/19/manifest.json',
+      '@type': 'sc:Manifest',
+      metadata: [
+        {
+          label: [
+            { '@language': 'de-label', '@value': 'Besitzende Einrichtung' },
+            { '@language': 'en-label', '@value': 'Holding Institution' },
+          ],
+          value: 'Herzog August Bibliothek Wolfenb\u00fcttel',
+        },
+        {
+          label: 'Digitization Project',
+          value: [
+            { '@language': 'en-value', '@value': 'Manuscripts from German-Speaking Lands - A Polonsky Foundation Digitization Project - A collaboration between the Bodleian Libraries and the Herzog August Bibliothek.' },
+            { '@language': 'de-value', '@value': 'Handschriften aus dem deutschen Sprachraum. Ein Digitalisierungsprojekt der Polonsky Stiftung. Eine Zusammenarbeit zwischen der Universit\u00e4t Oxford und der Herzog August Bibliothek Wolfenb\u00fcttel' },
+          ],
+        },
+        {
+          label: 'Some label',
+          value: { '@language': 'one-value', '@value': '1' },
+        },
+      ],
+    };
+    const state = { manifests: { x: { json: manifest } } };
+    const received = getMetadataLocales(state, { manifestId: 'x' });
+    expect(received).toEqual(['de-label', 'en-label', 'en-value', 'de-value', 'one-value']);
   });
 });

--- a/src/components/LocalePicker.js
+++ b/src/components/LocalePicker.js
@@ -1,0 +1,67 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import Typography from '@material-ui/core/Typography';
+
+
+/**
+ * Provide a locale picker
+ */
+export class LocalePicker extends Component {
+  /**
+   * render
+   * @return
+   */
+  render() {
+    const {
+      availableLocales,
+      classes,
+      locale,
+      setLocale,
+    } = this.props;
+
+    if (!setLocale || availableLocales.length < 2) return <></>;
+    return (
+      <FormControl>
+        <Select
+          MenuProps={{
+            anchorOrigin: {
+              horizontal: 'left',
+              vertical: 'bottom',
+            },
+            getContentAnchorEl: null,
+          }}
+          displayEmpty
+          value={locale}
+          onChange={(e) => { setLocale(e.target.value); }}
+          name="locale"
+          classes={{ select: classes.select }}
+          className={classes.selectEmpty}
+        >
+          {
+            availableLocales.map(l => (
+              <MenuItem key={l} value={l}><Typography variant="body2">{ l }</Typography></MenuItem>
+            ))
+          }
+        </Select>
+      </FormControl>
+    );
+  }
+}
+
+
+LocalePicker.propTypes = {
+  availableLocales: PropTypes.arrayOf(PropTypes.string),
+  classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  locale: PropTypes.string,
+  setLocale: PropTypes.func,
+};
+
+LocalePicker.defaultProps = {
+  availableLocales: [],
+  classes: {},
+  locale: '',
+  setLocale: undefined,
+};

--- a/src/components/WindowSideBarInfoPanel.js
+++ b/src/components/WindowSideBarInfoPanel.js
@@ -32,6 +32,7 @@ export class WindowSideBarInfoPanel extends Component {
       locale,
       setLocale,
       availableLocales,
+      showLocalePicker,
     } = this.props;
 
     return (
@@ -41,7 +42,14 @@ export class WindowSideBarInfoPanel extends Component {
         windowId={windowId}
         id={id}
         titleControls={(
-          <LocalePicker locale={locale} setLocale={setLocale} availableLocales={availableLocales} />
+          showLocalePicker
+            && (
+            <LocalePicker
+              locale={locale}
+              setLocale={setLocale}
+              availableLocales={availableLocales}
+            />
+            )
         )}
       >
         <div className={classes.section}>
@@ -120,6 +128,7 @@ WindowSideBarInfoPanel.propTypes = {
   manifestMetadata: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   manifestUrl: PropTypes.string,
   setLocale: PropTypes.func,
+  showLocalePicker: PropTypes.bool,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
 };
@@ -136,5 +145,6 @@ WindowSideBarInfoPanel.defaultProps = {
   manifestMetadata: [],
   manifestUrl: null,
   setLocale: undefined,
+  showLocalePicker: false,
   t: key => key,
 };

--- a/src/components/WindowSideBarInfoPanel.js
+++ b/src/components/WindowSideBarInfoPanel.js
@@ -4,6 +4,7 @@ import Typography from '@material-ui/core/Typography';
 import { SanitizedHtml } from './SanitizedHtml';
 import { LabelValueMetadata } from './LabelValueMetadata';
 import CompanionWindow from '../containers/CompanionWindow';
+import LocalePicker from '../containers/LocalePicker';
 import ns from '../config/css-ns';
 
 
@@ -28,10 +29,21 @@ export class WindowSideBarInfoPanel extends Component {
       id,
       classes,
       t,
+      locale,
+      setLocale,
+      availableLocales,
     } = this.props;
 
     return (
-      <CompanionWindow title={t('aboutThisItem')} paperClassName={ns('window-sidebar-info-panel')} windowId={windowId} id={id}>
+      <CompanionWindow
+        title={t('aboutThisItem')}
+        paperClassName={ns('window-sidebar-info-panel')}
+        windowId={windowId}
+        id={id}
+        titleControls={(
+          <LocalePicker locale={locale} setLocale={setLocale} availableLocales={availableLocales} />
+        )}
+      >
         <div className={classes.section}>
           {canvasLabel && (
             <>
@@ -96,27 +108,33 @@ export class WindowSideBarInfoPanel extends Component {
 }
 
 WindowSideBarInfoPanel.propTypes = {
+  availableLocales: PropTypes.arrayOf(PropTypes.string),
   canvasDescription: PropTypes.string,
   canvasLabel: PropTypes.string,
   canvasMetadata: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   id: PropTypes.string.isRequired,
+  locale: PropTypes.string,
   manifestDescription: PropTypes.string,
   manifestLabel: PropTypes.string,
   manifestMetadata: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   manifestUrl: PropTypes.string,
+  setLocale: PropTypes.func,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
 };
 
 WindowSideBarInfoPanel.defaultProps = {
+  availableLocales: [],
   canvasDescription: null,
   canvasLabel: null,
   canvasMetadata: [],
   classes: {},
+  locale: '',
   manifestDescription: null,
   manifestLabel: null,
   manifestMetadata: [],
   manifestUrl: null,
+  setLocale: undefined,
   t: key => key,
 };

--- a/src/containers/LocalePicker.js
+++ b/src/containers/LocalePicker.js
@@ -1,0 +1,27 @@
+import { compose } from 'redux';
+import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
+import { LocalePicker } from '../components/LocalePicker';
+
+/**
+ *
+ * @param theme
+ * @returns {label: {paddingLeft: number}}}
+ */
+const styles = theme => ({
+  select: {
+    '&:focus': {
+      backgroundColor: theme.palette.background.paper,
+    },
+  },
+  selectEmpty: {
+    backgroundColor: theme.palette.background.paper,
+  },
+});
+
+const enhance = compose(
+  withTranslation(),
+  withStyles(styles),
+);
+
+export default enhance(LocalePicker);

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -14,19 +14,14 @@ import { getManifestCanvases } from '../state/selectors/manifests';
  * @memberof ThumbnailNavigation
  * @private
  */
-const mapStateToProps = ({
-  companionWindows, config, manifests, windows,
-}, { windowId }) => ({
+const mapStateToProps = (state, { windowId }) => ({
   canvasGroupings: new CanvasGroupings(
-    getManifestCanvases({
-      manifests,
-      windows,
-    }, { windowId }),
-    windows[windowId].view,
+    getManifestCanvases(state, { windowId }),
+    state.windows[windowId].view,
   ),
-  config,
-  position: companionWindows[windows[windowId].thumbnailNavigationId].position,
-  window: getWindow({ windows }, { windowId }),
+  config: state.config,
+  position: state.companionWindows[state.windows[windowId].thumbnailNavigationId].position,
+  window: getWindow(state, { windowId }),
 });
 
 /**

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend';
+import * as actions from '../state/actions';
 import {
+  getDefaultManifestLocale,
   getDestructuredMetadata,
   getCanvasLabel,
   getManifestDescription,
@@ -11,6 +13,7 @@ import {
   getManifestUrl,
   getSelectedCanvas,
   getManifestMetadata,
+  getMetadataLocales,
   getCanvasDescription,
 } from '../state/selectors';
 import { WindowSideBarInfoPanel } from '../components/WindowSideBarInfoPanel';
@@ -20,14 +23,23 @@ import { WindowSideBarInfoPanel } from '../components/WindowSideBarInfoPanel';
  * @memberof WindowSideBarInfoPanel
  * @private
  */
-const mapStateToProps = (state, { windowId }) => ({
-  canvasDescription: getCanvasDescription(state, { canvasIndex: 'selected', windowId }),
-  canvasLabel: getCanvasLabel(state, { canvasIndex: 'selected', windowId }),
-  canvasMetadata: getDestructuredMetadata(getSelectedCanvas(state, { windowId })),
-  manifestDescription: getManifestDescription(state, { windowId }),
-  manifestLabel: getManifestTitle(state, { windowId }),
-  manifestMetadata: getManifestMetadata(state, { windowId }),
+const mapStateToProps = (state, { id, windowId }) => ({
+  availableLocales: getMetadataLocales(state, { companionWindowId: id, windowId }),
+  canvasDescription: getCanvasDescription(state, { canvasIndex: 'selected', companionWindowId: id, windowId }),
+  canvasLabel: getCanvasLabel(state, { canvasIndex: 'selected', companionWindowId: id, windowId }),
+  canvasMetadata: getDestructuredMetadata(
+    getSelectedCanvas(state, { companionWindowId: id, windowId }),
+  ),
+  locale: state.companionWindows[id].locale || getDefaultManifestLocale(state, { windowId }),
+  manifestDescription: getManifestDescription(state, { companionWindowId: id, windowId }),
+  manifestLabel: getManifestTitle(state, { companionWindowId: id, windowId }),
+  manifestMetadata: getManifestMetadata(state, { companionWindowId: id, windowId }),
   manifestUrl: getManifestUrl(state, { windowId }),
+});
+
+/** */
+const mapDispatchToProps = (dispatch, { windowId, id }) => ({
+  setLocale: locale => dispatch(actions.updateCompanionWindow(windowId, id, { locale })),
 });
 
 /**
@@ -48,7 +60,7 @@ const styles = theme => ({
 const enhance = compose(
   withTranslation(),
   withStyles(styles),
-  connect(mapStateToProps, null),
+  connect(mapStateToProps, mapDispatchToProps),
   withPlugins('WindowSideBarInfoPanel'),
 );
 

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -12,9 +12,10 @@ export function getManifest(state, { manifestId, windowId }) {
 
 /** */
 function getLocale(state, { companionWindowId }) {
-  return companionWindowId
+  return (companionWindowId
     && state.companionWindows[companionWindowId]
-    && state.companionWindows[companionWindowId].locale;
+    && state.companionWindows[companionWindowId].locale)
+    || (state.config && state.config.language);
 }
 
 /** Instantiate a manifesto instance */


### PR DESCRIPTION
Add a language picker to the info panel when the manifest metadata is multilingual. Part of #1877.

<img width="736" alt="Screen Shot 2019-03-21 at 09 26 16" src="https://user-images.githubusercontent.com/111218/54767927-68c1a700-4bbb-11e9-9a10-7b5a0a35a6ef.png">

(I'm using https://iiif.hab.de/object/mss_272-helmst/manifest.json as the manifest)


----

I don't know that the UI plumbing is right, but it'll provide something to react to.

I also don't know if the backend plumbing, where we reinstantiate the manifesto instance for a language is a great long-term pattern, but it at least kicks the can down the road until we decide on its fate.