### PR TITLE
Update how annotations in the panel are styled

### DIFF
--- a/src/components/WindowSideBarAnnotationsPanel.js
+++ b/src/components/WindowSideBarAnnotationsPanel.js
@@ -13,15 +13,35 @@ import ns from '../config/css-ns';
 */
 export class WindowSideBarAnnotationsPanel extends Component {
   /**
+   * constructor -
+   */
+  constructor(props) {
+    super(props);
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  /**
+   * Handle click event of an annotation.
+  */
+  handleClick(event, annotation) {
+    const {
+      deselectAnnotation, selectAnnotation, selectedAnnotationIds, windowId,
+    } = this.props;
+
+    if (selectedAnnotationIds.includes(annotation.id)) {
+      deselectAnnotation(windowId, annotation.targetId, annotation.id);
+    } else {
+      selectAnnotation(windowId, annotation.targetId, annotation.id);
+    }
+  }
+
+  /**
    * Rreturn an array of sanitized annotation data
    */
   sanitizedAnnotations() {
     const {
       annotations,
-      classes,
-      deselectAnnotation,
-      windowId,
-      selectAnnotation,
       selectedAnnotationIds,
     } = this.props;
 
@@ -31,18 +51,8 @@ export class WindowSideBarAnnotationsPanel extends Component {
           annotations.map(annotation => (
             <ListItem
               key={annotation.id}
-              className={
-                selectedAnnotationIds.includes(annotation.id)
-                  ? classes.selectedAnnotation
-                  : null
-              }
-              onClick={() => {
-                if (selectedAnnotationIds.includes(annotation.id)) {
-                  deselectAnnotation(windowId, annotation.targetId, annotation.id);
-                } else {
-                  selectAnnotation(windowId, annotation.targetId, annotation.id);
-                }
-              }}
+              selected={selectedAnnotationIds.includes(annotation.id)}
+              onClick={e => this.handleClick(e, annotation)}
             >
               <Typography variant="body2">
                 <SanitizedHtml ruleSet="iiif" htmlString={annotation.content} />


### PR DESCRIPTION
This PR simply improves the selected annotation styling (and includes a minor function abstraction to cleanup the click event on the component).

Closes #2264

Updates to behavior are now described in #2383 

![annotation-style-improvement](https://user-images.githubusercontent.com/96776/55521003-b87c8580-5633-11e9-8b30-7c7217e27450.gif)
