### PR TITLE
Use reselect for manifest selectors in order to remove manifesto instance from the redux store

### DIFF
--- a/__tests__/integration/vanilla-js/index.html
+++ b/__tests__/integration/vanilla-js/index.html
@@ -31,7 +31,7 @@
           if(manifest.error){
             contents = manifest.error.message;
           } else {
-            contents = JSON.stringify(manifest.manifestation.__jsonld, 0, 3);
+            contents = JSON.stringify(manifest.json, 0, 3);
           }
           break;
         default: contents = ''

--- a/__tests__/src/components/GalleryView.test.js
+++ b/__tests__/src/components/GalleryView.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import manifesto from 'manifesto.js';
 import manifestJson from '../../fixtures/version-2/019.json';
 import { GalleryView } from '../../../src/components/GalleryView';
@@ -9,7 +9,7 @@ function createWrapper(props) {
   return shallow(
     <GalleryView
       window={{ id: '1234', canvasIndex: 0 }}
-      manifest={{ manifestation: manifesto.create(manifestJson) }}
+      canvases={manifesto.create(manifestJson).getSequences()[0].getCanvases()}
       setCanvas={() => {}}
       {...props}
     />,

--- a/__tests__/src/components/WindowList.test.js
+++ b/__tests__/src/components/WindowList.test.js
@@ -8,19 +8,19 @@ describe('WindowList', () => {
   let wrapper;
   let handleClose;
   let focusWindow;
-  let manifests;
+  let titles;
   let windows;
   beforeEach(() => {
     handleClose = jest.fn();
     focusWindow = jest.fn();
-    manifests = {};
+    titles = {};
     windows = {};
 
     wrapper = shallow(
       <WindowList
         containerId="mirador"
         anchorEl={{}}
-        manifests={manifests}
+        titles={titles}
         windows={windows}
         handleClose={handleClose}
         focusWindow={focusWindow}
@@ -40,7 +40,7 @@ describe('WindowList', () => {
         <WindowList
           containerId="mirador"
           anchorEl={{}}
-          manifests={manifests}
+          titles={titles}
           windows={windows}
           handleClose={handleClose}
           focusWindow={focusWindow}
@@ -63,13 +63,13 @@ describe('WindowList', () => {
   describe('with a window with a matching manifest', () => {
     beforeEach(() => {
       windows = { xyz: { id: 'xyz', manifestId: 'abc' } };
-      manifests = { abc: { manifestation: { getLabel: jest.fn(() => [{ value: 'Some title' }]) } } };
+      titles = { xyz: 'Some title' };
 
       wrapper = shallow(
         <WindowList
           containerId="mirador"
           anchorEl={{}}
-          manifests={manifests}
+          titles={titles}
           windows={windows}
           handleClose={handleClose}
           focusWindow={focusWindow}
@@ -92,13 +92,13 @@ describe('WindowList', () => {
         zyx: { id: 'zyx', manifestId: '123' },
         xyz: { id: 'xyz', manifestId: 'abc' },
       };
-      manifests = { abc: { manifestation: { getLabel: jest.fn(() => [{ value: 'Some title' }]) } } };
+      titles = { xyz: 'Some title' };
 
       wrapper = shallow(
         <WindowList
           containerId="mirador"
           anchorEl={{}}
-          manifests={manifests}
+          titles={titles}
           windows={windows}
           handleClose={handleClose}
           focusWindow={focusWindow}

--- a/__tests__/src/components/WindowViewer.test.js
+++ b/__tests__/src/components/WindowViewer.test.js
@@ -8,10 +8,7 @@ import fixture from '../../fixtures/version-2/019.json';
 import emptyCanvasFixture from '../../fixtures/version-2/emptyCanvas.json';
 import otherContentFixture from '../../fixtures/version-2/299843.json';
 
-let mockManifest = {
-  id: 123,
-  manifestation: manifesto.create(fixture),
-};
+let canvases = manifesto.create(fixture).getSequences()[0].getCanvases();
 
 let mockWindow = {
   canvasIndex: 0,
@@ -26,7 +23,7 @@ function createWrapper(props) {
       infoResponses={{}}
       fetchInfoResponse={() => {}}
       fetchAnnotation={() => {}}
-      manifest={mockManifest}
+      canvases={canvases}
       window={mockWindow}
       {...props}
     />,
@@ -130,22 +127,19 @@ describe('WindowViewer', () => {
     it('does not call fetchInfoResponse for a canvas that has no images', () => {
       const mockFnCanvas0 = jest.fn();
       const mockFnCanvas2 = jest.fn();
-      mockManifest = {
-        id: 123,
-        manifestation: manifesto.create(emptyCanvasFixture),
-      };
+      canvases = manifesto.create(emptyCanvasFixture).getSequences()[0].getCanvases();
       mockWindow = {
         canvasIndex: 0,
         view: 'single',
       };
       wrapper = createWrapper(
-        { manifest: mockManifest, fetchInfoResponse: mockFnCanvas0, window: mockWindow },
+        { canvases, fetchInfoResponse: mockFnCanvas0, window: mockWindow },
       );
       expect(mockFnCanvas0).toHaveBeenCalledTimes(1);
 
       wrapper = createWrapper(
         {
-          manifest: mockManifest,
+          canvases,
           fetchInfoResponse: mockFnCanvas2,
           window: { canvasIndex: 2, view: 'single' },
         },
@@ -154,12 +148,9 @@ describe('WindowViewer', () => {
     });
     it('calls fetchAnnotation when otherContent is present', () => {
       const mockFnAnno = jest.fn();
-      mockManifest = {
-        id: 123,
-        manifestation: manifesto.create(otherContentFixture),
-      };
+      canvases = manifesto.create(otherContentFixture).getSequences()[0].getCanvases();
       wrapper = createWrapper(
-        { manifest: mockManifest, fetchAnnotation: mockFnAnno },
+        { canvases, fetchAnnotation: mockFnAnno },
       );
       expect(mockFnAnno).toHaveBeenCalledTimes(1);
     });
@@ -168,16 +159,13 @@ describe('WindowViewer', () => {
   describe('componentDidUpdate', () => {
     it('does not call fetchInfoResponse for a canvas that has no images', () => {
       const mockFn = jest.fn();
-      mockManifest = {
-        id: 123,
-        manifestation: manifesto.create(emptyCanvasFixture),
-      };
+      canvases = manifesto.create(emptyCanvasFixture).getSequences()[0].getCanvases();
       mockWindow = {
         canvasIndex: 2,
         view: 'single',
       };
       wrapper = createWrapper(
-        { manifest: mockManifest, fetchInfoResponse: mockFn, window: mockWindow },
+        { canvases, fetchInfoResponse: mockFn, window: mockWindow },
       );
 
       wrapper.setProps({ window: { canvasIndex: 3, view: 'single' } });

--- a/__tests__/src/reducers/manifests.test.js
+++ b/__tests__/src/reducers/manifests.test.js
@@ -34,7 +34,11 @@ describe('manifests reducer', () => {
       abc123: {
         id: 'abc123',
         isFetching: false,
-        manifestation: {},
+        json: {
+          id: 'abc123',
+          '@type': 'sc:Manifest',
+          content: 'lots of canvases and metadata and such',
+        },
         error: null,
       },
     });

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -77,51 +77,53 @@ describe('getManifest()', () => {
 
 describe('getManifestLogo()', () => {
   it('should return manifest logo id', () => {
-    const received = getManifestLogo({ manifests: { x: { manifestation: manifesto.create(manifestFixture001) } } }, { manifestId: 'x' });
+    const received = getManifestLogo({ manifests: { x: { json: manifestFixture001 } } }, { manifestId: 'x' });
     expect(received).toEqual(manifestFixture001.logo['@id']);
   });
 
   it('should return null if manifest has no logo', () => {
-    const received = getManifestLogo({ manifests: { x: { manifestation: manifesto.create({}) } } }, { manifestId: 'x' });
-    expect(received).toBeNull();
+    const received = getManifestLogo({ manifests: { x: {} } }, { manifestId: 'x' });
+    expect(received).toBeUndefined();
   });
 });
 
 describe('getManifestThumbnail()', () => {
   it('should return manifest thumbnail id', () => {
-    const manifest = manifesto.create(manifestFixture001);
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: { json: manifestFixture001 } } };
     const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toEqual(manifestFixture001.thumbnail['@id']);
   });
 
   it('returns the first canvas thumbnail id', () => {
     const manifest = {
-      getThumbnail: () => (null),
-      getSequences: () => [
+      '@context': 'http://iiif.io/api/presentation/2/context.json',
+      '@id':
+       'http://iiif.io/api/presentation/2.1/example/fixtures/19/manifest.json',
+      '@type': 'sc:Manifest',
+      sequences: [
         {
-          getCanvases: () => [
-            { getThumbnail: () => ({ id: 'xyz' }) },
+          canvases: [
+            {
+              thumbnail: { id: 'xyz' },
+            },
           ],
         },
       ],
     };
 
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: { json: manifest } } };
     const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toEqual('xyz');
   });
 
   it('returns a thumbnail sized image url from the first canvas', () => {
-    const manifest = manifesto.create(manifestFixture019);
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: { json: manifestFixture019 } } };
     const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toEqual('https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/,80/0/default.jpg');
   });
 
   it('should return null if manifest has no thumbnail', () => {
-    const manifest = manifesto.create({});
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: {} } };
     const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toBeNull();
   });
@@ -129,15 +131,13 @@ describe('getManifestThumbnail()', () => {
 
 describe('getManifestCanvases', () => {
   it('returns an empty array if the manifestation is not loaded', () => {
-    const manifest = {};
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: {} } };
     const received = getManifestCanvases(state, { manifestId: 'x' });
     expect(received).toEqual([]);
   });
 
   it('returns canvases from the manifest', () => {
-    const manifest = manifesto.create(manifestFixture001);
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: { json: manifestFixture001 } } };
     const received = getManifestCanvases(state, { manifestId: 'x' });
     expect(received.length).toBe(1);
     expect(received[0].id).toBe('https://iiif.bodleian.ox.ac.uk/iiif/canvas/9cca8fdd-4a61-4429-8ac1-f648764b4d6d.json');
@@ -173,8 +173,7 @@ describe('getThumbnailNavigationPosition', () => {
 
 describe('getManifestTitle', () => {
   it('should return manifest title', () => {
-    const manifest = manifesto.create(manifestFixture001);
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: { json: manifestFixture001 } } };
     const received = getManifestTitle(state, { manifestId: 'x' });
     expect(received).toBe('Bodleian Library Human Freaks 2 (33)');
   });
@@ -193,9 +192,9 @@ describe('getWindowTitles', () => {
         b: { manifestId: 'bmanifest' },
       },
       manifests: {
-        amanifest: { manifestation: manifesto.create(manifestFixture001) },
-        bmanifest: { manifestation: manifesto.create(manifestFixture002) },
-        cmanifest: { manifestation: manifesto.create(manifestFixture019) },
+        amanifest: { json: manifestFixture001 },
+        bmanifest: { json: manifestFixture002 },
+        cmanifest: { json: manifestFixture019 },
       },
     };
 
@@ -234,8 +233,7 @@ describe('getWindowViewType', () => {
 
 describe('getManifestDescription', () => {
   it('should return manifest description', () => {
-    const manifest = manifesto.create(manifestFixture001);
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: { json: manifestFixture001 } } };
     const received = getManifestDescription(state, { manifestId: 'x' });
     expect(received).toBe('[Handbill of Mr. Becket, [1787] ]');
   });
@@ -248,8 +246,7 @@ describe('getManifestDescription', () => {
 
 describe('getManifestProvider', () => {
   it('should return manifest provider label', () => {
-    const manifest = manifesto.create(manifestFixtureWithAProvider);
-    const state = { manifests: { x: { manifestation: manifest } } };
+    const state = { manifests: { x: { json: manifestFixtureWithAProvider } } };
     const received = getManifestProvider(state, { manifestId: 'x' });
     expect(received).toBe('Example Organization');
   });
@@ -271,7 +268,7 @@ describe('getSelectedCanvas', () => {
     manifests: {
       x: {
         id: 'x',
-        manifestation: manifesto.create(manifestFixture019),
+        json: manifestFixture019,
       },
     },
   };
@@ -319,7 +316,7 @@ describe('getSelectedCanvases', () => {
     manifests: {
       x: {
         id: 'x',
-        manifestation: manifesto.create(manifestFixture019),
+        json: manifestFixture019,
       },
     },
   };
@@ -400,8 +397,7 @@ describe('getDestructuredMetadata', () => {
 
 describe('getManifestMetadata', () => {
   it('should return the first value of label/value attributes for each object in the array ', () => {
-    const iiifResource = manifesto.create(manifestFixture002);
-    const state = { manifests: { x: { manifestation: iiifResource } } };
+    const state = { manifests: { x: { json: manifestFixture002 } } };
     const received = getManifestMetadata(state, { manifestId: 'x' });
     const expected = [{
       label: 'date',

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -268,7 +268,7 @@ describe('getSelectedCanvas', () => {
   };
 
   it('should return canvas based on the canvas index stored window state', () => {
-    const selectedCanvas = getSelectedCanvas(state, 'a');
+    const selectedCanvas = getSelectedCanvas(state, { windowId: 'a' });
 
     expect(selectedCanvas.id).toEqual(
       'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
@@ -276,7 +276,7 @@ describe('getSelectedCanvas', () => {
   });
 
   it('should return undefined when there is no manifestation to get a canvas from', () => {
-    const selectedCanvas = getSelectedCanvas(noManifestationState, 'a');
+    const selectedCanvas = getSelectedCanvas(noManifestationState, { windowId: 'a' });
 
     expect(selectedCanvas).toBeUndefined();
   });
@@ -316,7 +316,7 @@ describe('getSelectedCanvases', () => {
   };
 
   it('should return canvas groupings based on the canvas index stored window state', () => {
-    const selectedCanvases = getSelectedCanvases(state, 'a');
+    const selectedCanvases = getSelectedCanvases(state, { windowId: 'a' });
 
     expect(selectedCanvases.length).toEqual(2);
     expect(selectedCanvases.map(canvas => canvas.id)).toEqual([
@@ -326,7 +326,7 @@ describe('getSelectedCanvases', () => {
   });
 
   it('should return undefined when there is no manifestation to get a canvas from', () => {
-    const selectedCanvas = getSelectedCanvases(noManifestationState, 'a');
+    const selectedCanvas = getSelectedCanvases(noManifestationState, { windowId: 'a' });
 
     expect(selectedCanvas).toBeUndefined();
   });

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -28,6 +28,7 @@ import {
   getIdAndLabelOfCanvases,
   getCompanionWindowsOfWindow,
   getManifestMetadata,
+  getWindowTitles,
 } from '../../../src/state/selectors';
 import Annotation from '../../../src/lib/Annotation';
 import AnnotationResource from '../../../src/lib/AnnotationResource';
@@ -181,6 +182,29 @@ describe('getManifestTitle', () => {
   it('should return undefined if manifest undefined', () => {
     const received = getManifestTitle({ manifests: {} }, { manifestId: 'x' });
     expect(received).toBeUndefined();
+  });
+});
+
+describe('getWindowTitles', () => {
+  it('should return manifest titles for the open windows', () => {
+    const state = {
+      windows: {
+        a: { manifestId: 'amanifest' },
+        b: { manifestId: 'bmanifest' },
+      },
+      manifests: {
+        amanifest: { manifestation: manifesto.create(manifestFixture001) },
+        bmanifest: { manifestation: manifesto.create(manifestFixture002) },
+        cmanifest: { manifestation: manifesto.create(manifestFixture019) },
+      },
+    };
+
+    const received = getWindowTitles(state);
+
+    expect(received).toEqual({
+      a: 'Bodleian Library Human Freaks 2 (33)',
+      b: 'Test 2 Manifest: Metadata Pairs',
+    });
   });
 });
 

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -166,12 +166,13 @@ describe('getThumbnailNavigationPosition', () => {
 describe('getManifestTitle', () => {
   it('should return manifest title', () => {
     const manifest = manifesto.create(manifestFixture001);
-    const received = getManifestTitle(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestTitle(state, { manifestId: 'x' });
     expect(received).toBe('Bodleian Library Human Freaks 2 (33)');
   });
 
   it('should return undefined if manifest undefined', () => {
-    const received = getManifestTitle(undefined);
+    const received = getManifestTitle({ manifests: {} }, { manifestId: 'x' });
     expect(received).toBeUndefined();
   });
 });

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -27,6 +27,7 @@ import {
   getWindowViewType,
   getIdAndLabelOfCanvases,
   getCompanionWindowsOfWindow,
+  getManifestMetadata,
 } from '../../../src/state/selectors';
 import Annotation from '../../../src/lib/Annotation';
 import AnnotationResource from '../../../src/lib/AnnotationResource';
@@ -357,6 +358,27 @@ describe('getDestructuredMetadata', () => {
   it('should return the first value of label/value attributes for each object in the array ', () => {
     const iiifResource = manifesto.create(manifestFixture002);
     const received = getDestructuredMetadata(iiifResource);
+    const expected = [{
+      label: 'date',
+      value: 'some date',
+    }];
+
+    expect(received).toEqual(expected);
+  });
+
+  it('returns an empty array if there is no metadata', () => {
+    const iiifResource = manifesto.create(manifestFixture019);
+    const received = getDestructuredMetadata(iiifResource);
+
+    expect(received).toEqual([]);
+  });
+});
+
+describe('getManifestMetadata', () => {
+  it('should return the first value of label/value attributes for each object in the array ', () => {
+    const iiifResource = manifesto.create(manifestFixture002);
+    const state = { manifests: { x: { manifestation: iiifResource } } };
+    const received = getManifestMetadata(state, { manifestId: 'x' });
     const expected = [{
       label: 'date',
       value: 'some date',

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -204,12 +204,13 @@ describe('getWindowViewType', () => {
 describe('getManifestDescription', () => {
   it('should return manifest description', () => {
     const manifest = manifesto.create(manifestFixture001);
-    const received = getManifestDescription(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestDescription(state, { manifestId: 'x' });
     expect(received).toBe('[Handbill of Mr. Becket, [1787] ]');
   });
 
   it('should return undefined if manifest undefined', () => {
-    const received = getManifestDescription(undefined);
+    const received = getManifestDescription({ manifests: {} }, { manifestId: 'x' });
     expect(received).toBeUndefined();
   });
 });

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -68,14 +68,12 @@ describe('getWindowManifest()', () => {
 
 describe('getManifestLogo()', () => {
   it('should return manifest logo id', () => {
-    const manifest = { manifestation: manifesto.create(manifestFixture001) };
-    const received = getManifestLogo(manifest);
+    const received = getManifestLogo({ manifests: { x: { manifesto: manifesto.create(manifestFixture001) } } }, { manifestId: 'x' });
     expect(received).toEqual(manifestFixture001.logo['@id']);
   });
 
   it('should return null if manifest has no logo', () => {
-    const manifest = { manifestation: manifesto.create({}) };
-    const received = getManifestLogo(manifest);
+    const received = getManifestLogo({ manifests: { x: { manifesto: manifesto.create({}) } } }, { manifestId: 'x' });
     expect(received).toBeNull();
   });
 });

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -88,7 +88,8 @@ describe('getManifestLogo()', () => {
 describe('getManifestThumbnail()', () => {
   it('should return manifest thumbnail id', () => {
     const manifest = manifesto.create(manifestFixture001);
-    const received = getManifestThumbnail(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toEqual(manifestFixture001.thumbnail['@id']);
   });
 
@@ -104,19 +105,22 @@ describe('getManifestThumbnail()', () => {
       ],
     };
 
-    const received = getManifestThumbnail(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toEqual('xyz');
   });
 
   it('returns a thumbnail sized image url from the first canvas', () => {
     const manifest = manifesto.create(manifestFixture019);
-    const received = getManifestThumbnail(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toEqual('https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/,80/0/default.jpg');
   });
 
   it('should return null if manifest has no thumbnail', () => {
     const manifest = manifesto.create({});
-    const received = getManifestThumbnail(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestThumbnail(state, { manifestId: 'x' });
     expect(received).toBeNull();
   });
 });
@@ -124,13 +128,15 @@ describe('getManifestThumbnail()', () => {
 describe('getManifestCanvases', () => {
   it('returns an empty array if the manifestation is not loaded', () => {
     const manifest = {};
-    const received = getManifestCanvases(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestCanvases(state, { manifestId: 'x' });
     expect(received).toEqual([]);
   });
 
   it('returns canvases from the manifest', () => {
     const manifest = manifesto.create(manifestFixture001);
-    const received = getManifestCanvases(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestCanvases(state, { manifestId: 'x' });
     expect(received.length).toBe(1);
     expect(received[0].id).toBe('https://iiif.bodleian.ox.ac.uk/iiif/canvas/9cca8fdd-4a61-4429-8ac1-f648764b4d6d.json');
   });

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -12,7 +12,7 @@ import {
   getLanguagesFromConfigWithCurrent,
   getSelectedCanvas,
   getSelectedCanvases,
-  getWindowManifest,
+  getManifest,
   getManifestLogo,
   getManifestCanvases,
   getManifestDescription,
@@ -32,7 +32,7 @@ import Annotation from '../../../src/lib/Annotation';
 import AnnotationResource from '../../../src/lib/AnnotationResource';
 
 
-describe('getWindowManifest()', () => {
+describe('getManifest()', () => {
   const state = {
     windows: {
       a: { id: 'a', manifestId: 'x' },
@@ -44,59 +44,64 @@ describe('getWindowManifest()', () => {
     },
   };
 
+  it('should return the manifest of a certain id', () => {
+    const received = getManifest(state, { manifestId: 'x' });
+    const expected = { id: 'x' };
+    expect(received).toEqual(expected);
+  });
+
+
   it('should return the manifest of a certain window', () => {
-    const received = getWindowManifest(state, 'a');
+    const received = getManifest(state, { windowId: 'a' });
     const expected = { id: 'x' };
     expect(received).toEqual(expected);
   });
 
   it('should return undefined if window doesnt exist', () => {
-    const received = getWindowManifest(state, 'unknown');
+    const received = getManifest(state, { windowId: 'unknown' });
     expect(received).toBeUndefined();
   });
 
   it('should return undefined if window has no manifest id', () => {
-    const received = getWindowManifest(state, 'c');
+    const received = getManifest(state, { windowId: 'c' });
     expect(received).toBeUndefined();
   });
 
   it('should return undefined if manifest does not exist', () => {
-    const received = getWindowManifest(state, 'b');
+    const received = getManifest(state, { windowId: 'b' });
     expect(received).toBeUndefined();
   });
 });
 
 describe('getManifestLogo()', () => {
   it('should return manifest logo id', () => {
-    const received = getManifestLogo({ manifests: { x: { manifesto: manifesto.create(manifestFixture001) } } }, { manifestId: 'x' });
+    const received = getManifestLogo({ manifests: { x: { manifestation: manifesto.create(manifestFixture001) } } }, { manifestId: 'x' });
     expect(received).toEqual(manifestFixture001.logo['@id']);
   });
 
   it('should return null if manifest has no logo', () => {
-    const received = getManifestLogo({ manifests: { x: { manifesto: manifesto.create({}) } } }, { manifestId: 'x' });
+    const received = getManifestLogo({ manifests: { x: { manifestation: manifesto.create({}) } } }, { manifestId: 'x' });
     expect(received).toBeNull();
   });
 });
 
 describe('getManifestThumbnail()', () => {
   it('should return manifest thumbnail id', () => {
-    const manifest = { manifestation: manifesto.create(manifestFixture001) };
+    const manifest = manifesto.create(manifestFixture001);
     const received = getManifestThumbnail(manifest);
     expect(received).toEqual(manifestFixture001.thumbnail['@id']);
   });
 
   it('returns the first canvas thumbnail id', () => {
     const manifest = {
-      manifestation: {
-        getThumbnail: () => (null),
-        getSequences: () => [
-          {
-            getCanvases: () => [
-              { getThumbnail: () => ({ id: 'xyz' }) },
-            ],
-          },
-        ],
-      },
+      getThumbnail: () => (null),
+      getSequences: () => [
+        {
+          getCanvases: () => [
+            { getThumbnail: () => ({ id: 'xyz' }) },
+          ],
+        },
+      ],
     };
 
     const received = getManifestThumbnail(manifest);
@@ -104,13 +109,13 @@ describe('getManifestThumbnail()', () => {
   });
 
   it('returns a thumbnail sized image url from the first canvas', () => {
-    const manifest = { manifestation: manifesto.create(manifestFixture019) };
+    const manifest = manifesto.create(manifestFixture019);
     const received = getManifestThumbnail(manifest);
     expect(received).toEqual('https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/,80/0/default.jpg');
   });
 
   it('should return null if manifest has no thumbnail', () => {
-    const manifest = { manifestation: manifesto.create({}) };
+    const manifest = manifesto.create({});
     const received = getManifestThumbnail(manifest);
     expect(received).toBeNull();
   });
@@ -124,7 +129,7 @@ describe('getManifestCanvases', () => {
   });
 
   it('returns canvases from the manifest', () => {
-    const manifest = { manifestation: manifesto.create(manifestFixture001) };
+    const manifest = manifesto.create(manifestFixture001);
     const received = getManifestCanvases(manifest);
     expect(received.length).toBe(1);
     expect(received[0].id).toBe('https://iiif.bodleian.ox.ac.uk/iiif/canvas/9cca8fdd-4a61-4429-8ac1-f648764b4d6d.json');
@@ -160,19 +165,13 @@ describe('getThumbnailNavigationPosition', () => {
 
 describe('getManifestTitle', () => {
   it('should return manifest title', () => {
-    const manifest = { manifestation: manifesto.create(manifestFixture001) };
+    const manifest = manifesto.create(manifestFixture001);
     const received = getManifestTitle(manifest);
     expect(received).toBe('Bodleian Library Human Freaks 2 (33)');
   });
 
   it('should return undefined if manifest undefined', () => {
     const received = getManifestTitle(undefined);
-    expect(received).toBeUndefined();
-  });
-
-  it('should return undefined if no manifestation', () => {
-    const manifest = {};
-    const received = getManifestTitle(manifest);
     expect(received).toBeUndefined();
   });
 });
@@ -203,7 +202,7 @@ describe('getWindowViewType', () => {
 
 describe('getManifestDescription', () => {
   it('should return manifest description', () => {
-    const manifest = { manifestation: manifesto.create(manifestFixture001) };
+    const manifest = manifesto.create(manifestFixture001);
     const received = getManifestDescription(manifest);
     expect(received).toBe('[Handbill of Mr. Becket, [1787] ]');
   });
@@ -212,29 +211,17 @@ describe('getManifestDescription', () => {
     const received = getManifestDescription(undefined);
     expect(received).toBeUndefined();
   });
-
-  it('should return undefined if no manifestation', () => {
-    const manifest = {};
-    const received = getManifestDescription(manifest);
-    expect(received).toBeUndefined();
-  });
 });
 
 describe('getManifestProvider', () => {
   it('should return manifest provider label', () => {
-    const manifest = { manifestation: manifesto.create(manifestFixtureWithAProvider) };
+    const manifest = manifesto.create(manifestFixtureWithAProvider);
     const received = getManifestProvider(manifest);
     expect(received).toBe('Example Organization');
   });
 
   it('should return undefined if manifest undefined', () => {
     const received = getManifestProvider(undefined);
-    expect(received).toBeUndefined();
-  });
-
-  it('should return undefined if no manifestation', () => {
-    const manifest = {};
-    const received = getManifestProvider(manifest);
     expect(received).toBeUndefined();
   });
 });

--- a/__tests__/src/selectors/index.test.js
+++ b/__tests__/src/selectors/index.test.js
@@ -224,12 +224,13 @@ describe('getManifestDescription', () => {
 describe('getManifestProvider', () => {
   it('should return manifest provider label', () => {
     const manifest = manifesto.create(manifestFixtureWithAProvider);
-    const received = getManifestProvider(manifest);
+    const state = { manifests: { x: { manifestation: manifest } } };
+    const received = getManifestProvider(state, { manifestId: 'x' });
     expect(received).toBe('Example Organization');
   });
 
   it('should return undefined if manifest undefined', () => {
-    const received = getManifestProvider(undefined);
+    const received = getManifestProvider({ manifests: {} }, { manifestId: 'x' });
     expect(received).toBeUndefined();
   });
 });

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "redux-debounced": "^0.5.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "sass-loader": "^7.1.0",
     "uuid": "^3.3.2"
   },

--- a/src/components/GalleryView.js
+++ b/src/components/GalleryView.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import ManifestoCanvas from '../lib/ManifestoCanvas';
-import { getCanvasLabel, getManifestCanvases } from '../state/selectors';
+import { getCanvasLabel } from '../state/selectors';
 import { CanvasThumbnail } from './CanvasThumbnail';
 import ns from '../config/css-ns';
 
@@ -12,16 +12,6 @@ import ns from '../config/css-ns';
  * OSD and Navigation
  */
 export class GalleryView extends Component {
-  /**
-   * @param {Object} props
-   */
-  constructor(props) {
-    super(props);
-
-    const { manifest } = this.props;
-    this.canvases = manifest.manifestation.getSequences()[0].getCanvases();
-  }
-
   /**
    * container classes
    */
@@ -35,7 +25,7 @@ export class GalleryView extends Component {
    * Renders things
    */
   render() {
-    const { window, manifest, setCanvas } = this.props;
+    const { window, canvases, setCanvas } = this.props;
     return (
       <>
         <section
@@ -43,7 +33,7 @@ export class GalleryView extends Component {
           id={`${window.id}-gallery`}
         >
           {
-            getManifestCanvases(manifest).map((canvas) => {
+            canvases.map((canvas) => {
               const manifestoCanvas = new ManifestoCanvas(canvas);
               return (
                 <div
@@ -75,7 +65,7 @@ export class GalleryView extends Component {
 }
 
 GalleryView.propTypes = {
-  manifest: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   setCanvas: PropTypes.func.isRequired,
 };

--- a/src/components/PrimaryWindow.js
+++ b/src/components/PrimaryWindow.js
@@ -30,7 +30,6 @@ export class PrimaryWindow extends Component {
       return (
         <WindowViewer
           window={window}
-          manifest={manifest}
         />
       );
     }

--- a/src/components/WindowList.js
+++ b/src/components/WindowList.js
@@ -14,14 +14,9 @@ export class WindowList extends Component {
    * @private
    */
   titleContent(window) {
-    const { manifests, t } = this.props;
+    const { titles, t } = this.props;
 
-    if (window.manifestId
-        && manifests[window.manifestId]
-        && manifests[window.manifestId].manifestation) {
-      return manifests[window.manifestId].manifestation.getLabel().map(label => label.value)[0];
-    }
-    return t('untitled');
+    return titles[window.id] || t('untitled');
   }
 
   /**
@@ -69,11 +64,12 @@ WindowList.propTypes = {
   handleClose: PropTypes.func.isRequired,
   anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   windows: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  manifests: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  titles: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   t: PropTypes.func,
 };
 
 WindowList.defaultProps = {
   anchorEl: null,
   t: key => key,
+  titles: {},
 };

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -16,8 +16,8 @@ export class WindowViewer extends Component {
   constructor(props) {
     super(props);
 
-    const { manifest, window } = this.props;
-    this.canvases = manifest.manifestation.getSequences()[0].getCanvases();
+    const { canvases, window } = this.props;
+    this.canvases = canvases;
     this.canvasGroupings = new CanvasGroupings(this.canvases, window.view);
   }
 
@@ -137,9 +137,9 @@ export class WindowViewer extends Component {
 }
 
 WindowViewer.propTypes = {
+  canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   infoResponses: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   fetchAnnotation: PropTypes.func.isRequired,
   fetchInfoResponse: PropTypes.func.isRequired,
-  manifest: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/src/containers/GalleryView.js
+++ b/src/containers/GalleryView.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import * as actions from '../state/actions';
 import { withPlugins } from '../extend';
 import { GalleryView } from '../components/GalleryView';
+import { getManifestCanvases } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -10,7 +11,9 @@ import { GalleryView } from '../components/GalleryView';
  * @private
  */
 const mapStateToProps = state => (
-  {}
+  {
+    canvases: getManifestCanvases(state, { windowId: window.id }),
+  }
 );
 
 /**

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state, { manifestId }) => {
     isFetching: manifest.isFetching,
     title: getManifestTitle(state, { manifestId }),
     thumbnail: getManifestThumbnail(state, { manifestId }),
-    provider: manifest.provider || getManifestProvider(getManifestoInstance(state, { manifestId })),
+    provider: manifest.provider || getManifestProvider(state, { manifestId }),
     size: getManifestCanvases(state, { manifestId }).length,
     manifestLogo: getManifestLogo(state, { manifestId }),
   };

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, { manifestId }) => {
     ready: !!manifest.manifestation,
     error: manifest.error,
     isFetching: manifest.isFetching,
-    title: getManifestTitle(getManifestoInstance(state, { manifestId })),
+    title: getManifestTitle(state, { manifestId }),
     thumbnail: getManifestThumbnail(getManifestoInstance(state, { manifestId })),
     provider: manifest.provider || getManifestProvider(getManifestoInstance(state, { manifestId })),
     size: getManifestCanvases(getManifestoInstance(state, { manifestId })).length,

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -21,7 +21,7 @@ const mapStateToProps = (state, { manifestId }) => {
     thumbnail: getManifestThumbnail(manifest),
     provider: getManifestProvider(manifest),
     size: getManifestCanvases(manifest).length,
-    manifestLogo: getManifestLogo(state.manifests[manifestId]),
+    manifestLogo: getManifestLogo(state, { manifestId }),
   };
 };
 

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -19,9 +19,9 @@ const mapStateToProps = (state, { manifestId }) => {
     error: manifest.error,
     isFetching: manifest.isFetching,
     title: getManifestTitle(state, { manifestId }),
-    thumbnail: getManifestThumbnail(getManifestoInstance(state, { manifestId })),
+    thumbnail: getManifestThumbnail(state, { manifestId }),
     provider: manifest.provider || getManifestProvider(getManifestoInstance(state, { manifestId })),
-    size: getManifestCanvases(getManifestoInstance(state, { manifestId })).length,
+    size: getManifestCanvases(state, { manifestId }).length,
     manifestLogo: getManifestLogo(state, { manifestId }),
   };
 };

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -4,7 +4,8 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend';
 import {
-  getManifestTitle, getManifestThumbnail, getManifestCanvases, getManifestLogo, getManifestProvider,
+  getManifestTitle, getManifestThumbnail, getManifestCanvases,
+  getManifestLogo, getManifestProvider, getManifestoInstance,
 } from '../state/selectors';
 import * as actions from '../state/actions';
 import { ManifestListItem } from '../components/ManifestListItem';
@@ -17,10 +18,10 @@ const mapStateToProps = (state, { manifestId }) => {
     ready: !!manifest.manifestation,
     error: manifest.error,
     isFetching: manifest.isFetching,
-    title: getManifestTitle(manifest),
-    thumbnail: getManifestThumbnail(manifest),
-    provider: getManifestProvider(manifest),
-    size: getManifestCanvases(manifest).length,
+    title: getManifestTitle(getManifestoInstance(state, { manifestId })),
+    thumbnail: getManifestThumbnail(getManifestoInstance(state, { manifestId })),
+    provider: manifest.provider || getManifestProvider(getManifestoInstance(state, { manifestId })),
+    size: getManifestCanvases(getManifestoInstance(state, { manifestId })).length,
     manifestLogo: getManifestLogo(state, { manifestId }),
   };
 };

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend';
 import {
   getManifestTitle, getManifestThumbnail, getManifestCanvases,
-  getManifestLogo, getManifestProvider, getManifestoInstance,
+  getManifestLogo, getManifestProvider,
 } from '../state/selectors';
 import * as actions from '../state/actions';
 import { ManifestListItem } from '../components/ManifestListItem';

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -15,7 +15,7 @@ const mapStateToProps = (state, { manifestId }) => {
   const manifest = state.manifests[manifestId];
 
   return {
-    ready: !!manifest.manifestation,
+    ready: !!manifest.json,
     error: manifest.error,
     isFetching: manifest.isFetching,
     title: getManifestTitle(state, { manifestId }),

--- a/src/containers/MosaicRenderPreview.js
+++ b/src/containers/MosaicRenderPreview.js
@@ -3,13 +3,13 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
-import { getManifestoInstance, getManifestTitle } from '../state/selectors';
+import { getManifestTitle } from '../state/selectors';
 import { MosaicRenderPreview } from '../components/MosaicRenderPreview';
 
 /** */
 const mapStateToProps = (state, { windowId }) => (
   {
-    title: getManifestTitle(getManifestoInstance(state, { windowId })),
+    title: getManifestTitle(state, { windowId }),
   }
 );
 

--- a/src/containers/MosaicRenderPreview.js
+++ b/src/containers/MosaicRenderPreview.js
@@ -3,13 +3,13 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
-import { getWindowManifest, getManifestTitle } from '../state/selectors';
+import { getManifestoInstance, getManifestTitle } from '../state/selectors';
 import { MosaicRenderPreview } from '../components/MosaicRenderPreview';
 
 /** */
 const mapStateToProps = (state, { windowId }) => (
   {
-    title: getManifestTitle(getWindowManifest(state, windowId)),
+    title: getManifestTitle(getManifestoInstance(state, { windowId })),
   }
 );
 

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -23,7 +23,7 @@ const mapStateToProps = ({
 }, { windowId, currentCanvases }) => ({
   viewer: viewers[windowId],
   label: getCanvasLabel(
-    getSelectedCanvas({ windows, manifests }, windowId),
+    getSelectedCanvas({ windows, manifests }, { windowId }),
     windows[windowId].canvasIndex,
   ),
   annotations: getSelectedTargetAnnotationResources(

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -6,7 +6,7 @@ import { withPlugins } from '../extend';
 import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
 import { ThumbnailNavigation } from '../components/ThumbnailNavigation';
-import { getManifestCanvases, getManifestoInstance } from '../state/selectors';
+import { getManifestCanvases } from '../state/selectors';
 /**
  * mapStateToProps - used to hook up state to props
  * @memberof ThumbnailNavigation
@@ -16,9 +16,7 @@ const mapStateToProps = ({
   companionWindows, config, manifests, windows,
 }, { windowId }) => ({
   canvasGroupings: new CanvasGroupings(
-    getManifestCanvases(
-      getManifestoInstance({ windows, manifests }, { windowId }),
-    ),
+    getManifestCanvases({ windows, manifests }, { windowId }),
     windows[windowId].view,
   ),
   position: companionWindows[windows[windowId].thumbnailNavigationId].position,

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -6,7 +6,7 @@ import { withPlugins } from '../extend';
 import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
 import { ThumbnailNavigation } from '../components/ThumbnailNavigation';
-import { getManifestCanvases, getWindowManifest } from '../state/selectors';
+import { getManifestCanvases, getManifestoInstance } from '../state/selectors';
 /**
  * mapStateToProps - used to hook up state to props
  * @memberof ThumbnailNavigation
@@ -17,7 +17,7 @@ const mapStateToProps = ({
 }, { windowId }) => ({
   canvasGroupings: new CanvasGroupings(
     getManifestCanvases(
-      getWindowManifest({ windows, manifests }, windowId),
+      getManifestoInstance({ windows, manifests }, { windowId }),
     ),
     windows[windowId].view,
   ),

--- a/src/containers/ViewerInfo.js
+++ b/src/containers/ViewerInfo.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import { ViewerInfo } from '../components/ViewerInfo';
-import { getCanvasLabel, getWindowManifest, getManifestCanvases } from '../state/selectors';
+import { getCanvasLabel, getManifestoInstance, getManifestCanvases } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -12,7 +12,7 @@ import { getCanvasLabel, getWindowManifest, getManifestCanvases } from '../state
  */
 const mapStateToProps = (state, props) => {
   const { windowId } = props;
-  const manifest = getWindowManifest(state, windowId);
+  const manifest = getManifestoInstance(state, { windowId });
   const canvases = getManifestCanvases(manifest);
   const { canvasIndex } = state.windows[windowId];
 

--- a/src/containers/ViewerInfo.js
+++ b/src/containers/ViewerInfo.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import { ViewerInfo } from '../components/ViewerInfo';
-import { getCanvasLabel, getManifestoInstance, getManifestCanvases } from '../state/selectors';
+import { getCanvasLabel, getManifestCanvases } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -12,8 +12,7 @@ import { getCanvasLabel, getManifestoInstance, getManifestCanvases } from '../st
  */
 const mapStateToProps = (state, props) => {
   const { windowId } = props;
-  const manifest = getManifestoInstance(state, { windowId });
-  const canvases = getManifestCanvases(manifest);
+  const canvases = getManifestCanvases(state, { windowId });
   const { canvasIndex } = state.windows[windowId];
 
   return {

--- a/src/containers/Window.js
+++ b/src/containers/Window.js
@@ -5,7 +5,7 @@ import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
 import { Window } from '../components/Window';
-import { getManifestoInstance, getManifestTitle, getThumbnailNavigationPosition } from '../state/selectors';
+import { getManifestTitle, getThumbnailNavigationPosition } from '../state/selectors';
 
 
 /**
@@ -17,7 +17,7 @@ const mapStateToProps = (state, props) => ({
   manifest: state.manifests[props.window.manifestId],
   window: state.windows[props.window.id],
   workspaceType: state.config.workspace.type,
-  label: getManifestTitle(getManifestoInstance(state, { windowId: props.window.id })),
+  label: getManifestTitle(state, { windowId: props.window.id }),
   thumbnailNavigationPosition: getThumbnailNavigationPosition(state, props.window.id),
 });
 

--- a/src/containers/Window.js
+++ b/src/containers/Window.js
@@ -5,7 +5,7 @@ import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
 import { Window } from '../components/Window';
-import { getWindowManifest, getManifestTitle, getThumbnailNavigationPosition } from '../state/selectors';
+import { getManifestoInstance, getManifestTitle, getThumbnailNavigationPosition } from '../state/selectors';
 
 
 /**
@@ -17,7 +17,7 @@ const mapStateToProps = (state, props) => ({
   manifest: state.manifests[props.window.manifestId],
   window: state.windows[props.window.id],
   workspaceType: state.config.workspace.type,
-  label: getManifestTitle(getWindowManifest(state, props.window.id)),
+  label: getManifestTitle(getManifestoInstance(state, { windowId: props.window.id })),
   thumbnailNavigationPosition: getThumbnailNavigationPosition(state, props.window.id),
 });
 

--- a/src/containers/WindowCanvasNavigationControls.js
+++ b/src/containers/WindowCanvasNavigationControls.js
@@ -11,7 +11,7 @@ import { WindowCanvasNavigationControls } from '../components/WindowCanvasNaviga
 const mapStateToProps = (state, { windowId }) => ({
   window: state.windows[windowId],
   canvasLabel: getCanvasLabel(
-    getSelectedCanvas(state, windowId),
+    getSelectedCanvas(state, { windowId }),
     state.windows[windowId].canvasIndex,
   ),
   visible: state.workspace.focusedWindowId === windowId,

--- a/src/containers/WindowList.js
+++ b/src/containers/WindowList.js
@@ -3,6 +3,7 @@ import { compose } from 'redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
+import { getWindowTitles } from '../state/selectors';
 import { WindowList } from '../components/WindowList';
 
 /**
@@ -22,8 +23,8 @@ const mapDispatchToProps = {
 const mapStateToProps = state => (
   {
     containerId: state.config.id,
+    titles: getWindowTitles(state),
     windows: state.windows,
-    manifests: state.manifests,
   }
 );
 

--- a/src/containers/WindowSideBarAnnotationsPanel.js
+++ b/src/containers/WindowSideBarAnnotationsPanel.js
@@ -20,13 +20,13 @@ import { WindowSideBarAnnotationsPanel } from '../components/WindowSideBarAnnota
  */
 const mapStateToProps = (state, { windowId }) => ({
   selectedAnnotationIds: getSelectedAnnotationIds(
-    state, windowId, getSelectedCanvases(state, windowId).map(canvas => canvas.id),
+    state, windowId, getSelectedCanvases(state, { windowId }).map(canvas => canvas.id),
   ),
   annotations: getIdAndContentOfResources(
     getAnnotationResourcesByMotivation(
       getSelectedTargetsAnnotations(
         state,
-        getSelectedCanvases(state, windowId).map(canvas => canvas.id),
+        getSelectedCanvases(state, { windowId }).map(canvas => canvas.id),
       ),
       ['oa:commenting', 'sc:painting'],
     ),

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -33,7 +33,7 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  */
 const mapStateToProps = (state, { windowId }) => ({
   hasAnnotations: getAnnotationResourcesByMotivation(
-    getSelectedTargetAnnotations(state, (getSelectedCanvas(state, windowId) || {}).id),
+    getSelectedTargetAnnotations(state, (getSelectedCanvas(state, { windowId }) || {}).id),
     ['oa:commenting', 'sc:painting'],
   ).length > 0,
   sideBarPanel: (getCompanionWindowForPosition(state, windowId, 'left') || {}).content,

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -7,14 +7,14 @@ import * as actions from '../state/actions';
 import { WindowSideBarCanvasPanel } from '../components/WindowSideBarCanvasPanel';
 import {
   getManifestCanvases,
-  getWindowManifest,
+  getManifestoInstance,
 } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
  */
 const mapStateToProps = (state, { windowId }) => {
-  const manifest = getWindowManifest(state, windowId);
+  const manifest = getManifestoInstance(state, { windowId });
   const canvases = getManifestCanvases(manifest);
   const { config } = state;
   return {

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -7,15 +7,13 @@ import * as actions from '../state/actions';
 import { WindowSideBarCanvasPanel } from '../components/WindowSideBarCanvasPanel';
 import {
   getManifestCanvases,
-  getManifestoInstance,
 } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
  */
 const mapStateToProps = (state, { windowId }) => {
-  const manifest = getManifestoInstance(state, { windowId });
-  const canvases = getManifestCanvases(manifest);
+  const canvases = getManifestCanvases(state, { windowId });
   const { config } = state;
   return {
     canvases,

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -27,7 +27,7 @@ const mapStateToProps = (state, { windowId }) => ({
   canvasDescription: getCanvasDescription(getSelectedCanvas(state, windowId)),
   canvasMetadata: getDestructuredMetadata(getSelectedCanvas(state, windowId)),
   manifestLabel: getManifestTitle(state, { windowId }),
-  manifestDescription: getManifestDescription(getManifestoInstance(state, { windowId })),
+  manifestDescription: getManifestDescription(state, { windowId }),
   manifestMetadata: getDestructuredMetadata(getManifestoInstance(state, { windowId })),
 });
 

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -26,7 +26,7 @@ const mapStateToProps = (state, { windowId }) => ({
   ),
   canvasDescription: getCanvasDescription(getSelectedCanvas(state, windowId)),
   canvasMetadata: getDestructuredMetadata(getSelectedCanvas(state, windowId)),
-  manifestLabel: getManifestTitle(getManifestoInstance(state, { windowId })),
+  manifestLabel: getManifestTitle(state, { windowId }),
   manifestDescription: getManifestDescription(getManifestoInstance(state, { windowId })),
   manifestMetadata: getDestructuredMetadata(getManifestoInstance(state, { windowId })),
 });

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -21,11 +21,11 @@ import { WindowSideBarInfoPanel } from '../components/WindowSideBarInfoPanel';
  */
 const mapStateToProps = (state, { windowId }) => ({
   canvasLabel: getCanvasLabel(
-    getSelectedCanvas(state, windowId),
+    getSelectedCanvas(state, { windowId }),
     state.windows[windowId].canvasIndex,
   ),
-  canvasDescription: getCanvasDescription(getSelectedCanvas(state, windowId)),
-  canvasMetadata: getDestructuredMetadata(getSelectedCanvas(state, windowId)),
+  canvasDescription: getCanvasDescription(getSelectedCanvas(state, { windowId })),
+  canvasMetadata: getDestructuredMetadata(getSelectedCanvas(state, { windowId })),
   manifestLabel: getManifestTitle(state, { windowId }),
   manifestDescription: getManifestDescription(state, { windowId }),
   manifestMetadata: getManifestMetadata(state, { windowId }),

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -9,7 +9,7 @@ import {
   getManifestDescription,
   getManifestTitle,
   getSelectedCanvas,
-  getManifestoInstance,
+  getManifestMetadata,
   getCanvasDescription,
 } from '../state/selectors';
 import { WindowSideBarInfoPanel } from '../components/WindowSideBarInfoPanel';
@@ -28,7 +28,7 @@ const mapStateToProps = (state, { windowId }) => ({
   canvasMetadata: getDestructuredMetadata(getSelectedCanvas(state, windowId)),
   manifestLabel: getManifestTitle(state, { windowId }),
   manifestDescription: getManifestDescription(state, { windowId }),
-  manifestMetadata: getDestructuredMetadata(getManifestoInstance(state, { windowId })),
+  manifestMetadata: getManifestMetadata(state, { windowId }),
 });
 
 /**

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -9,7 +9,7 @@ import {
   getManifestDescription,
   getManifestTitle,
   getSelectedCanvas,
-  getWindowManifest,
+  getManifestoInstance,
   getCanvasDescription,
 } from '../state/selectors';
 import { WindowSideBarInfoPanel } from '../components/WindowSideBarInfoPanel';
@@ -26,9 +26,9 @@ const mapStateToProps = (state, { windowId }) => ({
   ),
   canvasDescription: getCanvasDescription(getSelectedCanvas(state, windowId)),
   canvasMetadata: getDestructuredMetadata(getSelectedCanvas(state, windowId)),
-  manifestLabel: getManifestTitle(getWindowManifest(state, windowId)),
-  manifestDescription: getManifestDescription(getWindowManifest(state, windowId)),
-  manifestMetadata: getDestructuredMetadata(getWindowManifest(state, windowId).manifestation),
+  manifestLabel: getManifestTitle(getManifestoInstance(state, { windowId })),
+  manifestDescription: getManifestDescription(getManifestoInstance(state, { windowId })),
+  manifestMetadata: getDestructuredMetadata(getManifestoInstance(state, { windowId })),
 });
 
 /**

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -4,12 +4,12 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
-import { getManifestoInstance, getManifestTitle } from '../state/selectors';
+import { getManifestTitle } from '../state/selectors';
 import { WindowTopBar } from '../components/WindowTopBar';
 
 /** mapStateToProps */
 const mapStateToProps = (state, { windowId }) => ({
-  manifestTitle: getManifestTitle(getManifestoInstance(state, { windowId })),
+  manifestTitle: getManifestTitle(state, { windowId }),
   maximized: state.windows[windowId].maximized,
   focused: state.workspace.focusedWindowId === windowId,
   allowClose: state.config.window.allowClose,

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -4,12 +4,12 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
-import { getWindowManifest, getManifestTitle } from '../state/selectors';
+import { getManifestoInstance, getManifestTitle } from '../state/selectors';
 import { WindowTopBar } from '../components/WindowTopBar';
 
 /** mapStateToProps */
 const mapStateToProps = (state, { windowId }) => ({
-  manifestTitle: getManifestTitle(getWindowManifest(state, windowId)),
+  manifestTitle: getManifestTitle(getManifestoInstance(state, { windowId })),
   maximized: state.windows[windowId].maximized,
   focused: state.workspace.focusedWindowId === windowId,
   allowClose: state.config.window.allowClose,

--- a/src/containers/WindowViewer.js
+++ b/src/containers/WindowViewer.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
 import { WindowViewer } from '../components/WindowViewer';
+import { getManifestCanvases } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -12,6 +13,7 @@ import { WindowViewer } from '../components/WindowViewer';
 const mapStateToProps = (state, { window }) => (
   {
     infoResponses: state.infoResponses,
+    canvases: getManifestCanvases(state, { windowId: window.id }),
   }
 );
 

--- a/src/state/reducers/manifests.js
+++ b/src/state/reducers/manifests.js
@@ -23,6 +23,7 @@ export const manifestsReducer = (state = {}, action) => {
           ...state[action.manifestId],
           id: action.manifestId,
           manifestation: manifesto.create(action.manifestJson),
+          json: manifestJson,
           isFetching: false,
           error: null, // Explicitly set the error to null in case this is a re-fetch
         },

--- a/src/state/reducers/manifests.js
+++ b/src/state/reducers/manifests.js
@@ -1,4 +1,3 @@
-import manifesto from 'manifesto.js';
 import omit from 'lodash/omit';
 import ActionTypes from '../actions/action-types';
 
@@ -22,8 +21,7 @@ export const manifestsReducer = (state = {}, action) => {
         [action.manifestId]: {
           ...state[action.manifestId],
           id: action.manifestId,
-          manifestation: manifesto.create(action.manifestJson),
-          json: manifestJson,
+          json: action.manifestJson,
           isFetching: false,
           error: null, // Explicitly set the error to null in case this is a re-fetch
         },

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -14,11 +14,20 @@ export function getManifest(state, { manifestId, windowId }) {
   ];
 }
 
+/** Instantiate a manifesto instance */
 export const getManifestoInstance = createSelector(
   [getManifest],
   manifest => manifest && manifest.json && manifesto.create(manifest.json),
 );
 
+/**
+ * Get the logo for a manifest
+ * @param {object} state
+ * @param {object} props
+ * @param {string} props.manifestId
+ * @param {string} props.windowId
+ * @return {String|null}
+ */
 export const getManifestLogo = createSelector(
   [getManifestoInstance],
   manifest => manifest && manifest.getLogo(),
@@ -26,7 +35,10 @@ export const getManifestLogo = createSelector(
 
 /**
 * Return the IIIF v3 provider of a manifest or null
-* @param {object} manifest
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @return {String|null}
 */
 export const getManifestProvider = createSelector(
@@ -39,7 +51,10 @@ export const getManifestProvider = createSelector(
 
 /**
 * Return the supplied thumbnail for a manifest or null
-* @param {object} manifest
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @return {String|null}
 */
 export function getManifestThumbnail(state, props) {
@@ -77,7 +92,10 @@ export function getManifestThumbnail(state, props) {
 
 /**
 * Return the logo of a manifest or null
-* @param {object} manifest
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @return {String|null}
 */
 export const getManifestCanvases = createSelector(
@@ -110,7 +128,9 @@ export function getIdAndLabelOfCanvases(canvases) {
 /**
 * Return the current canvas selected in a window
 * @param {object} state
-* @param {String} windowId
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @return {Object}
 */
 export const getSelectedCanvas = createSelector(
@@ -128,7 +148,9 @@ export const getSelectedCanvas = createSelector(
 * Return the current canvases selected in a window
 * For book view returns 2, for single returns 1
 * @param {object} state
-* @param {String} windowId
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @return {Array}
 */
 export const getSelectedCanvases = createSelector(
@@ -215,6 +237,10 @@ export function getThumbnailNavigationPosition(state, windowId) {
 
 /**
 * Return manifest title
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @return {String}
 */
 export const getManifestTitle = createSelector(
@@ -223,7 +249,11 @@ export const getManifestTitle = createSelector(
     && manifest.getLabel().map(label => label.value)[0],
 );
 
-/** */
+/**
+ * Return the manifest titles for all open windows
+ * @param {object} state
+ * @return {object}
+ */
 export function getWindowTitles(state) {
   const result = {};
 
@@ -236,7 +266,9 @@ export function getWindowTitles(state) {
 
 /** Return type of view in a certain window.
 * @param {object} state
-* @param {String} windowId
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @param {String}
 */
 export function getWindowViewType(state, windowId) {
@@ -245,7 +277,10 @@ export function getWindowViewType(state, windowId) {
 
 /**
 * Return manifest description
-* @param {object} manifest
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
 * @return {String}
 */
 export const getManifestDescription = createSelector(
@@ -288,6 +323,11 @@ export function getDestructuredMetadata(iiifResource) {
 
 /**
  * Return manifest metadata in a label / value structure
+ * @param {object} state
+ * @param {object} props
+ * @param {string} props.manifestId
+ * @param {string} props.windowId
+ * @return {Array[Object]}
  */
 export const getManifestMetadata = createSelector(
   [getManifestoInstance],

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -16,10 +16,7 @@ export function getManifest(state, { manifestId, windowId }) {
 
 export const getManifestoInstance = createSelector(
   [getManifest],
-  manifest => manifest && (
-    manifest.manifestation
-    || (manifest.json && manifesto.create(manifest.json))
-  ),
+  manifest => manifest && manifest.json && manifesto.create(manifest.json),
 );
 
 export const getManifestLogo = createSelector(

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -10,7 +10,7 @@ import CanvasGroupings from '../../lib/CanvasGroupings';
 export function getManifest(state, { manifestId, windowId }) {
   return state.manifests[
     manifestId
-    || (state.windows[windowId] && state.windows[windowId].manifestId)
+    || (windowId && state.windows[windowId] && state.windows[windowId].manifestId)
   ];
 }
 
@@ -209,10 +209,11 @@ export function getThumbnailNavigationPosition(state, windowId) {
 
 /**
 * Return manifest title
-* @param {object} manifest
 * @return {String}
 */
-export function getManifestTitle(manifest) {
+export function getManifestTitle(state, props) {
+  const manifest = getManifestoInstance(state, props);
+
   return manifest
     && manifest.getLabel().map(label => label.value)[0];
 }

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -223,6 +223,17 @@ export const getManifestTitle = createSelector(
     && manifest.getLabel().map(label => label.value)[0],
 );
 
+/** */
+export function getWindowTitles(state) {
+  const result = {};
+
+  Object.keys(state.windows).forEach((windowId) => {
+    result[windowId] = getManifestTitle(state, { windowId });
+  });
+
+  return result;
+}
+
 /** Return type of view in a certain window.
 * @param {object} state
 * @param {String} windowId

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -278,6 +278,15 @@ export function getDestructuredMetadata(iiifResource) {
 }
 
 /**
+ * Return manifest metadata in a label / value structure
+ */
+export function getManifestMetadata(state, props) {
+  const manifest = getManifestoInstance(state, props);
+
+  return getDestructuredMetadata(manifest);
+}
+
+/**
 * Return canvas description
 * @param {object} canvas
 * @param {String}

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -29,7 +29,9 @@ export const getManifestLogo = createSelector(
 * @param {object} manifest
 * @return {String|null}
 */
-export function getManifestProvider(manifest) {
+export function getManifestProvider(state, props) {
+  const manifest = getManifestoInstance(state, props);
+
   return manifest
     && manifest.getProperty('provider')
     && manifest.getProperty('provider')[0].label

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -1,9 +1,36 @@
+import { createSelector } from 'reselect';
 import filter from 'lodash/filter';
 import flatten from 'lodash/flatten';
 import { LanguageMap } from 'manifesto.js';
 import Annotation from '../../lib/Annotation';
 import ManifestoCanvas from '../../lib/ManifestoCanvas';
 import CanvasGroupings from '../../lib/CanvasGroupings';
+
+/** */
+const uncurry = curriedFn => (...args) => (
+  args.reduce((left, right) => left(right), curriedFn)
+);
+
+/** */
+const createSelectorN = (...selectors) => {
+  const curriedFn = selectors[selectors.length - 1];
+  return createSelector(...selectors.slice(0, -1), uncurry(curriedFn));
+};
+
+/** */
+function getManifest(state, { manifestId }) {
+  return state.manifests[manifestId];
+}
+
+export const getManifestoInstance = createSelector(
+  [getManifest],
+  manifest => manifest.manifesto,
+);
+
+export const getManifestLogo = createSelectorN(
+  [getManifestoInstance],
+  manifest => manifest && manifest.getLogo(),
+);
 
 /**
 * Return the manifest that belongs to a certain window.
@@ -15,16 +42,6 @@ export function getWindowManifest(state, windowId) {
   return state.windows[windowId]
     && state.windows[windowId].manifestId
     && state.manifests[state.windows[windowId].manifestId];
-}
-
-/**
-* Return the logo of a manifest or null
-* @param {object} manifest
-* @return {String|null}
-*/
-export function getManifestLogo(manifest) {
-  return manifest.manifestation
-    && manifest.manifestation.getLogo();
 }
 
 /**

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -41,9 +41,11 @@ export function getManifestProvider(manifest) {
 * @param {object} manifest
 * @return {String|null}
 */
-export function getManifestThumbnail(manifest) {
+export function getManifestThumbnail(state, props) {
   /** */
   function getTopLevelManifestThumbnail() {
+    const manifest = getManifestoInstance(state, props);
+
     return manifest
       && manifest.getThumbnail()
       && manifest.getThumbnail().id;
@@ -51,14 +53,14 @@ export function getManifestThumbnail(manifest) {
 
   /** */
   function getFirstCanvasThumbnail() {
-    const canvases = getManifestCanvases(manifest);
+    const canvases = getManifestCanvases(state, props);
 
     return canvases.length > 0 && canvases[0].getThumbnail() && canvases[0].getThumbnail().id;
   }
 
   /** */
   function generateThumbnailFromFirstCanvas() {
-    const canvases = getManifestCanvases(manifest);
+    const canvases = getManifestCanvases(state, props);
 
     if (canvases.length === 0) return null;
 
@@ -77,7 +79,9 @@ export function getManifestThumbnail(manifest) {
 * @param {object} manifest
 * @return {String|null}
 */
-export function getManifestCanvases(manifest) {
+export function getManifestCanvases(state, props) {
+  const manifest = getManifestoInstance(state, props);
+
   if (!manifest) {
     return [];
   }

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import filter from 'lodash/filter';
 import flatten from 'lodash/flatten';
-import { LanguageMap } from 'manifesto.js';
+import manifesto, { LanguageMap } from 'manifesto.js';
 import Annotation from '../../lib/Annotation';
 import ManifestoCanvas from '../../lib/ManifestoCanvas';
 import CanvasGroupings from '../../lib/CanvasGroupings';
@@ -16,7 +16,10 @@ export function getManifest(state, { manifestId, windowId }) {
 
 export const getManifestoInstance = createSelector(
   [getManifest],
-  manifest => manifest && manifest.manifestation,
+  manifest => manifest && (
+    manifest.manifestation
+    || (manifest.json && manifesto.create(manifest.json))
+  ),
 );
 
 export const getManifestLogo = createSelector(

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -232,7 +232,9 @@ export function getWindowViewType(state, windowId) {
 * @param {object} manifest
 * @return {String}
 */
-export function getManifestDescription(manifest) {
+export function getManifestDescription(state, props) {
+  const manifest = getManifestoInstance(state, props);
+
   return manifest
     && manifest.getDescription().map(label => label.value)[0];
 }

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -29,14 +29,13 @@ export const getManifestLogo = createSelector(
 * @param {object} manifest
 * @return {String|null}
 */
-export function getManifestProvider(state, props) {
-  const manifest = getManifestoInstance(state, props);
-
-  return manifest
+export const getManifestProvider = createSelector(
+  [getManifestoInstance],
+  manifest => manifest
     && manifest.getProperty('provider')
     && manifest.getProperty('provider')[0].label
-    && LanguageMap.parse(manifest.getProperty('provider')[0].label, manifest.options.locale).map(label => label.value)[0];
-}
+    && LanguageMap.parse(manifest.getProperty('provider')[0].label, manifest.options.locale).map(label => label.value)[0],
+);
 
 /**
 * Return the supplied thumbnail for a manifest or null
@@ -81,19 +80,20 @@ export function getManifestThumbnail(state, props) {
 * @param {object} manifest
 * @return {String|null}
 */
-export function getManifestCanvases(state, props) {
-  const manifest = getManifestoInstance(state, props);
+export const getManifestCanvases = createSelector(
+  [getManifestoInstance],
+  (manifest) => {
+    if (!manifest) {
+      return [];
+    }
 
-  if (!manifest) {
-    return [];
-  }
+    if (!manifest.getSequences || !manifest.getSequences()[0]) {
+      return [];
+    }
 
-  if (!manifest.getSequences || !manifest.getSequences()[0]) {
-    return [];
-  }
-
-  return manifest.getSequences()[0].getCanvases();
-}
+    return manifest.getSequences()[0].getCanvases();
+  },
+);
 
 /**
 * Return ids and labels of canvases
@@ -113,15 +113,16 @@ export function getIdAndLabelOfCanvases(canvases) {
 * @param {String} windowId
 * @return {Object}
 */
-export function getSelectedCanvas(state, windowId) {
-  const manifest = getManifestoInstance(state, { windowId });
-  const { canvasIndex } = state.windows[windowId];
-
-  return manifest
+export const getSelectedCanvas = createSelector(
+  [
+    getManifestoInstance,
+    (state, { windowId }) => state.windows[windowId].canvasIndex,
+  ],
+  (manifest, canvasIndex) => manifest
     && manifest
       .getSequences()[0]
-      .getCanvasByIndex(canvasIndex);
-}
+      .getCanvasByIndex(canvasIndex),
+);
 
 /**
 * Return the current canvases selected in a window
@@ -130,18 +131,17 @@ export function getSelectedCanvas(state, windowId) {
 * @param {String} windowId
 * @return {Array}
 */
-export function getSelectedCanvases(state, windowId) {
-  const manifest = getManifestoInstance(state, { windowId });
-  const { canvasIndex, view } = state.windows[windowId];
-  console.debug();
-
-  return manifest
+export const getSelectedCanvases = createSelector(
+  [
+    getManifestoInstance,
+    (state, { windowId }) => state.windows[windowId],
+  ],
+  (manifest, { canvasIndex, view }) => manifest
     && new CanvasGroupings(
       manifest.getSequences()[0].getCanvases(),
       view,
-    ).getCanvases(canvasIndex);
-}
-
+    ).getCanvases(canvasIndex),
+);
 
 /**
 * Return annotations for an array of targets
@@ -217,12 +217,11 @@ export function getThumbnailNavigationPosition(state, windowId) {
 * Return manifest title
 * @return {String}
 */
-export function getManifestTitle(state, props) {
-  const manifest = getManifestoInstance(state, props);
-
-  return manifest
-    && manifest.getLabel().map(label => label.value)[0];
-}
+export const getManifestTitle = createSelector(
+  [getManifestoInstance],
+  manifest => manifest
+    && manifest.getLabel().map(label => label.value)[0],
+);
 
 /** Return type of view in a certain window.
 * @param {object} state
@@ -238,12 +237,11 @@ export function getWindowViewType(state, windowId) {
 * @param {object} manifest
 * @return {String}
 */
-export function getManifestDescription(state, props) {
-  const manifest = getManifestoInstance(state, props);
-
-  return manifest
-    && manifest.getDescription().map(label => label.value)[0];
-}
+export const getManifestDescription = createSelector(
+  [getManifestoInstance],
+  manifest => manifest
+    && manifest.getDescription().map(label => label.value)[0],
+);
 
 /**
 * Return canvas label, or alternatively return the given index + 1 to be displayed
@@ -280,11 +278,10 @@ export function getDestructuredMetadata(iiifResource) {
 /**
  * Return manifest metadata in a label / value structure
  */
-export function getManifestMetadata(state, props) {
-  const manifest = getManifestoInstance(state, props);
-
-  return getDestructuredMetadata(manifest);
-}
+export const getManifestMetadata = createSelector(
+  [getManifestoInstance],
+  manifest => manifest && getDestructuredMetadata(manifest),
+);
 
 /**
 * Return canvas description

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -7,17 +7,6 @@ import ManifestoCanvas from '../../lib/ManifestoCanvas';
 import CanvasGroupings from '../../lib/CanvasGroupings';
 
 /** */
-const uncurry = curriedFn => (...args) => (
-  args.reduce((left, right) => left(right), curriedFn)
-);
-
-/** */
-const createSelectorN = (...selectors) => {
-  const curriedFn = selectors[selectors.length - 1];
-  return createSelector(...selectors.slice(0, -1), uncurry(curriedFn));
-};
-
-/** */
 function getManifest(state, { manifestId }) {
   return state.manifests[manifestId];
 }
@@ -27,7 +16,7 @@ export const getManifestoInstance = createSelector(
   manifest => manifest.manifesto,
 );
 
-export const getManifestLogo = createSelectorN(
+export const getManifestLogo = createSelector(
   [getManifestoInstance],
   manifest => manifest && manifest.getLogo(),
 );


### PR DESCRIPTION
I started work on #1877 and it seems like manifesto is deficient in several key ways that will make that work somewhat challenging to do cleanly. In a face-to-face discussion, we decided that it's probably appropriate to at least be cautious in how we use manifesto (perhaps going as far as replacing it). As a first step, it seems helpful to get the manifesto instance out of the redux store.

