### PR TITLE
Update the WindowSideBar focus implementation to use refs and …

### DIFF
--- a/__tests__/src/components/WindowSideBarButtons.test.js
+++ b/__tests__/src/components/WindowSideBarButtons.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { WindowSideBarButtons } from '../../../src/components/WindowSideBarButtons';
 
 /** create wrapper */
 function createWrapper(props) {
-  return shallow(
+  return mount(
     <WindowSideBarButtons
       addCompanionWindow={() => {}}
       {...props}
@@ -12,14 +12,24 @@ function createWrapper(props) {
   );
 }
 
-describe('WindowSideBarButtons', () => {
+/**
+ * Assert which tab is focussed
+ */
+function assertTabFocused(wrapper, tabIndex) {
+  const tabs = wrapper.find('button[role="tab"]');
+
+  tabs.forEach((tab, index) => {
+    if (index === tabIndex) {
+      expect(tab.find('button').instance()).toEqual(document.activeElement);
+    }
+  });
+}
+
+describe('WindowSideBarButtons (shallow)', () => {
   const windowId = 'test123';
   let wrapper;
 
   beforeEach(() => {
-    document.body.innerHTML = `<div id="${windowId}-sidebar-buttons" >`
-    + '<button role="tab" aria-selected="true" />'
-    + '</div>';
     wrapper = createWrapper({ windowId });
   });
 
@@ -31,7 +41,7 @@ describe('WindowSideBarButtons', () => {
     const addCompanionWindow = jest.fn();
     wrapper = createWrapper({ addCompanionWindow, windowId });
 
-    wrapper.find('WithStyles(Tabs)').simulate('change', { target: { removeAttribute: () => {}, setAttribute: () => {} } }, 'info');
+    wrapper.find('WithStyles(Tabs)').props().onChange({ target: { removeAttribute: () => {}, setAttribute: () => {} } }, 'info');
     expect(addCompanionWindow).toHaveBeenCalledTimes(1);
     expect(addCompanionWindow).toHaveBeenCalledWith('info');
   });
@@ -39,12 +49,38 @@ describe('WindowSideBarButtons', () => {
   it('has a badge indicating if the annotations panel has annotations', () => {
     let tab;
     wrapper = createWrapper({ hasAnnotations: true, windowId });
-    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]').dive().dive();
+    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]');
     expect(tab.find('WithStyles(Badge)').props().invisible).toBe(false);
 
     wrapper = createWrapper({ hasAnnotations: false, windowId });
-    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]').dive().dive();
+    tab = wrapper.find('WithStyles(Tab)[aria-label="openAnnotationCompanionWindow"]');
 
     expect(tab.find('WithStyles(Badge)').props().invisible).toBe(true);
+  });
+
+  describe('handleKeyUp', () => {
+    it('the first tab is focussed by default', () => {
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the next tab when pressing the down arrow', () => {
+      wrapper.find('button[role="tab"]').at(0).simulate('keyUp', { key: 'ArrowDown' });
+      assertTabFocused(wrapper, 1);
+    });
+
+    it('the focuses on the previous tab when pressing the up arrow', () => {
+      wrapper.find('button[role="tab"]').at(1).simulate('keyUp', { key: 'ArrowUp' });
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the first tab when pressing the down arrow from the last tab', () => {
+      wrapper.find('button[role="tab"]').last().simulate('keyUp', { key: 'ArrowDown' });
+      assertTabFocused(wrapper, 0);
+    });
+
+    it('the focuses on the last tab when pressing the up arrow from the first tab', () => {
+      wrapper.find('button[role="tab"]').first().simulate('keyUp', { key: 'ArrowUp' });
+      assertTabFocused(wrapper, 2); // Assuming 3 tabs
+    });
   });
 });

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Badge from '@material-ui/core/Badge';
 import Tabs from '@material-ui/core/Tabs';
@@ -47,16 +48,25 @@ export class WindowSideBarButtons extends Component {
    *
    */
   componentDidMount() {
-    this.tabs = Array.from(document.querySelectorAll(`#${this.containerId} button[role=tab]`));
-    this.tabBar = this.tabs[0].parentElement;
+    this.tabBar = ReactDOM.findDOMNode(this.tabsRef); // eslint-disable-line react/no-find-dom-node
+    this.tabs = Array.from(this.tabBar.querySelectorAll('button[role=tab]'));
 
     /*
       the change event isn't fired, when the tabs component is initialized,
       so we have to perform the required actions on our own
     */
-    const selectedTab = this.tabs.find(t => (t.getAttribute('aria-selected')) === 'true');
+    const selectedTab = this.tabs.find(t => (t.getAttribute('aria-selected')) === 'true') || this.tabs[0];
     this.selectTab(selectedTab);
     selectedTab.focus();
+  }
+
+  /**
+   * Set the ref to the parent tabs element
+   */
+  setTabsRef(ref) {
+    if (this.tabsRef) return;
+
+    this.tabsRef = ref;
   }
 
   /**
@@ -109,26 +119,12 @@ export class WindowSideBarButtons extends Component {
   }
 
   /**
-   * focus the first tab
-   */
-  focusFirstTab() {
-    this.tabBar.firstChild.focus();
-  }
-
-  /**
    * focus the previous tab
    * @param {object} tab the currently selected tab
    */
   focusPreviousTab(tab) {
-    const previousTab = tab.previousSibling || this.tabBar.lastChild;
+    const previousTab = tab.previousSibling || this.tabs[this.tabs.length - 1];
     previousTab.focus();
-  }
-
-  /**
-   * focus the last tab
-   */
-  focusLastTab() {
-    this.tabBar.lastChild.focus();
   }
 
   /**
@@ -136,7 +132,7 @@ export class WindowSideBarButtons extends Component {
    * @param {object} tab the currently selected tab
    */
   focusNextTab(tab) {
-    const nextTab = tab.nextSibling || this.tabBar.firstChild;
+    const nextTab = tab.nextSibling || this.tabs[0];
     nextTab.focus();
   }
 
@@ -163,6 +159,7 @@ export class WindowSideBarButtons extends Component {
           indicatorColor="secondary"
           textColor="secondary"
           aria-orientation="vertical"
+          ref={ref => this.setTabsRef(ref)}
         >
           <Tab
             classes={{ root: classes.tab, selected: classes.tabSelected }}


### PR DESCRIPTION
…ReactDOM.findDOMNode instead of document.querySelectorAll (which allows us to test a bit easier)