### PR TITLE
Make the resource add button a medium-sized fab; fixes #2294

### DIFF
--- a/src/components/WorkspaceAddButton.js
+++ b/src/components/WorkspaceAddButton.js
@@ -19,6 +19,7 @@ export class WorkspaceAddButton extends Component {
     return (
       <Tooltip title={isWorkspaceAddVisible ? t('closeAddResourceMenu') : t('addResource')}>
         <Fab
+          size="medium"
           color="secondary"
           id="addBtn"
           aria-label={isWorkspaceAddVisible ? t('closeAddResourceMenu') : t('addResource')}

--- a/src/containers/WorkspaceAddButton.js
+++ b/src/containers/WorkspaceAddButton.js
@@ -31,17 +31,7 @@ const mapDispatchToProps = { setWorkspaceAddVisibility: actions.setWorkspaceAddV
  */
 const styles = theme => ({
   fab: {
-    [theme.breakpoints.up('sm')]: {
-      marginBottom: theme.spacing.unit,
-      marginLeft: theme.spacing.unit / 2,
-      marginRight: theme.spacing.unit / 2,
-      marginTop: theme.spacing.unit,
-    },
-
-    marginBottom: theme.spacing.unit / 2,
-    marginLeft: theme.spacing.unit,
-    marginRight: theme.spacing.unit,
-    marginTop: theme.spacing.unit / 2,
+    margin: theme.spacing.unit,
   },
 });
 


### PR DESCRIPTION
<img width="198" alt="Screen Shot 2019-03-22 at 08 45 29" src="https://user-images.githubusercontent.com/111218/54835158-de427b80-4c7e-11e9-8b15-9d73291c80f5.png">
