### PR TITLE
Have window focused class extend windowTopBarStyle so that the …

### DIFF
--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -34,15 +34,16 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  * windowTopBarStyle: {minHeight: number, paddingLeft: number, backgroundColor: string}}}
  */
 const styles = theme => ({
-  focused: {
-    borderTop: `2px solid ${theme.palette.secondary.main}`,
-  },
+  focused: {},
   title: {
     ...theme.typography.h6,
     flexGrow: 1,
     paddingLeft: theme.spacing.unit / 2,
   },
   windowTopBarStyle: {
+    '&$focused': {
+      borderTop: `2px solid ${theme.palette.secondary.main}`,
+    },
     backgroundColor: theme.palette.primary.light,
     borderTop: '2px solid transparent',
     minHeight: 32,


### PR DESCRIPTION
…borderTop rules don't clash.

Fixes #2305 
<img width="1407" alt="Screen Shot 2019-03-22 at 10 11 19 AM" src="https://user-images.githubusercontent.com/96776/54840753-e1dbff80-4c8a-11e9-828a-af2c634e71f2.png">
