### PR TITLE
Revert "🔪 💧 animation for active button and menu states coming from mui. Fixe…"

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -115,12 +115,7 @@ export default {
         lineHeight: "1.75em",
       },
       useNextVariants: true // set so that console deprecation warning is removed
-    },
-    props: {
-      MuiButtonBase: {
-        disableRipple: true, // No more ripple, on the whole application 💣!
-      },
-    },
+    }
   },
   language: 'en', // The default language set in the application
   availableLanguages: { // All the languages available in the language switcher


### PR DESCRIPTION
Reverts ProjectMirador/mirador#2309

I think we're going to need to revisit this. Unfortunately this PR disabled the focus indicator while tabbing through elements. 

Not sure whether we just need a more refined config on `MuiButtonBase` or if there's something we could change about how we implement icons. In the meantime, I don't want to block other work re: keyboard controls.