### PR TITLE
Add a reselect selector to get companionAreaVisibility.

### DIFF
--- a/__tests__/src/components/CompanionArea.test.js
+++ b/__tests__/src/components/CompanionArea.test.js
@@ -11,6 +11,7 @@ function createWrapper(props) {
       classes={{ horizontal: 'horizontal' }}
       windowId="abc123"
       position="right"
+      companionAreaOpen
       companionWindows={[
         {
           id: 'foo',

--- a/__tests__/src/selectors/windows.test.js
+++ b/__tests__/src/selectors/windows.test.js
@@ -2,6 +2,7 @@ import manifestFixture001 from '../../fixtures/version-2/001.json';
 import manifestFixture002 from '../../fixtures/version-2/002.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import {
+  getCompanionAreaVisibility,
   getWindowTitles,
   getThumbnailNavigationPosition,
   getWindowViewType,
@@ -193,6 +194,51 @@ describe('getViewer', () => {
 
     expect(received).toEqual({
       id: 'bar',
+    });
+  });
+});
+
+describe('getCompanionAreaVisibility', () => {
+  describe('in the left position', () => {
+    it('is true if the companionArea and sideBar are set to be open', () => {
+      const state = {
+        windows: {
+          abc123: { companionAreaOpen: true, sideBarOpen: true },
+        },
+      };
+      const props = { position: 'left', windowId: 'abc123' };
+
+      expect(getCompanionAreaVisibility(state, props)).toBe(true);
+    });
+
+    it('is false if either companionArea or the sideBar are set to be closed', () => {
+      const companionAreaClosedState = {
+        windows: {
+          abc123: { companionAreaOpen: false, sideBarOpen: true },
+        },
+      };
+      const sideBarClosedState = {
+        windows: {
+          abc123: { companionAreaOpen: true, sideBarOpen: false },
+        },
+      };
+      const props = { position: 'left', windowId: 'abc123' };
+
+      expect(getCompanionAreaVisibility(companionAreaClosedState, props)).toBe(false);
+      expect(getCompanionAreaVisibility(sideBarClosedState, props)).toBe(false);
+    });
+  });
+
+  describe('in any non-left position', () => {
+    it('is true', () => {
+      const state = {
+        windows: {
+          abc123: { companionAreaOpen: false, sideBarOpen: false },
+        },
+      };
+      const props = { position: 'right', windowId: 'abc123' };
+
+      expect(getCompanionAreaVisibility(state, props)).toBe(true);
     });
   });
 });

--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -44,7 +44,7 @@ export class CompanionArea extends Component {
             </MiradorMenuButton>
           )
         }
-        <div className={[ns('companion-windows'), this.areaLayoutClass()].join(' ')} style={{ display: companionAreaOpen && (position !== 'left' || sideBarOpen) ? 'flex' : 'none' }}>
+        <div className={[ns('companion-windows'), this.areaLayoutClass()].join(' ')} style={{ display: companionAreaOpen ? 'flex' : 'none' }}>
           {
             companionWindows.map(cw => (
               <CompanionWindowFactory id={cw.id} key={cw.id} windowId={windowId} />
@@ -58,7 +58,7 @@ export class CompanionArea extends Component {
 
 CompanionArea.propTypes = {
   classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  companionAreaOpen: PropTypes.bool,
+  companionAreaOpen: PropTypes.bool.isRequired,
   companionWindows: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   position: PropTypes.string.isRequired,
   setCompanionAreaOpen: PropTypes.func,
@@ -69,7 +69,6 @@ CompanionArea.propTypes = {
 
 CompanionArea.defaultProps = {
   classes: {},
-  companionAreaOpen: true,
   setCompanionAreaOpen: () => {},
   sideBarOpen: false,
 };

--- a/src/containers/CompanionArea.js
+++ b/src/containers/CompanionArea.js
@@ -3,12 +3,13 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
-import { getCompanionWindowsOfWindow, getWindow } from '../state/selectors';
+import { getCompanionWindowsOfWindow, getCompanionAreaVisibility, getWindow } from '../state/selectors';
 import * as actions from '../state/actions';
 import { CompanionArea } from '../components/CompanionArea';
 
 /** */
 const mapStateToProps = (state, { windowId, position }) => ({
+  companionAreaOpen: getCompanionAreaVisibility(state, { position, windowId }),
   companionWindows: getCompanionWindowsOfWindow(state, { windowId })
     .filter(cw => cw.position === position),
   sideBarOpen: getWindow(state, { windowId }).sideBarOpen,

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -47,6 +47,7 @@ export function addWindow(options) {
     const defaultOptions = {
       canvasIndex: 0,
       collectionIndex: 0,
+      companionAreaOpen: true,
       companionWindowIds: [cwDefault, cwThumbs],
       displayAllAnnotations: config.displayAllAnnotations || false,
       height: 400,

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -95,3 +95,20 @@ export const getViewer = createSelector(
   ],
   (viewers, windowId) => viewers[windowId],
 );
+
+/**
+ * Returns the visibility of the companion area
+ * @param {object} state
+ * @param {object} props
+ * @return {Boolean}
+ */
+export const getCompanionAreaVisibility = createSelector(
+  [
+    (state, { position }) => position,
+    getWindow,
+  ],
+  (position, { companionAreaOpen, sideBarOpen }) => {
+    if (position !== 'left') return true;
+    return !!(companionAreaOpen && sideBarOpen);
+  },
+);


### PR DESCRIPTION
Part of #2304 

This doesn't do anything w/ the styling of the tooltip/button, but instead addresses the click behavior bug.