### PR TITLE
Remove touchRipple effect from MUI components

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -115,7 +115,12 @@ export default {
         lineHeight: "1.75em",
       },
       useNextVariants: true // set so that console deprecation warning is removed
-    }
+    },
+    props: {
+      MuiButtonBase: {
+        disableTouchRipple: true,
+      },
+    },
   },
   language: 'en', // The default language set in the application
   availableLanguages: { // All the languages available in the language switcher


### PR DESCRIPTION
Fixes #2306
Related #2309

This PR disable the `disableTouchRipple` that appears when a user clicks on an element and keeps the `focusRipple` that's used while tabbing through the app.
More in the MUI docs here: 
https://material-ui.com/api/button-base/#props

## Before
![with-ripple](https://user-images.githubusercontent.com/5402927/54859964-8df40980-4cd0-11e9-824e-a7ddb04c727d.gif)


## After
![diff-ripple](https://user-images.githubusercontent.com/5402927/54859791-c561b680-4cce-11e9-88be-462c7ebd2148.gif)

