### PR TITLE
Updates theme approach

### DIFF
--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -32,7 +32,6 @@ export class WindowTopBar extends Component {
         <Toolbar disableGutters className={classNames(classes.windowTopBarStyle, focused ? classes.focused : null, ns('window-top-bar'))} variant="dense">
           <MiradorMenuButton
             aria-label={t('toggleWindowSideBar')}
-            color="inherit"
             onClick={toggleWindowSideBar}
           >
             <MenuIcon />
@@ -46,7 +45,6 @@ export class WindowTopBar extends Component {
             <MiradorMenuButton
               aria-label={(maximized ? t('minimizeWindow') : t('maximizeWindow'))}
               className={ns('window-maximize')}
-              color="inherit"
               onClick={(maximized ? minimizeWindow : maximizeWindow)}
             >
               {(maximized ? <FullscreenExitIcon /> : <FullscreenIcon />)}
@@ -56,7 +54,6 @@ export class WindowTopBar extends Component {
             <MiradorMenuButton
               aria-label={t('closeWindow')}
               className={ns('window-close')}
-              color="inherit"
               onClick={removeWindow}
             >
               <CloseIcon />

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -52,7 +52,6 @@ export class WindowTopMenuButton extends Component {
           aria-label={t('windowMenu')}
           aria-owns={anchorEl ? `window-menu_${windowId}` : undefined}
           className={anchorEl ? classes.ctrlBtnSelected : null}
-          color="inherit"
           onClick={this.handleMenuClick}
         >
           <MoreVertIcon />

--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -96,7 +96,6 @@ export class WorkspaceAdd extends React.Component {
                 <MiradorMenuButton
                   aria-label={t('closeAddResourceMenu')}
                   className={classes.menuButton}
-                  color="inherit"
                 >
                   <ExpandMoreIcon />
                 </MiradorMenuButton>

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -8,13 +8,17 @@ export default {
       type: 'light', // dark also available
       primary: {
         main: '#f5f5f5',
-        light: '#ffffff',
-        dark: '#eeeeee',
       },
       secondary: {
         main: '#1967d2',
-        light: '#64b5f6',
-        dark: '#0d47a1',
+      },
+      darkened: { // custom colors used for a specific offset in some places
+        dark: '#000000',
+        light: '#eeeeee'
+      },
+      lightened: { // custom colors used for a specific offset in some places
+        dark: '#424242',
+        light: '#ffffff',
       },
       error: {
         main: '#b00020',

--- a/src/containers/CompanionArea.js
+++ b/src/containers/CompanionArea.js
@@ -35,7 +35,7 @@ const styles = theme => ({
       backgroundColor: theme.palette.background.paper,
     },
     backgroundColor: theme.palette.background.paper,
-    border: `1px solid ${theme.palette.primary.dark}`,
+    border: `1px solid ${theme.palette.darkened[theme.palette.type]}`,
     borderRadius: 0,
     height: '48px',
     left: '100%',

--- a/src/containers/Window.js
+++ b/src/containers/Window.js
@@ -68,7 +68,7 @@ const styles = theme => ({
     position: 'relative',
   },
   thumbnailArea: {
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.darkened[theme.palette.type],
   },
   thumbnailAreaBottom: {
   },
@@ -76,7 +76,7 @@ const styles = theme => ({
     minWidth: 100,
   },
   window: {
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.darkened[theme.palette.type],
     display: 'flex',
     flexDirection: 'column',
     height: '100%',

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -44,7 +44,7 @@ const styles = theme => ({
     '&$focused': {
       borderTop: `2px solid ${theme.palette.secondary.main}`,
     },
-    backgroundColor: theme.palette.primary.light,
+    backgroundColor: theme.palette.lightened[theme.palette.type],
     borderTop: '2px solid transparent',
     minHeight: 32,
     paddingLeft: theme.spacing.unit / 2,


### PR DESCRIPTION
Inspired by embedding M3 in sul-embed, this PR builds off of discussion in #1906 and work completed in #1979 .

Based off [Material-UI documentation](https://material-ui.com/customization/themes/#type-light-dark-theme) my understanding is that setting `light` and `dark` primary values is used for setting the color when in a specific theme. This pull request resolves this by setting a new `lighten` and `darken` keys. While maybe not the final way we could do this, it is a refactor without modifying the colors currently being used.

Future alternatives could be to use the `lighten` and `darken` methods from Material-UI to do these calculations on the fly.

@ggeisler happy to chat more about this approach

## Light
### Before
<img width="1153" alt="Screen Shot 2019-03-29 at 10 06 08 AM" src="https://user-images.githubusercontent.com/1656824/55249910-66d69400-520a-11e9-960f-5621a9bfff56.png">

### After
<img width="1155" alt="Screen Shot 2019-03-29 at 10 06 18 AM" src="https://user-images.githubusercontent.com/1656824/55249909-66d69400-520a-11e9-8b0c-3c5fcc95eb7e.png">

## Dark
### Before
<img width="1154" alt="Screen Shot 2019-03-29 at 10 06 36 AM" src="https://user-images.githubusercontent.com/1656824/55249908-66d69400-520a-11e9-91b6-f697e834fe53.png">

### After
<img width="1151" alt="Screen Shot 2019-03-29 at 10 06 49 AM" src="https://user-images.githubusercontent.com/1656824/55249907-66d69400-520a-11e9-8a7d-55b3cd71bbc1.png">
