### PR TITLE
Update gallery view styling/layout

### DIFF
--- a/__tests__/src/components/GalleryView.test.js
+++ b/__tests__/src/components/GalleryView.test.js
@@ -9,7 +9,7 @@ function createWrapper(props) {
   return shallow(
     <GalleryView
       canvases={manifesto.create(manifestJson).getSequences()[0].getCanvases()}
-      classes={{ currentCanvas: 'currentCanvas' }}
+      classes={{ galleryViewItemCurrent: 'galleryViewItemCurrent' }}
       window={{
         canvasIndex: 0,
         id: '1234',
@@ -34,7 +34,7 @@ describe('GalleryView', () => {
     expect(wrapper.find('div[role="button"]').length).toBe(3);
   });
   it('sets a mirador-current-canvas class on current canvas', () => {
-    expect(wrapper.find('div[role="button"]').at(0).props().className).toEqual('currentCanvas');
+    expect(wrapper.find('div[role="button"]').at(0).props().className).toEqual('galleryViewItemCurrent');
   });
   it('renders the canvas labels for each canvas in canvas items', () => {
     expect(wrapper.find('WithStyles(Typography)').length).toBe(3);

--- a/src/components/GalleryView.js
+++ b/src/components/GalleryView.js
@@ -47,7 +47,7 @@ export class GalleryView extends Component {
                     aspectRatio={manifestoCanvas.aspectRatio}
                     style={{ margin: '0 auto' }}
                   />
-                  <Typography variant="caption">
+                  <Typography variant="caption" className={classes.galleryViewCaption}>
                     {manifestoCanvas.getLabel()}
                   </Typography>
                 </div>

--- a/src/components/GalleryView.js
+++ b/src/components/GalleryView.js
@@ -32,7 +32,7 @@ export class GalleryView extends Component {
                   className={
                     classNames(
                       classes.galleryViewItem,
-                      canvas.index === window.canvasIndex ? classes.currentCanvas : '',
+                      canvas.index === window.canvasIndex ? classes.galleryViewItemCurrent : '',
                     )
                   }
                   onClick={() => setCanvas(window.id, canvas.index)}
@@ -44,7 +44,6 @@ export class GalleryView extends Component {
                     imageUrl={manifestoCanvas.thumbnail(null, 100)}
                     isValid={manifestoCanvas.hasValidDimensions}
                     maxHeight={120}
-                    maxWidth={100}
                     aspectRatio={manifestoCanvas.aspectRatio}
                     style={{ margin: '0 auto' }}
                   />

--- a/src/containers/GalleryView.js
+++ b/src/containers/GalleryView.js
@@ -21,15 +21,14 @@ const mapStateToProps = (state, { window }) => (
  * Styles to be passed to the withStyles HOC
  */
 const styles = theme => ({
-  currentCanvas: {
-    border: `2px solid ${theme.palette.secondary.main}`,
-    padding: theme.spacing.unit / 2,
-  },
   galleryContainer: {
-    flex: '1',
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     overflowX: 'hidden',
     overflowY: 'scroll',
     padding: '50px 0 50px 20px',
+    width: '100%',
   },
   galleryViewItem: {
     '&:focus': {
@@ -37,20 +36,19 @@ const styles = theme => ({
     },
     '&:hover': {
       border: `2px solid ${theme.palette.secondary.main}`,
-      padding: theme.spacing.unit / 2,
-      transform: 'scale(1.05)',
-      transition: '.1s transform ease-out',
     },
-    boxSizing: 'border-box',
+    border: '2px solid transparent',
     cursor: 'pointer',
     display: 'inline-block',
-    height: '160px',
+    height: '165px',
     margin: `${theme.spacing.unit}px ${theme.spacing.unit / 2}px`,
-    maxWidth: '100px',
+    minWidth: '60px',
     overflow: 'hidden',
     padding: theme.spacing.unit / 2,
-    textOverflow: 'elipsis',
-    transition: '.1s transform ease-out',
+    width: 'min-content',
+  },
+  galleryViewItemCurrent: {
+    border: `2px solid ${theme.palette.secondary.main}`,
   },
 });
 

--- a/src/containers/GalleryView.js
+++ b/src/containers/GalleryView.js
@@ -30,6 +30,16 @@ const styles = theme => ({
     padding: '50px 0 50px 20px',
     width: '100%',
   },
+  galleryViewCaption: {
+    boxOrient: 'vertical',
+    display: '-webkit-box',
+    height: '3em',
+    lineClamp: '2',
+    lineHeight: '1.5em',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    wordBreak: 'break-word',
+  },
   galleryViewItem: {
     '&:focus': {
       outline: 'none',


### PR DESCRIPTION
Closes #2312 

## Chrome (before)
<img width="1463" alt="chrome-before" src="https://user-images.githubusercontent.com/96776/55366046-e3cc6c80-549b-11e9-97b2-f9ad9adf11bb.png">

## Chrome (after)
<img width="1464" alt="chrome-after" src="https://user-images.githubusercontent.com/96776/55366044-e3cc6c80-549b-11e9-9276-ac6ab26c1a50.png">

---

## Firefox (before)
<img width="1411" alt="ff-before" src="https://user-images.githubusercontent.com/96776/55366047-e3cc6c80-549b-11e9-942d-d298b5d189f0.png">

## Firefox (after)
_**Note:** Firefox does not support `display: box` yet, so the text is truncated w/o an ellipsis_
<img width="1414" alt="ff-after" src="https://user-images.githubusercontent.com/96776/55366048-e4650300-549b-11e9-8731-5cd7745516a3.png">

---

## Safari (before)
<img width="1323" alt="safari-before" src="https://user-images.githubusercontent.com/96776/55366049-e4650300-549b-11e9-85b8-4c8858da6b53.png">

## Safari (after)
<img width="1321" alt="safari-after" src="https://user-images.githubusercontent.com/96776/55366050-e4650300-549b-11e9-856c-df8e129ca343.png">
