### PR TITLE
Handle annotation resources that are a single object…

### DIFF
--- a/__tests__/src/lib/Annotation.test.js
+++ b/__tests__/src/lib/Annotation.test.js
@@ -22,5 +22,11 @@ describe('Annotation', () => {
         { resources: [{ foo: 'bar' }] },
       ).resources.forEach(resource => expect(resource).toBeInstanceOf(AnnotationResource));
     });
+
+    it('handles resources that are just a single object instead of an array of objects', () => {
+      new Annotation(
+        { resources: { foo: 'bar' } },
+      ).resources.forEach(resource => expect(resource).toBeInstanceOf(AnnotationResource));
+    });
   });
 });

--- a/src/lib/Annotation.js
+++ b/src/lib/Annotation.js
@@ -1,3 +1,4 @@
+import flatten from 'lodash/flatten';
 import AnnotationResource from './AnnotationResource';
 /** */
 export default class Annotation {
@@ -21,6 +22,7 @@ export default class Annotation {
   /** */
   get resources() {
     if (!this.json || !this.json.resources) return [];
-    return this.json.resources.map(resource => new AnnotationResource(resource));
+
+    return flatten([this.json.resources]).map(resource => new AnnotationResource(resource));
   }
 }


### PR DESCRIPTION
…(in addition to an array of objects)

Fixes #2329 

Example Manifest: https://gist.githubusercontent.com/jeffreycwitt/1a75fdb4a97e1c2a98bd35797aad263d/raw/859104cb6cd7bd99f3be668f064066f4b3ba2b29/manifest-with-three-level-deep-toc.json

Click on the canvas labeled `216r` (which currently crashes mirador in master)