### PR TITLE
Removes react-virtualized in favor of react-window

### DIFF
--- a/__tests__/integration/mirador/thumbnail-navigation.test.js
+++ b/__tests__/integration/mirador/thumbnail-navigation.test.js
@@ -13,7 +13,7 @@ describe('Thumbnail navigation', () => {
     expect(Object.values(windows)[0].canvasIndex).toBe(2); // test harness in index.html starts at 2
     await page.waitFor(1000);
     await expect(page).toClick('.mirador-thumbnail-nav-canvas-1 img');
-    await expect(page).toMatchElement('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas', { timeout: 1500 });
+    await expect(page).toMatchElement('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas-grouping', { timeout: 1500 });
     windows = await page.evaluate(() => (
       miradorInstance.store.getState().windows
     ));

--- a/__tests__/src/components/CaptionedCanvasThumbnail.test.js
+++ b/__tests__/src/components/CaptionedCanvasThumbnail.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import manifesto from 'manifesto.js';
+import { CaptionedCanvasThumbnail } from '../../../src/components/CaptionedCanvasThumbnail';
+import manifestJson from '../../fixtures/version-2/019.json';
+
+/** create wrapper */
+function createWrapper(props) {
+  return shallow(
+    <CaptionedCanvasThumbnail
+      canvas={manifesto.create(manifestJson).getSequences()[0].getCanvases()[0]}
+      classes={{}}
+      height={100}
+      {...props}
+    />,
+  );
+}
+
+describe('CaptionedCanvasThumbnail', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+  it('renders', () => {
+    expect(wrapper.find('CanvasThumbnail').length).toEqual(1);
+  });
+  it('sets a maxWidth style for the CanvasThumbnail', () => {
+    expect(wrapper.find('CanvasThumbnail').first().props().style.maxWidth).toEqual('67px');
+  });
+  it('adds a caption', () => {
+    expect(wrapper.find('WithStyles(Typography)').props().children).toEqual('Test 19 Canvas: 1');
+  });
+});

--- a/__tests__/src/components/GalleryView.test.js
+++ b/__tests__/src/components/GalleryView.test.js
@@ -33,7 +33,7 @@ describe('GalleryView', () => {
   it('renders gallery items for all canvases', () => {
     expect(wrapper.find('div[role="button"]').length).toBe(3);
   });
-  it('sets a mirador-current-canvas class on current canvas', () => {
+  it('sets a mirador-current-canvas-grouping class on current canvas', () => {
     expect(wrapper.find('div[role="button"]').at(0).props().className).toEqual('galleryViewItemCurrent');
   });
   it('renders the canvas labels for each canvas in canvas items', () => {

--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import manifesto from 'manifesto.js';
+import { ThumbnailCanvasGrouping } from '../../../src/components/ThumbnailCanvasGrouping';
+import CanvasGroupings from '../../../src/lib/CanvasGroupings';
+import manifestJson from '../../fixtures/version-2/019.json';
+
+/** create wrapper */
+function createWrapper(props) {
+  return shallow(
+    <ThumbnailCanvasGrouping
+      index={1}
+      classes={{}}
+      style={{
+        height: 90,
+        width: 100,
+      }}
+      window={{
+        canvasIndex: 1,
+        id: 'foobar',
+      }}
+      {...props}
+    />,
+  );
+}
+
+describe('ThumbnailCanvasGrouping', () => {
+  let wrapper;
+  let rightWrapper;
+  let setCanvas;
+  const data = {
+    canvasGroupings: new CanvasGroupings(manifesto.create(manifestJson)
+      .getSequences()[0].getCanvases()),
+    height: 131,
+    position: 'far-bottom',
+  };
+  beforeEach(() => {
+    setCanvas = jest.fn();
+    wrapper = createWrapper({ data, setCanvas });
+  });
+  it('renders', () => {
+    expect(wrapper.find('.mirador-thumbnail-nav-container').length).toEqual(1);
+  });
+  it('sets a mirador-current-canvas class on current canvas', () => {
+    expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas'));
+  });
+  it('renders a CaptionedCanvasThumbnail', () => {
+    expect(wrapper.find('WithStyles(WithPlugins(CaptionedCanvasThumbnail))').length).toEqual(1);
+  });
+  it('when clicked, updates the current canvas', () => {
+    wrapper = createWrapper({ data, index: 0, setCanvas });
+    wrapper.find('.mirador-thumbnail-nav-canvas-0').simulate('click', { currentTarget: { dataset: { canvasIndex: '0' } } });
+    expect(setCanvas).toHaveBeenCalledWith('foobar', 0);
+  });
+  describe('attributes based off far-bottom position', () => {
+    it('in button div', () => {
+      expect(wrapper.find('.mirador-thumbnail-nav-canvas').first().props().style).toEqual(
+        expect.objectContaining({
+          height: '123px',
+          width: 'auto',
+        }),
+      );
+    });
+  });
+  describe('attributes based off far-right position', () => {
+    beforeEach(() => {
+      rightWrapper = createWrapper({
+        data: {
+          ...data,
+          position: 'far-right',
+        },
+        setCanvas,
+      });
+    });
+    it('in button div', () => {
+      expect(rightWrapper.find('.mirador-thumbnail-nav-canvas').first().props().style).toEqual(
+        expect.objectContaining({
+          height: 'auto',
+          width: '100px',
+        }),
+      );
+    });
+  });
+});

--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -42,7 +42,7 @@ describe('ThumbnailCanvasGrouping', () => {
     expect(wrapper.find('.mirador-thumbnail-nav-container').length).toEqual(1);
   });
   it('sets a mirador-current-canvas-grouping class on current canvas', () => {
-    expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas-grouping'));
+    expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas-grouping').length).toEqual(1);
   });
   it('renders a CaptionedCanvasThumbnail', () => {
     expect(wrapper.find('WithStyles(WithPlugins(CaptionedCanvasThumbnail))').length).toEqual(1);

--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -41,8 +41,8 @@ describe('ThumbnailCanvasGrouping', () => {
   it('renders', () => {
     expect(wrapper.find('.mirador-thumbnail-nav-container').length).toEqual(1);
   });
-  it('sets a mirador-current-canvas class on current canvas', () => {
-    expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas'));
+  it('sets a mirador-current-canvas-grouping class on current canvas', () => {
+    expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas-grouping'));
   });
   it('renders a CaptionedCanvasThumbnail', () => {
     expect(wrapper.find('WithStyles(WithPlugins(CaptionedCanvasThumbnail))').length).toEqual(1);

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Grid from 'react-virtualized/dist/commonjs/Grid';
 import manifesto from 'manifesto.js';
 import { ThumbnailNavigation } from '../../../src/components/ThumbnailNavigation';
 import CanvasGroupings from '../../../src/lib/CanvasGroupings';
@@ -30,77 +29,45 @@ describe('ThumbnailNavigation', () => {
   let wrapper;
   let rightWrapper;
   let setCanvas;
-  let renderedGrid;
-  let grid;
   beforeEach(() => {
     setCanvas = jest.fn();
-    // Mock Grid's call to _scrollingContainer, which is handled by refs not
-    // available in `shallow`
-    Grid.prototype._scrollingContainer = jest.fn( // eslint-disable-line no-underscore-dangle
-      () => ({ scrollLeft: 0 }),
-    );
     wrapper = createWrapper({ setCanvas });
-    grid = wrapper.find('AutoSizer')
-      .dive()
-      .find('Grid');
-    renderedGrid = grid.dive();
   });
   it('renders the component', () => {
     expect(wrapper.find('.mirador-thumb-navigation').length).toBe(1);
   });
   it('renders containers based off of number of canvases', () => {
-    expect(renderedGrid.find('.mirador-thumbnail-nav-canvas').length).toBe(3);
-  });
-  it('sets a mirador-current-canvas class on current canvas', () => {
-    expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas'));
-  });
-  it('renders the canvas labels for each canvas in a GridListTileBar', () => {
-    expect(renderedGrid.find('WithStyles(GridListTileBar)').length).toBe(3);
-    const firstTitle = renderedGrid.find('WithStyles(GridListTileBar)').first().props().title;
-    expect(firstTitle.props.children).toEqual('Test 19 Canvas: 1');
-  });
-  it('when clicked, updates the current canvas', () => {
-    renderedGrid.find('.mirador-thumbnail-nav-canvas-0 WithStyles(GridListTile)').simulate('click');
-    expect(setCanvas).toHaveBeenCalledWith('foobar', 0);
-  });
-  it('sets up calculated width based off of height of area and dimensions of canvas', () => {
-    expect(renderedGrid.find('.mirador-thumbnail-nav-container').first().prop('style').width).toEqual(95);
-  });
-  it('renders canvas thumbnails', () => {
-    expect(renderedGrid.find('CanvasThumbnail').length).toBe(3);
-  });
-  it('Grid is set with expected props for scrolling alignment', () => {
-    expect(grid.props().scrollToAlignment).toBe('center');
-    expect(grid.props().scrollToColumn).toBe(1);
+    expect(wrapper
+      .find('AutoSizer').dive().find('List').dive()
+      .find('WithStyles(Connect(WithPlugins(ThumbnailCanvasGrouping)))').length).toEqual(3);
   });
   it('has a ref set used to reset on view change', () => {
     expect(wrapper.instance().gridRef).not.toBe(null);
   });
-  it('renders containers based off of canvas groupings ', () => {
-    wrapper = createWrapper({
-      canvasGroupings: new CanvasGroupings(manifesto.create(manifestJson).getSequences()[0].getCanvases(), 'book'),
-      setCanvas,
-    });
-    grid = wrapper.find('AutoSizer')
-      .dive()
-      .find('Grid');
-    renderedGrid = grid.dive();
-    expect(renderedGrid.find('.mirador-thumbnail-nav-canvas').length).toBe(2);
-    expect(renderedGrid.find('CanvasThumbnail').length).toBe(3);
-    expect(wrapper.instance().scrollToColumn()).toBe(1);
-  });
-  it('triggers a recomputeGridSize on view change', () => {
-    const mockRecompute = jest.fn();
-    wrapper.instance().gridRef = { current: { recomputeGridSize: mockRecompute } };
+  it('triggers a resetAfterIndex on view change', () => {
+    const mockReset = jest.fn();
+    wrapper.instance().gridRef = { current: { resetAfterIndex: mockReset } };
     wrapper.setProps({
       window: {
         canvasIndex: 1,
         id: 'foobar',
-        thumbnailNavigationPosition: 'bottom',
+        thumbnailNavigationPosition: 'far-bottom',
         view: 'book',
       },
     });
-    expect(mockRecompute).toHaveBeenCalled();
+    expect(mockReset).toHaveBeenCalled();
+  });
+  it('triggers a scrollToItem on canvasIndex change', () => {
+    const mockScroll = jest.fn();
+    wrapper.instance().gridRef = { current: { scrollToItem: mockScroll } };
+    wrapper.setProps({
+      window: {
+        canvasIndex: 3,
+        id: 'foobar',
+        thumbnailNavigationPosition: 'far-bottom',
+      },
+    });
+    expect(mockScroll).toHaveBeenCalled();
   });
   describe('calculating instance methods', () => {
     beforeEach(() => {
@@ -111,42 +78,63 @@ describe('ThumbnailNavigation', () => {
     });
     it('style', () => {
       expect(wrapper.instance().style()).toMatchObject({ height: '150px', width: '100%' });
-      expect(rightWrapper.instance().style()).toMatchObject({ height: '100%', width: '131px' });
+      expect(rightWrapper.instance().style()).toMatchObject({ height: '100%', minHeight: 0, width: '123px' });
     });
     it('rightWidth', () => {
       expect(wrapper.instance().rightWidth()).toEqual(100);
-      const mockRecompute = jest.fn();
-      wrapper.instance().gridRef = { current: { recomputeGridSize: mockRecompute } };
+      const mockReset = jest.fn();
+      wrapper.instance().gridRef = { current: { resetAfterIndex: mockReset } };
       wrapper.setProps({
         window: {
           canvasIndex: 1,
           id: 'foobar',
-          thumbnailNavigationPosition: 'bottom',
+          thumbnailNavigationPosition: 'far-bottom',
           view: 'book',
         },
       });
       expect(wrapper.instance().rightWidth()).toEqual(200);
     });
-    it('calculateScaledWidth', () => {
-      expect(wrapper.instance().calculateScaledWidth({ index: 0 })).toEqual(95);
-      expect(rightWrapper.instance().calculateScaledWidth({ index: 0 })).toEqual(116);
+    it('item count is based off of number of canvases', () => {
+      expect(wrapper.instance().itemCount()).toEqual(3);
     });
-    it('calculateScaledHeight', () => {
-      expect(wrapper.instance().calculateScaledHeight({ index: 0 })).toEqual(135);
-      expect(rightWrapper.instance().calculateScaledHeight({ index: 0 })).toEqual(166);
+    it('calculateScaledSize', () => {
+      expect(wrapper.instance().calculateScaledSize(0)).toEqual(82);
+      expect(rightWrapper.instance().calculateScaledSize(0)).toEqual(158);
     });
-
-    it('columnCount', () => {
-      expect(wrapper.instance().columnCount()).toEqual(3);
-      expect(rightWrapper.instance().columnCount()).toEqual(1);
-    });
-    it('rowCount', () => {
-      expect(wrapper.instance().rowCount()).toEqual(1);
-      expect(rightWrapper.instance().rowCount()).toEqual(3);
+    it('calculatingWidth', () => {
+      expect(wrapper.instance().calculatingWidth(1)).toEqual(100);
+      expect(wrapper.instance().calculatingWidth(2)).toEqual(200);
     });
     it('areaHeight', () => {
       expect(wrapper.instance().areaHeight()).toEqual(150);
       expect(rightWrapper.instance().areaHeight(99)).toEqual(99);
+    });
+  });
+  describe('keyboard navigation', () => {
+    const rightSetCanvas = jest.fn();
+    beforeEach(() => {
+      rightWrapper = createWrapper({
+        position: 'far-right',
+        setCanvas: rightSetCanvas,
+        window: {
+          canvasIndex: 1,
+          id: 'foobat',
+        },
+      });
+    });
+    describe('handleKeyUp', () => {
+      it('next', () => {
+        wrapper.instance().handleKeyUp({ key: 'ArrowRight' });
+        expect(setCanvas).toHaveBeenCalledWith('foobar', 2);
+        rightWrapper.instance().handleKeyUp({ key: 'ArrowDown' });
+        expect(rightSetCanvas).toHaveBeenCalledWith('foobat', 2);
+      });
+      it('previous', () => {
+        wrapper.instance().handleKeyUp({ key: 'ArrowLeft' });
+        expect(setCanvas).toHaveBeenCalledWith('foobar', 0);
+        rightWrapper.instance().handleKeyUp({ key: 'ArrowUp' });
+        expect(rightSetCanvas).toHaveBeenCalledWith('foobat', 0);
+      });
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react-redux": "^6.0.0",
     "react-resize-observer": "^1.1.1",
     "react-rnd": "^9.1.1",
-    "react-virtualized": "^9.21.0",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.7.1",
     "redux": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "react-resize-observer": "^1.1.1",
     "react-rnd": "^9.1.1",
     "react-virtualized": "^9.21.0",
+    "react-virtualized-auto-sizer": "^1.0.2",
+    "react-window": "^1.7.1",
     "redux": "4.0.1",
     "redux-debounced": "^0.5.0",
     "redux-devtools-extension": "^2.13.2",

--- a/src/components/CaptionedCanvasThumbnail.js
+++ b/src/components/CaptionedCanvasThumbnail.js
@@ -28,7 +28,8 @@ export class CaptionedCanvasThumbnail extends Component {
           isValid={manifestoCanvas.hasValidDimensions}
           maxHeight={height}
           style={{
-            maxWidth: `${(height * manifestoCanvas.aspectRatio)}px`,
+            maxWidth: `${Math.ceil(height * manifestoCanvas.aspectRatio)}px`,
+            verticalAlign: 'bottom',
           }}
         />
         <div
@@ -45,12 +46,6 @@ export class CaptionedCanvasThumbnail extends Component {
             <Typography
               classes={{ root: classes.title }}
               variant="caption"
-              style={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                width: '100%',
-              }}
             >
               {manifestoCanvas.getLabel()}
             </Typography>

--- a/src/components/CaptionedCanvasThumbnail.js
+++ b/src/components/CaptionedCanvasThumbnail.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import classNames from 'classnames';
+import ManifestoCanvas from '../lib/ManifestoCanvas';
+import { CanvasThumbnail } from './CanvasThumbnail';
+import ns from '../config/css-ns';
+
+/** */
+export class CaptionedCanvasThumbnail extends Component {
+  /** */
+  render() {
+    const { canvas, classes, height } = this.props;
+    const manifestoCanvas = new ManifestoCanvas(canvas);
+    console.log(height);
+    return (
+      <div
+        key={canvas.id}
+        style={{
+          display: 'inline-block',
+          height: 'inherit',
+          position: 'relative',
+        }}
+      >
+        <CanvasThumbnail
+          imageUrl={
+            manifestoCanvas.thumbnail(null, 200)
+          }
+          isValid={manifestoCanvas.hasValidDimensions}
+          maxHeight={height}
+          style={{
+            maxWidth: `${(height * manifestoCanvas.aspectRatio)}px`,
+          }}
+        />
+        <div
+          className={classNames(ns('canvas-thumb-label'), classes.canvasThumbLabel)}
+          style={{
+            width: '100%',
+            // width: `${Math.floor(height * manifestoCanvas.aspectRatio) - 8}px`,
+          }}
+        >
+          <div
+            style={{
+              margin: '4px',
+              padding: '4px',
+            }}
+          >
+            <Typography
+              classes={{ root: classes.title }}
+              variant="caption"
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                width: '100%',
+              }}
+            >
+              {manifestoCanvas.getLabel()}
+            </Typography>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+CaptionedCanvasThumbnail.propTypes = {
+  canvas: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  height: PropTypes.number.isRequired,
+};

--- a/src/components/CaptionedCanvasThumbnail.js
+++ b/src/components/CaptionedCanvasThumbnail.js
@@ -15,28 +15,21 @@ export class CaptionedCanvasThumbnail extends Component {
     return (
       <div
         key={canvas.id}
-        style={{
-          display: 'inline-block',
-          height: 'inherit',
-          position: 'relative',
-        }}
+        className={classes.container}
       >
         <CanvasThumbnail
           imageUrl={
             manifestoCanvas.thumbnail(null, 200)
+            // TODO: When we make these areas resizable, we should probably not hard code this
           }
           isValid={manifestoCanvas.hasValidDimensions}
           maxHeight={height}
           style={{
             maxWidth: `${Math.ceil(height * manifestoCanvas.aspectRatio)}px`,
-            verticalAlign: 'bottom',
           }}
         />
         <div
           className={classNames(ns('canvas-thumb-label'), classes.canvasThumbLabel)}
-          style={{
-            width: '100%',
-          }}
         >
           <div
             style={{

--- a/src/components/CaptionedCanvasThumbnail.js
+++ b/src/components/CaptionedCanvasThumbnail.js
@@ -12,7 +12,6 @@ export class CaptionedCanvasThumbnail extends Component {
   render() {
     const { canvas, classes, height } = this.props;
     const manifestoCanvas = new ManifestoCanvas(canvas);
-    console.log(height);
     return (
       <div
         key={canvas.id}
@@ -36,13 +35,11 @@ export class CaptionedCanvasThumbnail extends Component {
           className={classNames(ns('canvas-thumb-label'), classes.canvasThumbLabel)}
           style={{
             width: '100%',
-            // width: `${Math.floor(height * manifestoCanvas.aspectRatio) - 8}px`,
           }}
         >
           <div
             style={{
               margin: '4px',
-              padding: '4px',
             }}
           >
             <Typography

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -24,8 +24,8 @@ export class ThumbnailCanvasGrouping extends PureComponent {
    * a useful class.
    */
   currentCanvasClass(canvasIndices) {
-    const { window } = this.props;
-    if (canvasIndices.includes(window.canvasIndex)) return 'current-canvas';
+    const { index } = this.props;
+    if (canvasIndices.includes(index)) return 'current-canvas';
     return '';
   }
 
@@ -37,8 +37,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
     const {
       canvasGroupings, position, height,
     } = data;
-    const currentIndex = index;
-    const currentGroupings = canvasGroupings.groupings()[currentIndex];
+    const currentGroupings = canvasGroupings.groupings()[index];
     const SPACING = 8;
     return (
       <div
@@ -60,12 +59,12 @@ export class ThumbnailCanvasGrouping extends PureComponent {
           tabIndex={-1}
           style={{
             display: 'inline-block',
-            height: (position === 'far-right') ? '100%' : `${height - SPACING}px`,
+            height: (position === 'far-right') ? 'auto' : `${height - SPACING}px`,
             whiteSpace: 'nowrap',
             width: (position === 'far-bottom') ? 'auto' : `${style.width}px`,
           }}
           className={classNames(
-            ns(['thumbnail-nav-canvas', `thumbnail-nav-canvas-${currentIndex}`, this.currentCanvasClass(currentGroupings.map(canvas => canvas.index))]),
+            ns(['thumbnail-nav-canvas', `thumbnail-nav-canvas-${index}`, this.currentCanvasClass(currentGroupings.map(canvas => canvas.index))]),
             classes.canvas,
             {
               [classes.currentCanvas]: currentGroupings
@@ -77,7 +76,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
             <CaptionedCanvasThumbnail
               key={canvas.id}
               canvas={canvas}
-              height={(position === 'far-right') ? style.height - SPACING : height - (1.5 * SPACING)}
+              height={(position === 'far-right') ? style.height - (1.5 * SPACING) : height - (1.5 * SPACING)}
             />
           ))}
         </div>

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -1,12 +1,24 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { CaptionedCanvasThumbnail } from './CaptionedCanvasThumbnail';
+import CaptionedCanvasThumbnail from '../containers/CaptionedCanvasThumbnail';
 import ns from '../config/css-ns';
 
 
 /** */
 export class ThumbnailCanvasGrouping extends PureComponent {
+  /** */
+  constructor(props) {
+    super(props);
+    this.setCanvas = this.setCanvas.bind(this);
+  }
+
+  /** */
+  setCanvas(e) {
+    const { setCanvas } = this.props;
+    setCanvas(e.currentTarget.dataset.windowid, parseInt(e.currentTarget.dataset.canvasIndex, 10));
+  }
+
   /**
    * Determines whether the current index is the rendered canvas, providing
    * a useful class.
@@ -21,7 +33,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
   /** */
   render() {
     const {
-      index, style, data, classes, setCanvas,
+      index, style, data, classes,
     } = this.props;
     const {
       canvasGroupings, window, position, height,
@@ -43,12 +55,14 @@ export class ThumbnailCanvasGrouping extends PureComponent {
       >
         <div
           role="button"
-          onKeyUp={() => setCanvas(window.id, currentGroupings[0].index)}
-          onClick={() => setCanvas(window.id, currentGroupings[0].index)}
+          data-windowid={window.id}
+          data-canvas-index={currentGroupings[0].index}
+          onKeyUp={this.setCanvas}
+          onClick={this.setCanvas}
           tabIndex={-1}
           style={{
             display: 'inline-block',
-            height: (position === 'far-right') ? 'auto' : `${height - SPACING}px`,
+            height: (position === 'far-right') ? '100%' : `${height - SPACING}px`,
             whiteSpace: 'nowrap',
             width: (position === 'far-bottom') ? 'auto' : `${style.width}px`,
           }}
@@ -65,7 +79,6 @@ export class ThumbnailCanvasGrouping extends PureComponent {
             <CaptionedCanvasThumbnail
               key={canvas.id}
               canvas={canvas}
-              classes={classes}
               height={(position === 'far-right') ? style.height - SPACING : height - (1.5 * SPACING)}
             />
           ))}

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -1,0 +1,84 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { CaptionedCanvasThumbnail } from './CaptionedCanvasThumbnail';
+import ns from '../config/css-ns';
+
+
+/** */
+export class ThumbnailCanvasGrouping extends PureComponent {
+  /**
+   * Determines whether the current index is the rendered canvas, providing
+   * a useful class.
+   */
+  currentCanvasClass(canvasIndices) {
+    const { data } = this.props;
+    const { window } = data;
+    if (canvasIndices.includes(window.canvasIndex)) return 'current-canvas';
+    return '';
+  }
+
+  /** */
+  render() {
+    const {
+      index, style, data, classes, setCanvas,
+    } = this.props;
+    const {
+      canvasGroupings, window, position, height,
+    } = data;
+    const currentIndex = index;
+    const currentGroupings = canvasGroupings.groupings()[currentIndex];
+    const SPACING = 8;
+    return (
+      <div
+        style={{
+          ...style,
+          boxSizing: 'content-box',
+          height: (Number.isInteger(style.height)) ? style.height - SPACING : null,
+          left: style.left + SPACING,
+          top: style.top + SPACING,
+          width: (Number.isInteger(style.width)) ? style.width - SPACING : null,
+        }}
+        className={ns('thumbnail-nav-container')}
+      >
+        <div
+          role="button"
+          onKeyUp={() => setCanvas(window.id, currentGroupings[0].index)}
+          onClick={() => setCanvas(window.id, currentGroupings[0].index)}
+          tabIndex={-1}
+          style={{
+            display: 'inline-block',
+            height: (position === 'far-right') ? 'auto' : `${height - SPACING}px`,
+            whiteSpace: 'nowrap',
+            width: (position === 'far-bottom') ? 'auto' : `${style.width}px`,
+          }}
+          className={classNames(
+            ns(['thumbnail-nav-canvas', `thumbnail-nav-canvas-${currentIndex}`, this.currentCanvasClass(currentGroupings.map(canvas => canvas.index))]),
+            classes.canvas,
+            {
+              [classes.currentCanvas]: currentGroupings
+                .map(canvas => canvas.index).includes(window.canvasIndex),
+            },
+          )}
+        >
+          {currentGroupings.map((canvas, i) => (
+            <CaptionedCanvasThumbnail
+              key={canvas.id}
+              canvas={canvas}
+              classes={classes}
+              height={(position === 'far-right') ? style.height - SPACING : height - (1.5 * SPACING)}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+}
+
+ThumbnailCanvasGrouping.propTypes = {
+  classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  data: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  index: PropTypes.number.isRequired,
+  setCanvas: PropTypes.func.isRequired,
+  style: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -25,7 +25,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
    */
   currentCanvasClass(canvasIndices) {
     const { index } = this.props;
-    if (canvasIndices.includes(index)) return 'current-canvas';
+    if (canvasIndices.includes(index)) return 'current-canvas-grouping';
     return '';
   }
 

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -15,8 +15,8 @@ export class ThumbnailCanvasGrouping extends PureComponent {
 
   /** */
   setCanvas(e) {
-    const { setCanvas } = this.props;
-    setCanvas(e.currentTarget.dataset.windowid, parseInt(e.currentTarget.dataset.canvasIndex, 10));
+    const { setCanvas, window } = this.props;
+    setCanvas(window.id, parseInt(e.currentTarget.dataset.canvasIndex, 10));
   }
 
   /**
@@ -24,8 +24,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
    * a useful class.
    */
   currentCanvasClass(canvasIndices) {
-    const { data } = this.props;
-    const { window } = data;
+    const { window } = this.props;
     if (canvasIndices.includes(window.canvasIndex)) return 'current-canvas';
     return '';
   }
@@ -33,10 +32,10 @@ export class ThumbnailCanvasGrouping extends PureComponent {
   /** */
   render() {
     const {
-      index, style, data, classes,
+      index, style, data, classes, window,
     } = this.props;
     const {
-      canvasGroupings, window, position, height,
+      canvasGroupings, position, height,
     } = data;
     const currentIndex = index;
     const currentGroupings = canvasGroupings.groupings()[currentIndex];
@@ -55,7 +54,6 @@ export class ThumbnailCanvasGrouping extends PureComponent {
       >
         <div
           role="button"
-          data-windowid={window.id}
           data-canvas-index={currentGroupings[0].index}
           onKeyUp={this.setCanvas}
           onClick={this.setCanvas}
@@ -94,4 +92,5 @@ ThumbnailCanvasGrouping.propTypes = {
   index: PropTypes.number.isRequired,
   setCanvas: PropTypes.func.isRequired,
   style: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -63,9 +63,20 @@ export class ThumbnailNavigation extends Component {
   calculatingWidth(canvasesLength) {
     const { config } = this.props;
     if (canvasesLength === 1) {
-      return config.thumbnailNavigation.width / 2;
+      return config.thumbnailNavigation.width;
     }
-    return config.thumbnailNavigation.width;
+    return config.thumbnailNavigation.width * 2;
+  }
+
+  /** */
+  rightWidth() {
+    const { window, config } = this.props;
+    switch (window.view) {
+      case 'book':
+        return (config.thumbnailNavigation.width * 2);
+      default:
+        return config.thumbnailNavigation.width;
+    }
   }
 
   /** */
@@ -76,7 +87,7 @@ export class ThumbnailNavigation extends Component {
         return {
           height: '100%',
           minHeight: 0,
-          width: `${config.thumbnailNavigation.width + this.scrollbarSize + this.spacing}px`,
+          width: `${this.rightWidth() + this.scrollbarSize + this.spacing}px`,
         };
       // Default case bottom
       default:
@@ -136,7 +147,7 @@ export class ThumbnailNavigation extends Component {
               itemData={{
                 canvasGroupings,
                 config,
-                height: 150 - this.spacing - this.scrollbarSize,
+                height: config.thumbnailNavigation.height - this.spacing - this.scrollbarSize,
                 position,
                 windowId: window.id,
               }}

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -217,7 +217,10 @@ export class ThumbnailNavigation extends Component {
         onKeyUp={this.handleKeyUp}
         role="grid"
       >
-        <AutoSizer>
+        <AutoSizer
+          defaultHeight={100}
+          defaultWidth={400}
+        >
           {({ height, width }) => (
             <List
               height={this.areaHeight(height)}

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
-import Grid from 'react-virtualized/dist/commonjs/Grid';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { VariableSizeGrid as Grid } from 'react-window';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';
 import Typography from '@material-ui/core/Typography';
@@ -10,7 +10,6 @@ import { CanvasThumbnail } from './CanvasThumbnail';
 import ManifestoCanvas from '../lib/ManifestoCanvas';
 import CanvasWorld from '../lib/CanvasWorld';
 import ns from '../config/css-ns';
-import 'react-virtualized/styles.css';
 
 /**
  */
@@ -35,7 +34,8 @@ export class ThumbnailNavigation extends Component {
   componentDidUpdate(prevProps) {
     const { position, window } = this.props;
     if (prevProps.window.view !== window.view && position !== 'off') {
-      this.gridRef.current.recomputeGridSize();
+      this.gridRef.current.resetAfterColumnIndex(0);
+      this.gridRef.current.resetAfterRowIndex(0);
     }
   }
 
@@ -56,7 +56,7 @@ export class ThumbnailNavigation extends Component {
    */
   cellRenderer(options) {
     const {
-      columnIndex, key, style, rowIndex,
+      columnIndex, rowIndex, style,
     } = options;
     const {
       classes, window, setCanvas, config, canvasGroupings, position,
@@ -65,7 +65,6 @@ export class ThumbnailNavigation extends Component {
     const currentGroupings = canvasGroupings.groupings()[currentIndex];
     return (
       <div
-        key={key}
         style={style}
         className={ns('thumbnail-nav-container')}
       >
@@ -127,14 +126,14 @@ export class ThumbnailNavigation extends Component {
    * in a simple case, a column == canvas. In a book view, a group (or two)
    * canvases. When in the "right" position, this value is static.
    */
-  calculateScaledWidth(options) {
+  calculateScaledWidth(index) {
     const { config, canvasGroupings, position } = this.props;
     switch (position) {
       case 'far-right':
         return this.rightWidth() + this.spacing;
       // Default case bottom
       default: {
-        const canvases = canvasGroupings.getCanvases(options.index);
+        const canvases = canvasGroupings.getCanvases(index);
         const world = new CanvasWorld(canvases);
         const bounds = world.worldBounds();
         const calc = Math.floor(
@@ -151,11 +150,11 @@ export class ThumbnailNavigation extends Component {
    * in a simple case, a row == canvas. In a book view, a group (or two)
    * canvases. When in the "bottom" position, this value is static.
    */
-  calculateScaledHeight(options) {
+  calculateScaledHeight(index) {
     const { config, canvasGroupings, position } = this.props;
     switch (position) {
       case 'far-right': {
-        const canvases = canvasGroupings.getCanvases(options.index);
+        const canvases = canvasGroupings.getCanvases(index);
         const world = new CanvasWorld(canvases);
         const bounds = world.worldBounds();
         const calc = Math.floor(
@@ -270,7 +269,6 @@ export class ThumbnailNavigation extends Component {
         >
           {({ height, width }) => (
             <Grid
-              cellRenderer={this.cellRenderer}
               columnCount={this.columnCount()}
               columnWidth={this.calculateScaledWidth}
               height={this.areaHeight(height)}
@@ -280,7 +278,9 @@ export class ThumbnailNavigation extends Component {
               scrollToColumn={this.scrollToColumn()}
               width={width}
               ref={this.gridRef}
-            />
+            >
+              {this.cellRenderer}
+            </Grid>
           )}
         </AutoSizer>
       </nav>

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -138,7 +138,7 @@ export class ThumbnailNavigation extends Component {
                 config,
                 height: 150 - this.spacing - this.scrollbarSize,
                 position,
-                window,
+                windowId: window.id,
               }}
               ref={this.gridRef}
             >

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -38,7 +38,7 @@ export class ThumbnailNavigation extends Component {
    */
   calculateScaledSize(index) {
     const { config, canvasGroupings, position } = this.props;
-    const canvases = canvasGroupings.getCanvases(index);
+    const canvases = canvasGroupings.groupings()[index];
     const world = new CanvasWorld(canvases);
     const bounds = world.worldBounds();
     switch (position) {

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -46,7 +46,6 @@ export class ThumbnailNavigation extends Component {
         const calc = Math.floor(
           this.calculatingWidth(canvases.length) * bounds[3] / bounds[2],
         );
-        // console.log(calc);
         return calc + this.spacing;
       }
       // Default case bottom
@@ -55,7 +54,6 @@ export class ThumbnailNavigation extends Component {
           (config.thumbnailNavigation.height - this.scrollbarSize - this.spacing - 4)
            * bounds[2] / bounds[3],
         );
-        console.log(calc, bounds[2], bounds[3]);
         return calc;
       }
     }

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -143,7 +143,7 @@ export default {
   thumbnailNavigation: {
     defaultPosition: 'off', // Which position for the thumbnail navigation to be be displayed. Other possible values are "far-bottom" or "far-right"
     height: 150, // height of entire ThumbnailNavigation area when position is "far-bottom"
-    width: 100, // width of a single thumb in ThumbnailNavigation area when position is "far-right"
+    width: 200, // width of entire ThumbnailNavigation area when position is "far-right"
   },
   workspace: {
     type: 'mosaic', // Which workspace type to load by default. Other possible values are "elastic"

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -142,8 +142,8 @@ export default {
   windows: [], // Array of windows to be open when mirador initializes (each object should at least provide a loadedManifest key with the value of the IIIF presentation manifest to load)
   thumbnailNavigation: {
     defaultPosition: 'off', // Which position for the thumbnail navigation to be be displayed. Other possible values are "far-bottom" or "far-right"
-    height: 150, // height of entire ThumbnailNavigation area when position is "far-bottom"
-    width: 200, // width of entire ThumbnailNavigation area when position is "far-right"
+    height: 130, // height of entire ThumbnailNavigation area when position is "far-bottom"
+    width: 100, // width of one canvas (doubled for book view) in ThumbnailNavigation area when position is "far-right"
   },
   workspace: {
     type: 'mosaic', // Which workspace type to load by default. Other possible values are "elastic"

--- a/src/containers/CaptionedCanvasThumbnail.js
+++ b/src/containers/CaptionedCanvasThumbnail.js
@@ -10,9 +10,13 @@ import { CaptionedCanvasThumbnail } from '../components/CaptionedCanvasThumbnail
 const styles = theme => ({
   canvasThumbLabel: {
     background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-    bottom: '5px',
+    bottom: '0px',
     left: '0px',
+    overflow: 'hidden',
     position: 'absolute',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    width: '100%',
   },
   root: {
     background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',

--- a/src/containers/CaptionedCanvasThumbnail.js
+++ b/src/containers/CaptionedCanvasThumbnail.js
@@ -1,0 +1,31 @@
+import { compose } from 'redux';
+import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
+import { withPlugins } from '../extend';
+import { CaptionedCanvasThumbnail } from '../components/CaptionedCanvasThumbnail';
+
+/**
+ * Styles for withStyles HOC
+ */
+const styles = theme => ({
+  canvasThumbLabel: {
+    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+    bottom: '5px',
+    left: '0px',
+    position: 'absolute',
+  },
+  root: {
+    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+  },
+  title: {
+    color: '#ffffff',
+  },
+});
+
+const enhance = compose(
+  withStyles(styles),
+  withTranslation(),
+  withPlugins('ThumnailNavigation'),
+);
+
+export default enhance(CaptionedCanvasThumbnail);

--- a/src/containers/CaptionedCanvasThumbnail.js
+++ b/src/containers/CaptionedCanvasThumbnail.js
@@ -10,13 +10,18 @@ import { CaptionedCanvasThumbnail } from '../components/CaptionedCanvasThumbnail
 const styles = theme => ({
   canvasThumbLabel: {
     background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-    bottom: '0px',
+    bottom: '5px',
     left: '0px',
     overflow: 'hidden',
     position: 'absolute',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     width: '100%',
+  },
+  container: {
+    display: 'inline-block',
+    height: 'inherit',
+    position: 'relative',
   },
   root: {
     background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
@@ -29,7 +34,7 @@ const styles = theme => ({
 const enhance = compose(
   withStyles(styles),
   withTranslation(),
-  withPlugins('ThumnailNavigation'),
+  withPlugins('CaptionedCanvasThumbnail'),
 );
 
 export default enhance(CaptionedCanvasThumbnail);

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -4,6 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
+import { getWindow } from '../state/selectors';
 import { ThumbnailCanvasGrouping } from '../components/ThumbnailCanvasGrouping';
 
 /**
@@ -14,6 +15,15 @@ import { ThumbnailCanvasGrouping } from '../components/ThumbnailCanvasGrouping';
 const mapDispatchToProps = {
   setCanvas: actions.setCanvas,
 };
+
+/**
+ * mapStateToProps - used to hook up state to props
+ * @memberof ThumbnailCanvasGrouping
+ * @private
+ */
+const mapStateToProps = (state, { data }) => ({
+  window: getWindow(state, { windowId: data.windowId }),
+});
 
 /**
  * Styles for withStyles HOC
@@ -35,7 +45,7 @@ const styles = theme => ({
 const enhance = compose(
   withStyles(styles),
   withTranslation(),
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
   withPlugins('ThumnailNavigation'),
 );
 

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -46,7 +46,7 @@ const enhance = compose(
   withStyles(styles),
   withTranslation(),
   connect(mapStateToProps, mapDispatchToProps),
-  withPlugins('ThumnailNavigation'),
+  withPlugins('ThumbnailCanvasGrouping'),
 );
 
 export default enhance(ThumbnailCanvasGrouping);

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -28,19 +28,7 @@ const styles = theme => ({
     color: theme.palette.common.white,
     cursor: 'pointer',
   },
-  canvasThumbLabel: {
-    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-    bottom: '5px',
-    left: '0px',
-    position: 'absolute',
-  },
   currentCanvas: {
-  },
-  root: {
-    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-  },
-  title: {
-    color: '#ffffff',
   },
 });
 

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -1,0 +1,54 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
+import { withPlugins } from '../extend';
+import * as actions from '../state/actions';
+import { ThumbnailCanvasGrouping } from '../components/ThumbnailCanvasGrouping';
+
+/**
+ * mapDispatchToProps - used to hook up connect to action creators
+ * @memberof ThumbnailCanvasGrouping
+ * @private
+ */
+const mapDispatchToProps = {
+  setCanvas: actions.setCanvas,
+};
+
+/**
+ * Styles for withStyles HOC
+ */
+const styles = theme => ({
+  canvas: {
+    '&$currentCanvas': {
+      border: `2px solid ${theme.palette.secondary.main}`,
+    },
+    border: '2px solid transparent',
+    boxSizing: 'border-box',
+    color: theme.palette.common.white,
+    cursor: 'pointer',
+  },
+  canvasThumbLabel: {
+    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+    bottom: '5px',
+    left: '0px',
+    position: 'absolute',
+  },
+  currentCanvas: {
+  },
+  root: {
+    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+  },
+  title: {
+    color: '#ffffff',
+  },
+});
+
+const enhance = compose(
+  withStyles(styles),
+  withTranslation(),
+  connect(null, mapDispatchToProps),
+  withPlugins('ThumnailNavigation'),
+);
+
+export default enhance(ThumbnailCanvasGrouping);

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import CanvasGroupings from '../lib/CanvasGroupings';
-import * as actions from '../state/actions';
 import { ThumbnailNavigation } from '../components/ThumbnailNavigation';
 import { getWindow } from '../state/selectors/windows';
 import { getManifestCanvases } from '../state/selectors/manifests';

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -1,8 +1,10 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend';
 import CanvasGroupings from '../lib/CanvasGroupings';
+import * as actions from '../state/actions';
 import { ThumbnailNavigation } from '../components/ThumbnailNavigation';
 import { getWindow } from '../state/selectors/windows';
 import { getManifestCanvases } from '../state/selectors/manifests';
@@ -27,9 +29,32 @@ const mapStateToProps = ({
   window: getWindow({ windows }, { windowId }),
 });
 
+/**
+ * mapDispatchToProps - used to hook up connect to action creators
+ * @memberof ThumbnailNavigation
+ * @private
+ */
+const mapDispatchToProps = {
+  setCanvas: actions.setCanvas,
+};
+
+/**
+ * Styles for withStyles HOC
+ */
+const styles = theme => ({
+  thumbNavigation: {
+    '&:focus': {
+      boxShadow: 0,
+      outline: 0,
+    },
+  },
+});
+
+
 const enhance = compose(
+  withStyles(styles),
   withTranslation(),
-  connect(mapStateToProps, null),
+  connect(mapStateToProps, mapDispatchToProps),
   withPlugins('ThumnailNavigation'),
 );
 

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -55,7 +55,7 @@ const enhance = compose(
   withStyles(styles),
   withTranslation(),
   connect(mapStateToProps, mapDispatchToProps),
-  withPlugins('ThumnailNavigation'),
+  withPlugins('ThumbnailNavigation'),
 );
 
 export default enhance(ThumbnailNavigation);

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -1,7 +1,6 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend';
 import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
@@ -29,43 +28,9 @@ const mapStateToProps = ({
   window: getWindow({ windows }, { windowId }),
 });
 
-/**
- * mapDispatchToProps - used to hook up connect to action creators
- * @memberof ThumbnailNavigation
- * @private
- */
-const mapDispatchToProps = {
-  setCanvas: actions.setCanvas,
-};
-
-/**
- * Styles for withStyles HOC
- */
-const styles = theme => ({
-  canvas: {
-    '&$currentCanvas': {
-      border: `2px solid ${theme.palette.secondary.main}`,
-    },
-    border: '2px solid transparent',
-    color: theme.palette.common.white,
-    cursor: 'pointer',
-    margin: '2px',
-    padding: '2px',
-  },
-  currentCanvas: {
-  },
-  root: {
-    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-  },
-  title: {
-    color: '#ffffff',
-  },
-});
-
 const enhance = compose(
-  withStyles(styles),
   withTranslation(),
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps, null),
   withPlugins('ThumnailNavigation'),
 );
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -128,11 +128,6 @@
     text-align: center;
   }
 
-  &-thumb-navigation {
-    margin: 2px;
-    padding: 2px;
-  }
-
   &-label-value-metadata {
     dd {
       margin-bottom: .5em;


### PR DESCRIPTION
This PR does a few things:

 - Replaces react-virtualized w/ react-window (#2269)
 - Fixes #2090 
 - Fixes #2347 
 - Fixes #2310 
 - Fixes #2269
 - Fixes #2371 

# But wait there is more!!

Now when you are focused on the `ThumbnailNavigation` area, your left/right up/down keys work to navigate canvases
![](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy-downsized.gif)

This also improves "odd" dimension things. 🙄 https://media.nga.gov/public/manifests/nga_highlights.json

![Screen Shot 2019-04-03 at 3 53 10 PM](https://user-images.githubusercontent.com/1656824/55515778-a47f5680-5628-11e9-8ee2-e3ccae9f9112.png)

But it doesn't resolve an issue where canvas sizes do not match size of images. /tableflip

## Context about this approach
react-window is a rewrite of react-virtualized by the same author who is a React core team member. Their suggestion is to use react-window now. There does seem to have support for RTL when we get there.

#### A useful fixture for comparing performance issues: [Parker manifest](https://purl.stanford.edu/ky326yt7099/iiif/manifest)

### Some notes on comparisons between approaches:

React-Virtualized - Current approach in master. Uses windowing algorithm to only render "viewable" elements.

React-Window - This pull request, and my recommendation moving forward.

Rendering dom elements - See #2278. While this approach works nicely for some things, it slows Mirador to a halt when using large manifests.

While most of these comparisons are largely non scientific, I did create an "experiment" which relative results should be reproducible for most. Close all windows and open up the large manifest [https://purl.stanford.edu/ky326yt7099/iiif/manifest](https://purl.stanford.edu/ky326yt7099/iiif/manifest). Open up the "Memory" tab in Chrome devtools. Is this experiment flawed? Yes. Not all factors are the same in these approaches but to me it seems like the best comparison for us to make a decision and move forward.

![Screen Shot 2019-04-03 at 3 32 12 PM](https://user-images.githubusercontent.com/1656824/55514690-f672ad00-5625-11e9-86dc-784618f9fdfe.png)

Approach | Memory after GC | Link to demo
--- | --- | ---
react-virtualized | 22.4 MB | https://mirador-dev.netlify.com/__tests__/integration/mirador/
react-window | 19.4 MB | https://deploy-preview-2368--mirador-dev.netlify.com/__tests__/integration/mirador/
DOM | 61.6 MB | https://deploy-preview-2278--mirador-dev.netlify.com/__tests__/integration/mirador/

Alleged performance increases (not sure how to quantify this better) and about ~20kb reduction of gzipped bundle.

Out of scopes spun out:
 - #2384 change focus if possible when key board naving
 -  #2385
 - Some pixels are off hear and there.. I know I know.. I'm just not sure how to resolve this further at the moment
