### PR TITLE
removed customized terser in favor of default

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const webpack = require('webpack');
-const TerserPlugin = require('terser-webpack-plugin');
 const paths = require('./config/paths');
 
 const eslintLoaderConfig = {
@@ -61,15 +60,6 @@ const baseConfig = [
             'sass-loader', // compiles Sass to CSS, using Node Sass by default
           ],
         }],
-    },
-    optimization: {
-      minimizer: [
-        new TerserPlugin({
-          terserOptions: {
-            keep_fnames: true,
-          },
-        }),
-      ],
     },
     output: {
       filename: 'mirador.min.js',


### PR DESCRIPTION
This was added to support the previous version of the plugin system. Without the need to lookup classes by class name anymore we can use the standard build now.

Build size updates:

Approach | Size (min) | Size (min, gzip)
--- | --- | ---
keep_fnames | 1.55 MiB | 384.89 KB
default (this PR) | 1.44 MiB | 384.79 KB