### PR TITLE
Do not render components that are not visible

### DIFF
--- a/__tests__/src/components/WorkspaceMenu.test.js
+++ b/__tests__/src/components/WorkspaceMenu.test.js
@@ -42,7 +42,8 @@ describe('WorkspaceMenu', () => {
   describe('handleMenuItemClose', () => {
     it('resets the anchor state', () => {
       wrapper.instance().handleMenuItemClose('windowList')();
-      expect(wrapper.find(WindowList).props().open).toBe(false);
+      expect(Boolean(wrapper.state('windowList').anchorEl)).toEqual(false);
+      expect(wrapper.find(WindowList).length).toBe(0);
     });
   });
 

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -171,35 +171,47 @@ export class WorkspaceMenu extends Component {
             <Typography variant="body1">{t('importWorkspace')}</Typography>
           </MenuItem>
         </Menu>
-        <WindowList
-          anchorEl={windowList.anchorEl}
-          open={Boolean(windowList.anchorEl)}
-          handleClose={this.handleMenuItemClose('windowList')}
-        />
-        <WorkspaceSettings
-          open={Boolean(toggleZoom.open)}
-          handleClose={this.handleMenuItemClose('toggleZoom')}
-        />
-        <WorkspaceSettings
-          open={Boolean(settings.open)}
-          container={container}
-          handleClose={this.handleMenuItemClose('settings')}
-        />
-        <WorkspaceSelectionDialog
-          open={Boolean(workspaceSelection.open)}
-          container={container}
-          handleClose={this.handleMenuItemClose('workspaceSelection')}
-        />
-        <WorkspaceExport
-          open={Boolean(exportWorkspace.open)}
-          container={container}
-          handleClose={this.handleMenuItemClose('exportWorkspace')}
-        />
-        <WorkspaceImport
-          open={Boolean(importWorkspace.open)}
-          container={container}
-          handleClose={this.handleMenuItemClose('importWorkspace')}
-        />
+        {Boolean(windowList.anchorEl) && (
+          <WindowList
+            anchorEl={windowList.anchorEl}
+            open={Boolean(windowList.anchorEl)}
+            handleClose={this.handleMenuItemClose('windowList')}
+          />
+        )}
+        {Boolean(toggleZoom.open) && (
+          <WorkspaceSettings
+            open={Boolean(toggleZoom.open)}
+            handleClose={this.handleMenuItemClose('toggleZoom')}
+          />
+        )}
+        {Boolean(settings.open) && (
+          <WorkspaceSettings
+            open={Boolean(settings.open)}
+            container={container}
+            handleClose={this.handleMenuItemClose('settings')}
+          />
+        )}
+        {Boolean(workspaceSelection.open) && (
+          <WorkspaceSelectionDialog
+            open={Boolean(workspaceSelection.open)}
+            container={container}
+            handleClose={this.handleMenuItemClose('workspaceSelection')}
+          />
+        )}
+        {Boolean(exportWorkspace.open) && (
+          <WorkspaceExport
+            open={Boolean(exportWorkspace.open)}
+            container={container}
+            handleClose={this.handleMenuItemClose('exportWorkspace')}
+          />
+        )}
+        {Boolean(importWorkspace.open) && (
+          <WorkspaceImport
+            open={Boolean(importWorkspace.open)}
+            container={container}
+            handleClose={this.handleMenuItemClose('importWorkspace')}
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
This seems to work for me in our various uses/cases. Is there a reason why we render them when we don't show them?