### PR TITLE
Setup proptypes for children to handle multiple

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -38,6 +38,7 @@ describe('OpenSeadragonViewer', () => {
         canvasWorld={new CanvasWorld([])}
       >
         <div className="foo" />
+        <div className="bar" />
       </OpenSeadragonViewer>,
     );
   });
@@ -47,6 +48,10 @@ describe('OpenSeadragonViewer', () => {
   it('renders child components enhanced with additional props', () => {
     expect(wrapper.find('.foo').length).toBe(1);
     expect(wrapper.find('.foo').props()).toEqual(expect.objectContaining({
+      zoomToWorld: wrapper.instance().zoomToWorld,
+    }));
+    expect(wrapper.find('.bar').length).toBe(1);
+    expect(wrapper.find('.bar').props()).toEqual(expect.objectContaining({
       zoomToWorld: wrapper.instance().zoomToWorld,
     }));
   });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -271,7 +271,10 @@ OpenSeadragonViewer.defaultProps = {
 OpenSeadragonViewer.propTypes = {
   annotations: PropTypes.arrayOf(PropTypes.object),
   canvasWorld: PropTypes.instanceOf(CanvasWorld).isRequired,
-  children: PropTypes.element,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   label: PropTypes.string,
   t: PropTypes.func.isRequired,


### PR DESCRIPTION
This will still throw an error if you pass a dom element as a child instead of a component.