### PR TITLE
Remove viewport debouncing; we're losing updates if the viewer re-ren…

### DIFF
--- a/__tests__/src/actions/canvas.test.js
+++ b/__tests__/src/actions/canvas.test.js
@@ -1,8 +1,6 @@
 import * as actions from '../../../src/state/actions';
 import ActionTypes from '../../../src/state/actions/action-types';
 
-const debounceTime = 100;
-
 describe('canvas actions', () => {
   describe('setCanvas', () => {
     it('sets to a defined canvas', () => {
@@ -19,11 +17,6 @@ describe('canvas actions', () => {
     it('sets viewer state', () => {
       const id = 'abc123';
       const expectedAction = {
-        meta: {
-          debounce: {
-            time: debounceTime,
-          },
-        },
         payload: {
           x: 1,
           y: 0,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "react-rnd": "^9.1.1",
     "react-virtualized": "^9.21.0",
     "redux": "4.0.1",
-    "redux-debounced": "^0.5.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -122,8 +122,8 @@ export class OpenSeadragonViewer extends Component {
     const { viewport } = event.eventSource;
 
     updateViewport(windowId, {
-      x: viewport.centerSpringX.target.value,
-      y: viewport.centerSpringY.target.value,
+      x: Math.round(viewport.centerSpringX.target.value),
+      y: Math.round(viewport.centerSpringY.target.value),
       zoom: viewport.zoomSpring.target.value,
     });
   }

--- a/src/state/actions/canvas.js
+++ b/src/state/actions/canvas.js
@@ -18,16 +18,10 @@ export function setCanvas(windowId, canvasIndex) {
  *
  * @param windowId
  * @param payload
- * @returns {{payload: *, meta: {debounce: {time: number}}, type: string, windowId: *}}
+ * @returns {{payload: *, type: string, windowId: *}}
  */
 export function updateViewport(windowId, payload) {
   return {
-    meta: {
-      debounce: {
-        // TODO : set this value in a registry
-        time: 100,
-      },
-    },
     payload,
     type: ActionTypes.UPDATE_VIEWPORT,
     windowId,

--- a/src/state/createStore.js
+++ b/src/state/createStore.js
@@ -5,7 +5,6 @@
 
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware } from 'redux';
-import createDebounce from 'redux-debounced';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import createRootReducer from './reducers/rootReducer';
 
@@ -18,7 +17,6 @@ export default function (pluginReducers) {
     createRootReducer(pluginReducers),
     composeWithDevTools(
       applyMiddleware(
-        createDebounce(),
         thunkMiddleware,
       ),
     ),


### PR DESCRIPTION
…ders before the debounce.

This is most obvious if you:

- focus on a window
- initiate a pan/zoom
- switch focus to a different window

You'll see the first window revert back to the last-stored state.