### PR TITLE
[WIP] Eliminates extra OSD rendering cycles.

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -48,10 +48,14 @@ describe('OpenSeadragonViewer', () => {
   it('renders child components enhanced with additional props', () => {
     expect(wrapper.find('.foo').length).toBe(1);
     expect(wrapper.find('.foo').props()).toEqual(expect.objectContaining({
+      zoomIn: wrapper.instance().zoomIn,
+      zoomOut: wrapper.instance().zoomOut,
       zoomToWorld: wrapper.instance().zoomToWorld,
     }));
     expect(wrapper.find('.bar').length).toBe(1);
     expect(wrapper.find('.bar').props()).toEqual(expect.objectContaining({
+      zoomIn: wrapper.instance().zoomIn,
+      zoomOut: wrapper.instance().zoomOut,
       zoomToWorld: wrapper.instance().zoomToWorld,
     }));
   });
@@ -131,6 +135,36 @@ describe('OpenSeadragonViewer', () => {
       wrapper.instance().fitBounds = fitBounds;
       wrapper.instance().zoomToWorld();
       expect(fitBounds).toHaveBeenCalledWith(0, 0, 0, Infinity, true);
+    });
+  });
+
+  describe('zoomIn', () => {
+    it('zooms in osd instance', () => {
+      const zoomToMock = jest.fn();
+      wrapper.instance().viewer = {
+        viewport: {
+          getCenter: jest.fn(() => ({ x: 2, y: 3 })),
+          getZoom: jest.fn(() => 42),
+          zoomTo: zoomToMock,
+        },
+      };
+      wrapper.instance().zoomIn();
+      expect(zoomToMock).toHaveBeenCalledWith(84, { x: 2, y: 3 }, false);
+    });
+  });
+
+  describe('zoomOut', () => {
+    it('zooms out osd instance', () => {
+      const zoomToMock = jest.fn();
+      wrapper.instance().viewer = {
+        viewport: {
+          getCenter: jest.fn(() => ({ x: 2, y: 3 })),
+          getZoom: jest.fn(() => 42),
+          zoomTo: zoomToMock,
+        },
+      };
+      wrapper.instance().zoomOut();
+      expect(zoomToMock).toHaveBeenCalledWith(21, { x: 2, y: 3 }, false);
     });
   });
 

--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -169,7 +169,7 @@ describe('OpenSeadragonViewer', () => {
     it('calls the OSD viewport panTo and zoomTo with the component state', () => {
       wrapper.instance().componentDidMount();
 
-      expect(addHandler).toHaveBeenCalledWith('viewport-change', expect.anything());
+      expect(addHandler).toHaveBeenCalledWith('update-viewport', expect.anything());
 
       expect(panTo).toHaveBeenCalledWith(
         { x: 1, y: 0, zoom: 0.5 }, false,
@@ -268,18 +268,19 @@ describe('OpenSeadragonViewer', () => {
     });
   });
 
-  describe('onViewportChange', () => {
-    it('translates the OSD viewport data into an update to the component state', () => {
-      wrapper.instance().onViewportChange({
-        eventSource: {
-          viewport: {
-            centerSpringX: { target: { value: 1 } },
-            centerSpringY: { target: { value: 0 } },
-            zoomSpring: { target: { value: 0.5 } },
-          },
+  describe('componentWillUnmount', () => {
+    it('updates the viewer and removes all handlers', () => {
+      const removeMock = jest.fn();
+      wrapper.instance().viewer = {
+        removeAllHandlers: removeMock,
+        viewport: {
+          getCenter: jest.fn(() => ({ x: 1, y: 0 })),
+          getZoom: jest.fn(() => 0.5),
         },
-      });
+      };
+      wrapper.unmount();
 
+      expect(removeMock).toHaveBeenCalled();
       expect(updateViewport).toHaveBeenCalledWith(
         'base',
         { x: 1, y: 0, zoom: 0.5 },

--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -191,34 +191,6 @@ describe('OpenSeadragonViewer', () => {
   });
 
   describe('componentDidUpdate', () => {
-    it('calls the OSD viewport panTo and zoomTo with the component state and forces a redraw', () => {
-      const panTo = jest.fn();
-      const zoomTo = jest.fn();
-      const forceRedraw = jest.fn();
-
-      wrapper.instance().viewer = {
-        forceRedraw,
-        viewport: {
-          centerSpringX: { target: { value: 10 } },
-          centerSpringY: { target: { value: 10 } },
-          panTo,
-          zoomSpring: { target: { value: 1 } },
-          zoomTo,
-        },
-      };
-
-      wrapper.setProps({ viewer: { x: 0.5, y: 0.5, zoom: 0.1 } });
-      wrapper.setProps({ viewer: { x: 1, y: 0, zoom: 0.5 } });
-
-      expect(panTo).toHaveBeenCalledWith(
-        { x: 1, y: 0, zoom: 0.5 }, false,
-      );
-      expect(zoomTo).toHaveBeenCalledWith(
-        0.5, { x: 1, y: 0, zoom: 0.5 }, false,
-      );
-      expect(forceRedraw).not.toHaveBeenCalled();
-    });
-
     it('sets up canvasUpdate to add annotations to the canvas and forces a redraw', () => {
       const clear = jest.fn();
       const resize = jest.fn();

--- a/__tests__/src/components/WindowCanvasNavigationControls.test.js
+++ b/__tests__/src/components/WindowCanvasNavigationControls.test.js
@@ -12,6 +12,8 @@ function createWrapper(props) {
       canvases={[]}
       canvasLabel="label"
       window={{}}
+      zoomIn={() => {}}
+      zoomOut={() => {}}
       zoomToWorld={() => {}}
       {...props}
     />,
@@ -20,13 +22,15 @@ function createWrapper(props) {
 
 describe('WindowCanvasNavigationControls', () => {
   let wrapper;
+  const zoomIn = jest.fn();
+  const zoomOut = jest.fn();
   const zoomToWorld = jest.fn();
 
   it('renders properly', () => {
-    wrapper = createWrapper({ zoomToWorld });
+    wrapper = createWrapper({ zoomIn, zoomOut, zoomToWorld });
     expect(wrapper.matchesElement(
       <div>
-        <ZoomControls zoomToWorld={zoomToWorld} />
+        <ZoomControls zoomToWorld={zoomToWorld} zoomIn={zoomIn} zoomOut={zoomOut} />
         <ViewerNavigation />
         <ViewerInfo />
       </div>,

--- a/__tests__/src/components/ZoomControls.test.js
+++ b/__tests__/src/components/ZoomControls.test.js
@@ -18,6 +18,8 @@ describe('ZoomControls', () => {
         viewer={viewer}
         showZoomControls={showZoomControls}
         updateViewport={updateViewport}
+        zoomIn={() => {}}
+        zoomOut={() => {}}
         zoomToWorld={() => {}}
       />,
     );
@@ -31,6 +33,8 @@ describe('ZoomControls', () => {
 
 
   describe('with showZoomControls=true', () => {
+    const zoomIn = jest.fn();
+    const zoomOut = jest.fn();
     const zoomToWorld = jest.fn();
     beforeEach(() => {
       updateViewport = jest.fn();
@@ -41,6 +45,8 @@ describe('ZoomControls', () => {
           viewer={viewer}
           showZoomControls
           updateViewport={updateViewport}
+          zoomIn={zoomIn}
+          zoomOut={zoomOut}
           zoomToWorld={zoomToWorld}
         />,
       );
@@ -54,15 +60,13 @@ describe('ZoomControls', () => {
     it('has a zoom-in button', () => {
       const button = wrapper.find({ 'aria-label': 'zoomIn' }).first();
       button.props().onClick(); // Trigger the onClick prop
-      expect(updateViewport).toHaveBeenCalledTimes(1);
-      expect(updateViewport).toHaveBeenCalledWith('xyz', { x: 100, y: 100, zoom: 2 });
+      expect(zoomIn).toHaveBeenCalledTimes(1);
     });
 
     it('has a zoom-out button', () => {
       const button = wrapper.find({ 'aria-label': 'zoomOut' }).first();
       button.props().onClick(); // Trigger the onClick prop
-      expect(updateViewport).toHaveBeenCalledTimes(1);
-      expect(updateViewport).toHaveBeenCalledWith('xyz', { x: 100, y: 100, zoom: 0.5 });
+      expect(zoomOut).toHaveBeenCalledTimes(1);
     });
 
     it('has a zoom reset button', () => {
@@ -70,13 +74,6 @@ describe('ZoomControls', () => {
       button.props().onClick(); // Trigger the onClick prop
       expect(zoomToWorld).toHaveBeenCalledTimes(1);
       expect(zoomToWorld).toHaveBeenCalledWith(false);
-    });
-  });
-
-  describe('handleZoomInClick', () => {
-    it('increases the zoom value on Zoom-In', () => {
-      wrapper.instance().handleZoomInClick();
-      expect(updateViewport).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -49,6 +49,8 @@ export class OpenSeadragonViewer extends Component {
     this.updateCanvas = () => {};
     this.ref = React.createRef();
     this.onUpdateViewport = this.onUpdateViewport.bind(this);
+    this.zoomIn = this.zoomIn.bind(this);
+    this.zoomOut = this.zoomOut.bind(this);
     this.zoomToWorld = this.zoomToWorld.bind(this);
   }
 
@@ -227,6 +229,26 @@ export class OpenSeadragonViewer extends Component {
     this.fitBounds(...canvasWorld.worldBounds(), immediately);
   }
 
+  /** */
+  zoomIn() {
+    const center = this.viewer.viewport.getCenter();
+    this.viewer.viewport.zoomTo(
+      this.viewer.viewport.getZoom() * 2,
+      center,
+      false,
+    );
+  }
+
+  /** */
+  zoomOut() {
+    const center = this.viewer.viewport.getCenter();
+    this.viewer.viewport.zoomTo(
+      this.viewer.viewport.getZoom() / 2,
+      center,
+      false,
+    );
+  }
+
   /**
    * Renders things
    */
@@ -239,6 +261,8 @@ export class OpenSeadragonViewer extends Component {
       React.cloneElement(
         child,
         {
+          zoomIn: this.zoomIn,
+          zoomOut: this.zoomOut,
           zoomToWorld: this.zoomToWorld,
         },
       )

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -89,7 +89,7 @@ export class OpenSeadragonViewer extends Component {
    */
   componentDidUpdate(prevProps) {
     const {
-      tileSources, viewer, highlightedAnnotations, selectedAnnotations,
+      tileSources, highlightedAnnotations, selectedAnnotations,
     } = this.props;
     const highlightsUpdated = !OpenSeadragonViewer.annotationsMatch(
       highlightedAnnotations, prevProps.highlightedAnnotations,
@@ -123,17 +123,6 @@ export class OpenSeadragonViewer extends Component {
           this.zoomToWorld();
         }
       });
-    } else if (viewer) {
-      const { viewport } = this.viewer;
-
-      if (viewer.x !== viewport.centerSpringX.target.value
-        || viewer.y !== viewport.centerSpringY.target.value) {
-        this.viewer.viewport.panTo(viewer, false);
-      }
-
-      if (viewer.zoom !== viewport.zoomSpring.target.value) {
-        this.viewer.viewport.zoomTo(viewer.zoom, viewer, false);
-      }
     }
   }
 

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -49,7 +49,6 @@ export class OpenSeadragonViewer extends Component {
     this.updateCanvas = () => {};
     this.ref = React.createRef();
     this.onUpdateViewport = this.onUpdateViewport.bind(this);
-    this.onViewportChange = this.onViewportChange.bind(this);
     this.zoomToWorld = this.zoomToWorld.bind(this);
   }
 
@@ -73,7 +72,6 @@ export class OpenSeadragonViewer extends Component {
 
     this.osdCanvasOverlay = new OpenSeadragonCanvasOverlay(this.viewer);
     this.viewer.addHandler('update-viewport', this.onUpdateViewport);
-    this.viewer.addHandler('viewport-change', this.onViewportChange);
 
     if (viewer) {
       this.viewer.viewport.panTo(viewer, false);
@@ -142,6 +140,7 @@ export class OpenSeadragonViewer extends Component {
   /**
    */
   componentWillUnmount() {
+    this.updateViewerLocation();
     this.viewer.removeAllHandlers();
   }
 
@@ -153,17 +152,16 @@ export class OpenSeadragonViewer extends Component {
   }
 
   /**
-   * Forward OSD state to redux
+   * Only update the viewer redux state when explicitly asked to
    */
-  onViewportChange(event) {
+  updateViewerLocation() {
     const { updateViewport, windowId } = this.props;
 
-    const { viewport } = event.eventSource;
-
+    const center = this.viewer.viewport.getCenter();
     updateViewport(windowId, {
-      x: Math.round(viewport.centerSpringX.target.value),
-      y: Math.round(viewport.centerSpringY.target.value),
-      zoom: viewport.zoomSpring.target.value,
+      x: Math.round(center.x),
+      y: Math.round(center.y),
+      zoom: this.viewer.viewport.getZoom(),
     });
   }
 

--- a/src/components/WindowCanvasNavigationControls.js
+++ b/src/components/WindowCanvasNavigationControls.js
@@ -12,14 +12,19 @@ export class WindowCanvasNavigationControls extends Component {
   /** */
   render() {
     const {
-      visible, window, zoomToWorld,
+      visible, window, zoomIn, zoomOut, zoomToWorld,
     } = this.props;
 
     if (!visible) return (<></>);
 
     return (
       <div className={ns('canvas-nav')}>
-        <ZoomControls windowId={window.id} zoomToWorld={zoomToWorld} />
+        <ZoomControls
+          windowId={window.id}
+          zoomIn={zoomIn}
+          zoomOut={zoomOut}
+          zoomToWorld={zoomToWorld}
+        />
         <ViewerNavigation window={window} />
         <ViewerInfo windowId={window.id} />
       </div>
@@ -31,6 +36,8 @@ export class WindowCanvasNavigationControls extends Component {
 WindowCanvasNavigationControls.propTypes = {
   visible: PropTypes.bool,
   window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  zoomIn: PropTypes.func.isRequired,
+  zoomOut: PropTypes.func.isRequired,
   zoomToWorld: PropTypes.func.isRequired,
 };
 

--- a/src/components/ZoomControls.js
+++ b/src/components/ZoomControls.js
@@ -9,48 +9,12 @@ import MiradorMenuButton from '../containers/MiradorMenuButton';
  */
 export class ZoomControls extends Component {
   /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-
-    this.handleZoomInClick = this.handleZoomInClick.bind(this);
-    this.handleZoomOutClick = this.handleZoomOutClick.bind(this);
-  }
-
-  /**
-   * @private
-   */
-  handleZoomInClick() {
-    const { windowId, updateViewport, viewer } = this.props;
-
-    updateViewport(windowId, {
-      x: viewer.x,
-      y: viewer.y,
-      zoom: viewer.zoom * 2,
-    });
-  }
-
-  /**
-   * @private
-   */
-  handleZoomOutClick() {
-    const { windowId, updateViewport, viewer } = this.props;
-
-    updateViewport(windowId, {
-      x: viewer.x,
-      y: viewer.y,
-      zoom: viewer.zoom / 2,
-    });
-  }
-
-  /**
    * render
    * @return
    */
   render() {
     const {
-      showZoomControls, classes, t, zoomToWorld,
+      showZoomControls, classes, t, zoomIn, zoomOut, zoomToWorld,
     } = this.props;
 
     if (!showZoomControls) {
@@ -61,10 +25,10 @@ export class ZoomControls extends Component {
     }
     return (
       <div className={classes.zoom_controls}>
-        <MiradorMenuButton aria-label={t('zoomIn')} onClick={this.handleZoomInClick}>
+        <MiradorMenuButton aria-label={t('zoomIn')} onClick={zoomIn}>
           <AddCircleIcon />
         </MiradorMenuButton>
-        <MiradorMenuButton aria-label={t('zoomOut')} onClick={this.handleZoomOutClick}>
+        <MiradorMenuButton aria-label={t('zoomOut')} onClick={zoomOut}>
           <RemoveCircleIcon />
         </MiradorMenuButton>
         <MiradorMenuButton aria-label={t('zoomReset')} onClick={() => zoomToWorld(false)}>
@@ -79,20 +43,12 @@ ZoomControls.propTypes = {
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   showZoomControls: PropTypes.bool,
   t: PropTypes.func,
-  updateViewport: PropTypes.func,
-  viewer: PropTypes.shape({
-    x: PropTypes.number,
-    y: PropTypes.number,
-    zoom: PropTypes.number,
-  }),
-  windowId: PropTypes.string,
+  zoomIn: PropTypes.func.isRequired,
+  zoomOut: PropTypes.func.isRequired,
   zoomToWorld: PropTypes.func.isRequired,
 };
 
 ZoomControls.defaultProps = {
   showZoomControls: false,
   t: key => key,
-  updateViewport: () => {},
-  viewer: {},
-  windowId: '',
 };


### PR DESCRIPTION
Rather than continuously update redux state that is also passed in as a
prop, this change only makes those redux updates on demand when
explictly called. This increases performance, reduces complexity and
hopefully still accomplishes our state goals. A plugin / or other
component should also be able to explicatly call this instance method if
needed.

Related to #2283 , #2410, #2399 , #2280 
