### PR TITLE
Improve how annotation matching in the OSDViewer component works …

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -61,23 +61,22 @@ describe('OpenSeadragonViewer', () => {
 
   describe('annotationsMatch', () => {
     it('is false if the annotations are a different size', () => {
-      const currentAnnotations = [{ id: 1, resources: [] }];
-      const previousAnnotations = [{ id: 1, resources: [] }, { id: 2, resources: [] }];
+      const currentAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
+      const previousAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }, { id: 2, resources: [{ id: 'rid2' }] }];
 
       expect(
         OpenSeadragonViewer.annotationsMatch(currentAnnotations, previousAnnotations),
       ).toBe(false);
     });
 
-    // TODO: This scenario currently does not work
-    // it('is true if the previous annotation\'s resource IDs all match', () => {
-    //   const currentAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
-    //   const previousAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
-    //
-    //   expect(
-    //     OpenSeadragonViewer.annotationsMatch(currentAnnotations, previousAnnotations),
-    //   ).toBe(true);
-    // });
+    it('is true if the previous annotation\'s resource IDs all match', () => {
+      const currentAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
+      const previousAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
+
+      expect(
+        OpenSeadragonViewer.annotationsMatch(currentAnnotations, previousAnnotations),
+      ).toBe(true);
+    });
 
     it('is true if both are empty', () => {
       expect(OpenSeadragonViewer.annotationsMatch([], [])).toBe(true);
@@ -90,6 +89,15 @@ describe('OpenSeadragonViewer', () => {
       expect(
         OpenSeadragonViewer.annotationsMatch(currentAnnotations, previousAnnotations),
       ).toBe(false);
+    });
+
+    it('returns true if the annotation resources IDs are empty (to prevent unecessary rerender)', () => {
+      const currentAnnotations = [{ id: 1, resources: [] }];
+      const previousAnnotations = [{ id: 1, resources: [] }];
+
+      expect(
+        OpenSeadragonViewer.annotationsMatch(currentAnnotations, previousAnnotations),
+      ).toBe(true);
     });
   });
 

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Paper from '@material-ui/core/Paper';
+import isEqual from 'lodash/isEqual';
 import OpenSeadragon from 'openseadragon';
 import ns from '../config/css-ns';
 import OpenSeadragonCanvasOverlay from '../lib/OpenSeadragonCanvasOverlay';
@@ -20,17 +21,14 @@ export class OpenSeadragonViewer extends Component {
    */
   static annotationsMatch(currentAnnotations, prevAnnotations) {
     if (currentAnnotations.length === 0 && prevAnnotations.length === 0) return true;
-    return currentAnnotations.some((annotation, index) => {
-      if (!prevAnnotations[index]) {
-        return false;
-      }
+    if (currentAnnotations.length !== prevAnnotations.length) return false;
+    return currentAnnotations.every((annotation, index) => {
       const newIds = annotation.resources.map(r => r.id);
       const prevIds = prevAnnotations[index].resources.map(r => r.id);
+      if (newIds.length === 0 && prevIds.length === 0) return true;
+      if (newIds.length !== prevIds.length) return false;
 
-      // The newIds === prevIds is always returning false right now (because javascript)
-      // Using something like lodash's isEqual causes behavior
-      // that was unexpeected when switching annotations and should to be investigated further
-      if ((annotation.id === prevAnnotations[index].id) && (newIds === prevIds)) {
+      if ((annotation.id === prevAnnotations[index].id) && (isEqual(newIds, prevIds))) {
         return true;
       }
       return false;
@@ -105,12 +103,8 @@ export class OpenSeadragonViewer extends Component {
         this.osdCanvasOverlay.clear();
         this.osdCanvasOverlay.resize();
         this.osdCanvasOverlay.canvasUpdate(() => {
-          if (highlightsUpdated) {
-            this.annotationsToContext(highlightedAnnotations, '#00BFFF');
-          }
-          if (selectionsUpdated) {
-            this.annotationsToContext(selectedAnnotations, 'yellow');
-          }
+          this.annotationsToContext(highlightedAnnotations, '#00BFFF');
+          this.annotationsToContext(selectedAnnotations, 'yellow');
         });
       };
       this.viewer.forceRedraw();


### PR DESCRIPTION
… (by using isEqual on resource ID array comparison)

This is to address a `TODO` I left behind in some of the annotation work I did last week.  This should hopefully help cut down on some additional superfluous canvas redraws.