### PR TITLE
Add a consistent lineWidth based off of zoom Fixes #2279

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import OpenSeadragon from 'openseadragon';
+import manifesto from 'manifesto.js';
 import { OpenSeadragonViewer } from '../../../src/components/OpenSeadragonViewer';
 import OpenSeadragonCanvasOverlay from '../../../src/lib/OpenSeadragonCanvasOverlay';
 import Annotation from '../../../src/lib/Annotation';
 import CanvasWorld from '../../../src/lib/CanvasWorld';
+import fixture from '../../fixtures/version-2/019.json';
+
+const canvases = manifesto.create(fixture).getSequences()[0].getCanvases();
 
 jest.mock('openseadragon');
 jest.mock('../../../src/lib/OpenSeadragonCanvasOverlay');
@@ -35,7 +39,7 @@ describe('OpenSeadragonViewer', () => {
         updateViewport={updateViewport}
         t={k => k}
         classes={{ controls: 'controls' }}
-        canvasWorld={new CanvasWorld([])}
+        canvasWorld={new CanvasWorld(canvases)}
       >
         <div className="foo" />
         <div className="bar" />
@@ -138,7 +142,7 @@ describe('OpenSeadragonViewer', () => {
       const fitBounds = jest.fn();
       wrapper.instance().fitBounds = fitBounds;
       wrapper.instance().zoomToWorld();
-      expect(fitBounds).toHaveBeenCalledWith(0, 0, 0, Infinity, true);
+      expect(fitBounds).toHaveBeenCalledWith(0, 0, 5041, 1800, true);
     });
   });
 
@@ -312,6 +316,11 @@ describe('OpenSeadragonViewer', () => {
           strokeRect,
         },
       };
+      wrapper.instance().viewer = {
+        viewport: {
+          getZoom: () => (0.0005),
+        },
+      };
 
       const annotations = [
         new Annotation(
@@ -321,7 +330,7 @@ describe('OpenSeadragonViewer', () => {
       wrapper.instance().annotationsToContext(annotations);
       const context = wrapper.instance().osdCanvasOverlay.context2d;
       expect(context.strokeStyle).toEqual('yellow');
-      expect(context.lineWidth).toEqual(10);
+      expect(context.lineWidth).toEqual(4);
       expect(strokeRect).toHaveBeenCalledWith(10, 10, 100, 200);
     });
   });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -167,13 +167,15 @@ export class OpenSeadragonViewer extends Component {
   annotationsToContext(annotations, color = 'yellow') {
     const { canvasWorld } = this.props;
     const context = this.osdCanvasOverlay.context2d;
+    const zoom = this.viewer.viewport.getZoom(true);
+    const width = canvasWorld.worldBounds()[2];
     annotations.forEach((annotation) => {
       annotation.resources.forEach((resource) => {
         const offset = canvasWorld.offsetByCanvas(resource.targetId);
         const fragment = resource.fragmentSelector;
         fragment[0] += offset.x;
         context.strokeStyle = color;
-        context.lineWidth = 10;
+        context.lineWidth = Math.ceil(10 / (zoom * width));
         context.strokeRect(...fragment);
       });
     });


### PR DESCRIPTION
Based of M2 algorithm 

https://github.com/ProjectMirador/mirador/blob/v2.7.0/js/src/annotations/osd-svg-overlay.js#L725

