### PR TITLE
Pull WindowList out of WorkspaceMenu and into its own button in the Workspace Sidebar

### DIFF
--- a/__tests__/src/components/MiradorMenuButton.test.js
+++ b/__tests__/src/components/MiradorMenuButton.test.js
@@ -54,4 +54,11 @@ describe('MiradorMenuButton', () => {
 
     expect(wrapper.find('WithStyles(Tooltip) WithStyles(IconButton)').props().color).toEqual('inherit');
   });
+
+  it('wraps the child component in a badge if the badge prop is set to true (and passes BadgeProps)', () => {
+    wrapper = createWrapper({ badge: true, BadgeProps: { badgeContent: 3 } });
+
+    expect(wrapper.find('WithStyles(Badge)').props().badgeContent).toEqual(3);
+    expect(wrapper.find('WithStyles(Badge)').first().children().text()).toEqual('icon');
+  });
 });

--- a/__tests__/src/components/WindowListButton.test.js
+++ b/__tests__/src/components/WindowListButton.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import MiradorMenuButton from '../../../src/containers/MiradorMenuButton';
+import WindowList from '../../../src/containers/WindowList';
+import { WindowListButton } from '../../../src/components/WindowListButton';
+
+/**
+ * Helper function to create a shallow wrapper around WindowListButton
+ */
+function createWrapper(props) {
+  return shallow(
+    <WindowListButton
+      t={str => str}
+      windowCount={3}
+      {...props}
+    />,
+  );
+}
+
+describe('WindowListButton', () => {
+  let wrapper;
+
+  it('passes the windowCount as BadgeProps to MiradorMenuButton', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find(MiradorMenuButton).props().BadgeProps).toEqual({ badgeContent: 3 });
+  });
+
+  it('disabled the MiradorMenuButton if the disabled prop is true', () => {
+    wrapper = createWrapper({ disabled: true });
+
+    expect(wrapper.find(MiradorMenuButton).props().disabled).toBe(true);
+  });
+
+  it('toggles the WindowList comonent when clicking on the MiradorMenuButton', () => {
+    wrapper = createWrapper();
+    expect(wrapper.find(WindowList).length).toBe(0);
+    wrapper.find(MiradorMenuButton).simulate('click', { currentTarget: 'blah' });
+    expect(wrapper.find(WindowList).length).toBe(1);
+  });
+});

--- a/__tests__/src/components/WorkspaceMenu.test.js
+++ b/__tests__/src/components/WorkspaceMenu.test.js
@@ -31,22 +31,6 @@ describe('WorkspaceMenu', () => {
     expect(handleClose).toBeCalled();
   });
 
-  describe('handleMenuItemClick', () => {
-    it('sets the anchor state', () => {
-      wrapper.instance().handleMenuItemClick('windowList', { currentTarget: true });
-
-      expect(wrapper.find(WindowList).props().open).toBe(true);
-    });
-  });
-
-  describe('handleMenuItemClose', () => {
-    it('resets the anchor state', () => {
-      wrapper.instance().handleMenuItemClose('windowList')();
-      expect(Boolean(wrapper.state('windowList').anchorEl)).toEqual(false);
-      expect(wrapper.find(WindowList).length).toBe(0);
-    });
-  });
-
   describe('handleZoomToggleClick', () => {
     it('resets the anchor state', () => {
       wrapper.instance().handleZoomToggleClick();

--- a/src/components/MiradorMenuButton.js
+++ b/src/components/MiradorMenuButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Badge from '@material-ui/core/Badge';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import ns from '../config/css-ns';
@@ -12,16 +13,21 @@ import ns from '../config/css-ns';
 export function MiradorMenuButton(props) {
   const { 'aria-label': ariaLabel } = props;
   const {
+    badge,
     children,
     containerId,
     dispatch,
+    BadgeProps,
     TooltipProps,
     ...iconButtonProps
   } = props;
 
   const button = (
     <IconButton {...iconButtonProps}>
-      {children}
+      {badge
+        ? <Badge {...BadgeProps}>{children}</Badge>
+        : children
+      }
     </IconButton>
   );
 
@@ -42,6 +48,8 @@ export function MiradorMenuButton(props) {
 
 MiradorMenuButton.propTypes = {
   'aria-label': PropTypes.string.isRequired,
+  badge: PropTypes.bool,
+  BadgeProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   children: PropTypes.element.isRequired,
   containerId: PropTypes.string.isRequired,
   dispatch: PropTypes.func,
@@ -49,6 +57,8 @@ MiradorMenuButton.propTypes = {
 };
 
 MiradorMenuButton.defaultProps = {
+  badge: false,
+  BadgeProps: {},
   dispatch: () => {},
   TooltipProps: {},
 };

--- a/src/components/WindowList.js
+++ b/src/components/WindowList.js
@@ -27,8 +27,17 @@ export class WindowList extends Component {
     const {
       containerId, handleClose, anchorEl, windows, focusWindow, t,
     } = this.props;
+
     return (
       <Menu
+        anchorOrigin={{
+          horizontal: 'right',
+          vertical: 'top',
+        }}
+        transformOrigin={{
+          horizontal: 'left',
+          vertical: 'top',
+        }}
         id="window-list-menu"
         container={document.querySelector(`#${containerId} .${ns('viewer')}`)}
         anchorEl={anchorEl}

--- a/src/components/WindowListButton.js
+++ b/src/components/WindowListButton.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import BookmarksIcon from '@material-ui/icons/BookmarksSharp';
+import PropTypes from 'prop-types';
+import WindowList from '../containers/WindowList';
+import MiradorMenuButton from '../containers/MiradorMenuButton';
+
+/**
+ * WindowListButton ~
+*/
+export class WindowListButton extends Component {
+  /** */
+  constructor(props) {
+    super(props);
+
+    this.state = { windowListAnchor: null };
+    this.handleClose = this.handleClose.bind(this);
+    this.handleOpen = this.handleOpen.bind(this);
+  }
+
+  /** Set the windowListAnchor to null on window close */
+  handleClose() {
+    this.setState({ windowListAnchor: null });
+  }
+
+  /** Set the windowListAnchor to the event's current target  */
+  handleOpen(event) {
+    this.setState({ windowListAnchor: event.currentTarget });
+  }
+
+  /**
+   * Returns the rendered component
+  */
+  render() {
+    const { disabled, t, windowCount } = this.props;
+    const { windowListAnchor } = this.state;
+
+    return (
+      <>
+        <MiradorMenuButton
+          aria-haspopup="true"
+          aria-label={t('listAllOpenWindows')}
+          aria-owns={windowListAnchor ? 'window-list' : null}
+          disabled={disabled}
+          badge
+          BadgeProps={{ badgeContent: windowCount }}
+          onClick={e => this.handleOpen(e)}
+        >
+          <BookmarksIcon />
+        </MiradorMenuButton>
+
+        {Boolean(windowListAnchor) && (
+          <WindowList
+            anchorEl={windowListAnchor}
+            id="window-list"
+            open={Boolean(windowListAnchor)}
+            handleClose={this.handleClose}
+          />
+        )}
+      </>
+    );
+  }
+}
+
+WindowListButton.propTypes = {
+  disabled: PropTypes.bool,
+  t: PropTypes.func.isRequired,
+  windowCount: PropTypes.number.isRequired,
+};
+WindowListButton.defaultProps = {
+  disabled: false,
+};

--- a/src/components/WorkspaceControlPanelButtons.js
+++ b/src/components/WorkspaceControlPanelButtons.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import WorkspaceFullScreenButton from '../containers/WorkspaceFullScreenButton';
 import WorkspaceAddButton from '../containers/WorkspaceAddButton';
 import WorkspaceMenuButton from '../containers/WorkspaceMenuButton';
+import WindowListButton from '../containers/WindowListButton';
 
 /** Renders plugins */
 const PluginHook = (props) => {
@@ -26,6 +27,7 @@ export class WorkspaceControlPanelButtons extends Component {
     return (
       <>
         <WorkspaceAddButton />
+        <WindowListButton />
         <WorkspaceMenuButton />
         <WorkspaceFullScreenButton />
         <PluginHook {...this.props} />

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -8,7 +8,6 @@ import SaveAltIcon from '@material-ui/icons/SaveAltSharp';
 import PropTypes from 'prop-types';
 import LanguageSettings from '../containers/LanguageSettings';
 import { NestedMenu } from './NestedMenu';
-import WindowList from '../containers/WindowList';
 import WorkspaceSelectionDialog from '../containers/WorkspaceSelectionDialog';
 import WorkspaceExport from '../containers/WorkspaceExport';
 import WorkspaceImport from '../containers/WorkspaceImport';
@@ -28,7 +27,6 @@ export class WorkspaceMenu extends Component {
       exportWorkspace: {},
       importWorkspace: {},
       toggleZoom: {},
-      windowList: {},
       workspaceSelection: {},
     };
     this.handleMenuItemClick = this.handleMenuItemClick.bind(this);
@@ -83,7 +81,6 @@ export class WorkspaceMenu extends Component {
     const {
       importWorkspace,
       changeTheme,
-      windowList,
       toggleZoom,
       exportWorkspace,
       workspaceSelection,
@@ -108,13 +105,6 @@ export class WorkspaceMenu extends Component {
           open={Boolean(anchorEl)}
           onClose={handleClose}
         >
-          <MenuItem
-            aria-haspopup="true"
-            onClick={(e) => { this.handleMenuItemClick('windowList', e); handleClose(e); }}
-            aria-owns={windowList.anchorEl ? 'window-list-menu' : undefined}
-          >
-            <Typography variant="body1">{t('listAllOpenWindows')}</Typography>
-          </MenuItem>
           <MenuItem
             aria-haspopup="true"
             onClick={(e) => { this.handleZoomToggleClick(e); handleClose(e); }}
@@ -166,13 +156,6 @@ export class WorkspaceMenu extends Component {
             <Typography variant="body1">{t('importWorkspace')}</Typography>
           </MenuItem>
         </Menu>
-        {Boolean(windowList.anchorEl) && (
-          <WindowList
-            anchorEl={windowList.anchorEl}
-            open={Boolean(windowList.anchorEl)}
-            handleClose={this.handleMenuItemClose('windowList')}
-          />
-        )}
         {Boolean(changeTheme.open) && (
           <ChangeThemeDialog
             container={container}

--- a/src/containers/WindowListButton.js
+++ b/src/containers/WindowListButton.js
@@ -1,0 +1,19 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import { withPlugins } from '../extend';
+import { WindowListButton } from '../components/WindowListButton';
+
+/** */
+const mapStateToProps = ({ windows, workspace }) => ({
+  disabled: workspace.isWorkspaceAddVisible,
+  windowCount: Object.keys(windows).length,
+});
+
+const enhance = compose(
+  withTranslation(),
+  connect(mapStateToProps, null),
+  withPlugins('WindowListButton'),
+);
+
+export default enhance(WindowListButton);


### PR DESCRIPTION
Part of #2376 

Submitting this partial PR because I have gotten distracted on fixing up some previous work.  Will continue to make other changes in additional PRs, but this felt like it could stand on its own (or un-assign)

![WindowListMenuButton](https://user-images.githubusercontent.com/96776/55916461-49f27700-5ba1-11e9-81d1-866c55b36bbf.gif)