### PR TITLE
Add an openCompanionWindow i18n key for the attribution/rights context.

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -71,6 +71,7 @@
     "of": "of",
     "off": "Off",
     "openCompanionWindow_annotations": "Annotations",
+    "openCompanionWindow_attribution": "Rights",
     "openCompanionWindow_canvas": "Index",
     "openCompanionWindow_info": "Information",
     "openInCompanionWindow": "Open in separate panel",


### PR DESCRIPTION
Noticed this while poking around

## Before
<img width="381" alt="before" src="https://user-images.githubusercontent.com/96776/55919240-04867780-5baa-11e9-9722-c31cd0d4b7b7.png">

## After
<img width="291" alt="after" src="https://user-images.githubusercontent.com/96776/55919241-04867780-5baa-11e9-8064-89e139056c4c.png">
