### PR TITLE
Update color of close Add Resources panel button

### DIFF
--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -119,6 +119,7 @@ export class WorkspaceAdd extends React.Component {
                 <MiradorMenuButton
                   aria-label={t('closeAddResourceForm')}
                   className={classes.menuButton}
+                  color="inherit"
                 >
                   <ExpandMoreIcon />
                 </MiradorMenuButton>


### PR DESCRIPTION
Closes #2452

This PR ties the collapse Add Resources panel button to the local font color. 

### Before
<img width="254" alt="Screen Shot 2019-04-10 at 3 53 43 PM" src="https://user-images.githubusercontent.com/101482/55918982-1582b900-5ba9-11e9-988a-cc153415e1f7.png">

### After
<img width="254" alt="Screen Shot 2019-04-10 at 3 56 06 PM" src="https://user-images.githubusercontent.com/101482/55918999-2c291000-5ba9-11e9-8367-82f8fc9510e0.png">