### PR TITLE
Move Paper wrapper to be consistent with component it is styling

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -38,7 +38,6 @@ describe('OpenSeadragonViewer', () => {
         config={{}}
         updateViewport={updateViewport}
         t={k => k}
-        classes={{ controls: 'controls' }}
         canvasWorld={new CanvasWorld(canvases)}
       >
         <div className="foo" />
@@ -58,9 +57,6 @@ describe('OpenSeadragonViewer', () => {
     expect(wrapper.find('.bar').props()).toEqual(expect.objectContaining({
       zoomToWorld: wrapper.instance().zoomToWorld,
     }));
-  });
-  it('renders viewer controls', () => {
-    expect(wrapper.find('.controls').length).toBe(1);
   });
 
   describe('annotationsMatch', () => {

--- a/__tests__/src/components/WindowCanvasNavigationControls.test.js
+++ b/__tests__/src/components/WindowCanvasNavigationControls.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import Paper from '@material-ui/core/Paper';
 import { WindowCanvasNavigationControls } from '../../../src/components/WindowCanvasNavigationControls';
 import ViewerInfo from '../../../src/containers/ViewerInfo';
 import ViewerNavigation from '../../../src/containers/ViewerNavigation';
@@ -26,11 +27,11 @@ describe('WindowCanvasNavigationControls', () => {
   it('renders properly', () => {
     wrapper = createWrapper({ zoomToWorld });
     expect(wrapper.matchesElement(
-      <div>
+      <Paper square>
         <ZoomControls zoomToWorld={zoomToWorld} />
         <ViewerNavigation />
         <ViewerInfo />
-      </div>,
+      </Paper>,
     )).toBe(true);
   });
 

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Paper from '@material-ui/core/Paper';
 import isEqual from 'lodash/isEqual';
 import OpenSeadragon from 'openseadragon';
 import ns from '../config/css-ns';
@@ -250,7 +249,7 @@ export class OpenSeadragonViewer extends Component {
    */
   render() {
     const {
-      windowId, children, classes, label, t,
+      windowId, children, label, t,
     } = this.props;
 
     const enhancedChildren = React.Children.map(children, child => (
@@ -270,9 +269,7 @@ export class OpenSeadragonViewer extends Component {
           ref={this.ref}
           aria-label={t('item', { label })}
         >
-          <Paper square className={classes.controls} elevation={0}>
-            { enhancedChildren }
-          </Paper>
+          { enhancedChildren }
         </section>
       </>
     );
@@ -281,7 +278,6 @@ export class OpenSeadragonViewer extends Component {
 
 OpenSeadragonViewer.defaultProps = {
   children: null,
-  classes: {},
   highlightedAnnotations: [],
   label: null,
   selectedAnnotations: [],
@@ -293,7 +289,6 @@ OpenSeadragonViewer.defaultProps = {
 OpenSeadragonViewer.propTypes = {
   canvasWorld: PropTypes.instanceOf(CanvasWorld).isRequired,
   children: PropTypes.node,
-  classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   highlightedAnnotations: PropTypes.arrayOf(PropTypes.object),
   label: PropTypes.string,
   selectedAnnotations: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/WindowCanvasNavigationControls.js
+++ b/src/components/WindowCanvasNavigationControls.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Paper from '@material-ui/core/Paper';
 import ZoomControls from '../containers/ZoomControls';
 import ViewerInfo from '../containers/ViewerInfo';
 import ViewerNavigation from '../containers/ViewerNavigation';
@@ -22,15 +23,13 @@ export class WindowCanvasNavigationControls extends Component {
   /** */
   render() {
     const {
-      visible, window, zoomToWorld,
+      classes, visible, window, zoomToWorld,
     } = this.props;
 
     if (!visible) return (<></>);
 
     return (
-      <div
-        className={classNames(ns('canvas-nav'), this.canvasNavControlsAreStacked() ? ns('canvas-nav-stacked') : null)}
-      >
+      <Paper square className={classNames(classes.controls, ns('canvas-nav'), this.canvasNavControlsAreStacked() ? ns('canvas-nav-stacked') : null)} elevation={0}>
         <ZoomControls
           displayDivider={!this.canvasNavControlsAreStacked()}
           windowId={window.id}
@@ -38,13 +37,14 @@ export class WindowCanvasNavigationControls extends Component {
         />
         <ViewerNavigation window={window} />
         <ViewerInfo windowId={window.id} />
-      </div>
+      </Paper>
     );
   }
 }
 
 
 WindowCanvasNavigationControls.propTypes = {
+  classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   size: PropTypes.shape({ width: PropTypes.number }).isRequired,
   visible: PropTypes.bool,
   window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
@@ -52,5 +52,6 @@ WindowCanvasNavigationControls.propTypes = {
 };
 
 WindowCanvasNavigationControls.defaultProps = {
+  classes: {},
   visible: true,
 };

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -1,8 +1,6 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import { withStyles } from '@material-ui/core';
-import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withPlugins } from '../extend';
 import { OpenSeadragonViewer } from '../components/OpenSeadragonViewer';
 import * as actions from '../state/actions';
@@ -37,23 +35,7 @@ const mapDispatchToProps = {
   updateViewport: actions.updateViewport,
 };
 
-/**
- *
- * @param theme
- * @returns {{windowSideBarHeading: *}}
- */
-const styles = theme => ({
-  controls: {
-    backgroundColor: fade(theme.palette.background.paper, 0.5),
-    bottom: 0,
-    position: 'absolute',
-    width: '100%',
-    zIndex: 50,
-  },
-});
-
 const enhance = compose(
-  withStyles(styles),
   withTranslation(),
   connect(mapStateToProps, mapDispatchToProps),
   withPlugins('OpenSeadragonViewer'),

--- a/src/containers/WindowCanvasNavigationControls.js
+++ b/src/containers/WindowCanvasNavigationControls.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withSize } from 'react-sizeme';
+import { withStyles } from '@material-ui/core';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withPlugins } from '../extend';
 import {
   getCanvasLabel,
@@ -18,8 +20,23 @@ const mapStateToProps = (state, { windowId }) => ({
   window: getWindow(state, { windowId }),
 });
 
+/**
+ *
+ * @param theme
+ */
+const styles = theme => ({
+  controls: {
+    backgroundColor: fade(theme.palette.background.paper, 0.5),
+    bottom: 0,
+    position: 'absolute',
+    width: '100%',
+    zIndex: 50,
+  },
+});
+
 const enhance = compose(
   connect(mapStateToProps),
+  withStyles(styles),
   withSize(),
   withPlugins('WindowCanvasNavigationControls'),
 );


### PR DESCRIPTION
When working on a plugin where I wanted to wrap `WindowCanvasNavigationControls` I noticed that the `Paper` componenet styling them was actually part of another component. I wasn't sure if there was a reason for this, but I think this approach works in all cases.