### PR TITLE
Respect startcanvas metadata

### DIFF
--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -10,13 +10,13 @@ function createWrapper(props) {
   return shallow(
     <ThumbnailCanvasGrouping
       index={1}
+      canvasIndex={1}
       classes={{}}
       style={{
         height: 90,
         width: 100,
       }}
       window={{
-        canvasIndex: 1,
         id: 'foobar',
       }}
       {...props}

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -12,9 +12,9 @@ function createWrapper(props) {
       canvasGroupings={
         new CanvasGroupings(manifesto.create(manifestJson).getSequences()[0].getCanvases())
       }
+      canvasIndex={1}
       classes={{}}
       window={{
-        canvasIndex: 1,
         id: 'foobar',
       }}
       config={{ thumbnailNavigation: { height: 150, width: 100 } }}
@@ -48,8 +48,8 @@ describe('ThumbnailNavigation', () => {
     const mockReset = jest.fn();
     wrapper.instance().gridRef = { current: { resetAfterIndex: mockReset } };
     wrapper.setProps({
+      canvasIndex: 1,
       window: {
-        canvasIndex: 1,
         id: 'foobar',
         thumbnailNavigationPosition: 'far-bottom',
         view: 'book',
@@ -61,8 +61,8 @@ describe('ThumbnailNavigation', () => {
     const mockScroll = jest.fn();
     wrapper.instance().gridRef = { current: { scrollToItem: mockScroll } };
     wrapper.setProps({
+      canvasIndex: 3,
       window: {
-        canvasIndex: 3,
         id: 'foobar',
         thumbnailNavigationPosition: 'far-bottom',
       },
@@ -85,8 +85,8 @@ describe('ThumbnailNavigation', () => {
       const mockReset = jest.fn();
       wrapper.instance().gridRef = { current: { resetAfterIndex: mockReset } };
       wrapper.setProps({
+        canvasIndex: 1,
         window: {
-          canvasIndex: 1,
           id: 'foobar',
           thumbnailNavigationPosition: 'far-bottom',
           view: 'book',
@@ -114,10 +114,10 @@ describe('ThumbnailNavigation', () => {
     const rightSetCanvas = jest.fn();
     beforeEach(() => {
       rightWrapper = createWrapper({
+        canvasIndex: 1,
         position: 'far-right',
         setCanvas: rightSetCanvas,
         window: {
-          canvasIndex: 1,
           id: 'foobat',
         },
       });

--- a/__tests__/src/components/ViewerNavigation.test.js
+++ b/__tests__/src/components/ViewerNavigation.test.js
@@ -21,9 +21,9 @@ describe('ViewerNavigation', () => {
   beforeEach(() => {
     setCanvas = jest.fn();
     wrapper = createWrapper({
+      canvasIndex: 0,
       setCanvas,
       window: {
-        canvasIndex: 0,
         id: 'foo',
       },
     });
@@ -44,8 +44,8 @@ describe('ViewerNavigation', () => {
   describe('when next canvases are not present', () => {
     it('nextCanvas button is disabled', () => {
       const endWrapper = createWrapper({
+        canvasIndex: 1,
         window: {
-          canvasIndex: 1,
           id: 'foo',
         },
       });
@@ -65,9 +65,9 @@ describe('ViewerNavigation', () => {
     it('setCanvas function is called after click for next', () => {
       wrapper = createWrapper({
         canvases: [1, 2, 3],
+        canvasIndex: 0,
         setCanvas,
         window: {
-          canvasIndex: 0,
           id: 'foo',
           view: 'book',
         },
@@ -77,9 +77,9 @@ describe('ViewerNavigation', () => {
     });
     it('setCanvas function is called after click for previous', () => {
       wrapper = createWrapper({
+        canvasIndex: 5,
         setCanvas,
         window: {
-          canvasIndex: 5,
           id: 'foo',
           view: 'book',
         },

--- a/__tests__/src/components/WindowViewer.test.js
+++ b/__tests__/src/components/WindowViewer.test.js
@@ -12,7 +12,6 @@ import otherContentFixture from '../../fixtures/version-2/299843.json';
 let currentCanvases = manifesto.create(fixture).getSequences()[0].getCanvases();
 
 let mockWindow = {
-  canvasIndex: 0,
   view: 'single',
 };
 
@@ -20,6 +19,7 @@ let mockWindow = {
 function createWrapper(props) {
   return shallow(
     <WindowViewer
+      canvasIndex={0}
       canvasLabel="label"
       infoResponses={{}}
       fetchInfoResponse={() => {}}
@@ -49,6 +49,7 @@ describe('WindowViewer', () => {
       it('isFetching is false', () => {
         wrapper = createWrapper(
           {
+            canvasIndex: 1,
             infoResponses: {
               'https://stacks.stanford.edu/image/iiif/fr426cg9537%2FSC1094_s3_b14_f17_Cats_1976_0005': {
                 isFetching: false,
@@ -58,7 +59,6 @@ describe('WindowViewer', () => {
               },
             },
             window: {
-              canvasIndex: 1,
               view: 'book',
             },
           },
@@ -68,6 +68,7 @@ describe('WindowViewer', () => {
       it('infoResponse is undefined', () => {
         wrapper = createWrapper(
           {
+            canvasIndex: 1,
             infoResponses: {
               foo: {
                 isFetching: false,
@@ -77,7 +78,6 @@ describe('WindowViewer', () => {
               },
             },
             window: {
-              canvasIndex: 1,
               view: 'book',
             },
           },
@@ -87,6 +87,7 @@ describe('WindowViewer', () => {
       it('error is not present', () => {
         wrapper = createWrapper(
           {
+            canvasIndex: 1,
             infoResponses: {
               'https://stacks.stanford.edu/image/iiif/fr426cg9537%2FSC1094_s3_b14_f17_Cats_1976_0005': {
                 isFetching: false,
@@ -97,7 +98,6 @@ describe('WindowViewer', () => {
               },
             },
             window: {
-              canvasIndex: 1,
               view: 'book',
             },
           },
@@ -116,11 +116,11 @@ describe('WindowViewer', () => {
       currentCanvases = [canvases[0]];
 
       mockWindow = {
-        canvasIndex: 0,
         view: 'single',
       };
       wrapper = createWrapper(
         {
+          canvasIndex: 0,
           currentCanvases,
           fetchInfoResponse: mockFnCanvas0,
           window: mockWindow,
@@ -131,9 +131,10 @@ describe('WindowViewer', () => {
       currentCanvases = [canvases[2]];
       wrapper = createWrapper(
         {
+          canvasIndex: 2,
           currentCanvases,
           fetchInfoResponse: mockFnCanvas2,
-          window: { canvasIndex: 2, view: 'single' },
+          window: { view: 'single' },
         },
       );
       expect(mockFnCanvas2).toHaveBeenCalledTimes(0);
@@ -156,14 +157,18 @@ describe('WindowViewer', () => {
       const canvases = manifesto.create(emptyCanvasFixture).getSequences()[0].getCanvases();
       currentCanvases = [canvases[2]];
       mockWindow = {
-        canvasIndex: 2,
         view: 'single',
       };
       wrapper = createWrapper(
-        { currentCanvases, fetchInfoResponse: mockFn, window: mockWindow },
+        {
+          canvasIndex: 2,
+          currentCanvases,
+          fetchInfoResponse: mockFn,
+          window: mockWindow,
+        },
       );
 
-      wrapper.setProps({ currentCanvases: [canvases[3]], window: { canvasIndex: 3, view: 'single' } });
+      wrapper.setProps({ canvasIndex: 3, currentCanvases: [canvases[3]], window: { view: 'single' } });
 
       expect(mockFn).toHaveBeenCalledTimes(0);
     });

--- a/__tests__/src/selectors/canvases.test.js
+++ b/__tests__/src/selectors/canvases.test.js
@@ -1,60 +1,12 @@
 import manifestFixture001 from '../../fixtures/version-2/001.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import {
-  getSelectedCanvas,
   getSelectedCanvases,
   getCanvas,
   getCanvasLabel,
   selectCanvasAuthService,
   selectNextAuthService,
 } from '../../../src/state/selectors/canvases';
-
-describe('getSelectedCanvas', () => {
-  const state = {
-    manifests: {
-      x: {
-        id: 'x',
-        json: manifestFixture019,
-      },
-    },
-    windows: {
-      a: {
-        canvasIndex: 1,
-        id: 'a',
-        manifestId: 'x',
-      },
-    },
-  };
-
-  const noManifestationState = {
-    manifests: {
-      x: {
-        id: 'x',
-      },
-    },
-    windows: {
-      a: {
-        canvasIndex: 1,
-        id: 'a',
-        manifestId: 'x',
-      },
-    },
-  };
-
-  it('should return canvas based on the canvas index stored window state', () => {
-    const selectedCanvas = getSelectedCanvas(state, { windowId: 'a' });
-
-    expect(selectedCanvas.id).toEqual(
-      'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
-    );
-  });
-
-  it('should return undefined when there is no manifestation to get a canvas from', () => {
-    const selectedCanvas = getSelectedCanvas(noManifestationState, { windowId: 'a' });
-
-    expect(selectedCanvas).toBeUndefined();
-  });
-});
 
 describe('getSelectedCanvases', () => {
   const state = {
@@ -125,12 +77,12 @@ describe('getCanvas', () => {
     expect(received.id).toBe('https://iiif.bodleian.ox.ac.uk/iiif/canvas/9cca8fdd-4a61-4429-8ac1-f648764b4d6d.json');
   });
 
-  it('does nothing if an id or index is not provided', () => {
+  it('returns the default canvas if an id or index is not provided', () => {
     const state = { manifests: { a: { json: manifestFixture001 } } };
     const received = getCanvas(state, {
       manifestId: 'a',
     });
-    expect(received).toBeUndefined();
+    expect(received.index).toBe(0);
   });
 });
 

--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -14,6 +14,7 @@ import {
   getManifestDescription,
   getManifestHomepage,
   getManifestProvider,
+  getManifestStartCanvasIndex,
   getManifestTitle,
   getManifestThumbnail,
   getManifestMetadata,
@@ -381,5 +382,56 @@ describe('getRights', () => {
     const state = { manifests: { x: { json: manifest } } };
     const received = getRights(state, { manifestId: 'x' });
     expect(received).toEqual(['http://example.com']);
+  });
+});
+
+describe('getManifestStartCanvasIndex', () => {
+  it('gets the startCanvas index for a IIIF v2 manifest', () => {
+    const manifest = {
+      '@context': 'http://iiif.io/api/presentation/2/context.json',
+      '@id':
+       'http://iiif.io/api/presentation/2.1/example/fixtures/19/manifest.json',
+      '@type': 'sc:Manifest',
+      sequences: [{
+        canvases: [
+          {
+            '@id': 'http://example.com/1',
+          },
+          {
+            '@id': 'http://example.com/2',
+          },
+        ],
+        startCanvas: 'http://example.com/2',
+      }],
+    };
+    const state = { manifests: { x: { json: manifest } } };
+    expect(getManifestStartCanvasIndex(state, { manifestId: 'x' })).toEqual(1);
+  });
+
+  it('gets the start data for a IIIF v3 manifest', () => {
+    const manifest = {
+      '@context': 'http://iiif.io/api/presentation/2/context.json',
+      '@id':
+       'http://iiif.io/api/presentation/2.1/example/fixtures/19/manifest.json',
+      '@type': 'sc:Manifest',
+      sequences: [{
+        canvases: [
+          {
+            '@id': 'http://example.com/1',
+          },
+          {
+            '@id': 'http://example.com/2',
+          },
+        ],
+      }],
+      start: { source: 'http://example.com/2' },
+    };
+    const state = { manifests: { x: { json: manifest } } };
+    expect(getManifestStartCanvasIndex(state, { manifestId: 'x' })).toEqual(1);
+  });
+
+  it('is undefined if no start canvas is specified', () => {
+    const state = { manifests: { x: { json: manifestFixture001 } } };
+    expect(getManifestStartCanvasIndex(state, { manifestId: 'x' })).toEqual(undefined);
   });
 });

--- a/__tests__/src/selectors/windows.test.js
+++ b/__tests__/src/selectors/windows.test.js
@@ -12,6 +12,7 @@ import {
   getViewer,
   getWindowDraggability,
   selectCompanionWindowDimensions,
+  getCanvasIndex,
 } from '../../../src/state/selectors/windows';
 
 
@@ -38,6 +39,35 @@ describe('getWindowTitles', () => {
   });
 });
 
+describe('getCanvasIndex', () => {
+  it('returns the index if provided', () => {
+    expect(getCanvasIndex({}, { canvasIndex: 25 })).toEqual(25);
+  });
+  it('returns the current canvasIndex for the window if provided', () => {
+    const state = {
+      windows: {
+        a: { canvasIndex: 13 },
+      },
+    };
+
+    expect(getCanvasIndex(state, { windowId: 'a' })).toEqual(13);
+  });
+  it('returns the default canvasIndex for the manifest', () => {
+    const state = {
+      manifests: {
+        x: { json: { ...manifestFixture019, start: { id: 'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1' } } },
+      },
+      windows: {
+        a: { manifestId: 'x' },
+      },
+    };
+
+    expect(getCanvasIndex(state, { windowId: 'a' })).toEqual(1);
+  });
+  it('defaults to the first canvas', () => {
+    expect(getCanvasIndex({}, {})).toEqual(0);
+  });
+});
 
 describe('getThumbnailNavigationPosition', () => {
   const state = {

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -32,7 +32,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
   /** */
   render() {
     const {
-      index, style, data, classes, window,
+      index, style, data, classes, canvasIndex,
     } = this.props;
     const {
       canvasGroupings, position, height,
@@ -68,7 +68,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
             classes.canvas,
             {
               [classes.currentCanvas]: currentGroupings
-                .map(canvas => canvas.index).includes(window.canvasIndex),
+                .map(canvas => canvas.index).includes(canvasIndex),
             },
           )}
         >
@@ -86,6 +86,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
 }
 
 ThumbnailCanvasGrouping.propTypes = {
+  canvasIndex: PropTypes.number.isRequired,
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   data: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   index: PropTypes.number.isRequired,

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -30,12 +30,12 @@ export class ThumbnailNavigation extends Component {
    * of the grids
    */
   componentDidUpdate(prevProps) {
-    const { position, window } = this.props;
+    const { canvasIndex, position, window } = this.props;
     if (prevProps.window.view !== window.view && position !== 'off') {
       this.gridRef.current.resetAfterIndex(0);
     }
-    if (prevProps.window.canvasIndex !== window.canvasIndex) {
-      let index = window.canvasIndex;
+    if (prevProps.canvasIndex !== canvasIndex) {
+      let index = canvasIndex;
       if (window.view === 'book') index = Math.ceil(index / 2);
       this.gridRef.current.scrollToItem(index, 'center');
     }
@@ -149,33 +149,33 @@ export class ThumbnailNavigation extends Component {
   /**
    */
   nextCanvas() {
-    const { window, setCanvas } = this.props;
+    const { window, canvasIndex, setCanvas } = this.props;
     if (this.hasNextCanvas()) {
-      setCanvas(window.id, window.canvasIndex + this.canvasIncrementor());
+      setCanvas(window.id, canvasIndex + this.canvasIncrementor());
     }
   }
 
   /**
    */
   hasNextCanvas() {
-    const { window, canvasGroupings } = this.props;
-    return window.canvasIndex < canvasGroupings.canvases.length - this.canvasIncrementor();
+    const { canvasIndex, canvasGroupings } = this.props;
+    return canvasIndex < canvasGroupings.canvases.length - this.canvasIncrementor();
   }
 
   /**
    */
   previousCanvas() {
-    const { window, setCanvas } = this.props;
+    const { window, canvasIndex, setCanvas } = this.props;
     if (this.hasPreviousCanvas()) {
-      setCanvas(window.id, Math.max(0, window.canvasIndex - this.canvasIncrementor()));
+      setCanvas(window.id, Math.max(0, canvasIndex - this.canvasIncrementor()));
     }
   }
 
   /**
    */
   hasPreviousCanvas() {
-    const { window } = this.props;
-    return window.canvasIndex > 0;
+    const { canvasIndex } = this.props;
+    return canvasIndex > 0;
   }
 
   /**
@@ -248,6 +248,7 @@ export class ThumbnailNavigation extends Component {
 
 ThumbnailNavigation.propTypes = {
   canvasGroupings: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  canvasIndex: PropTypes.number.isRequired,
   classes: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   position: PropTypes.string.isRequired,

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -19,33 +19,33 @@ export class ViewerNavigation extends Component {
   /**
    */
   nextCanvas() {
-    const { window, setCanvas } = this.props;
+    const { window, canvasIndex, setCanvas } = this.props;
     if (this.hasNextCanvas()) {
-      setCanvas(window.id, window.canvasIndex + this.canvasIncrementor());
+      setCanvas(window.id, canvasIndex + this.canvasIncrementor());
     }
   }
 
   /**
    */
   hasNextCanvas() {
-    const { window, canvases } = this.props;
-    return window.canvasIndex < canvases.length - this.canvasIncrementor();
+    const { canvasIndex, canvases } = this.props;
+    return canvasIndex < canvases.length - this.canvasIncrementor();
   }
 
   /**
    */
   previousCanvas() {
-    const { window, setCanvas } = this.props;
+    const { window, canvasIndex, setCanvas } = this.props;
     if (this.hasPreviousCanvas()) {
-      setCanvas(window.id, Math.max(0, window.canvasIndex - this.canvasIncrementor()));
+      setCanvas(window.id, Math.max(0, canvasIndex - this.canvasIncrementor()));
     }
   }
 
   /**
    */
   hasPreviousCanvas() {
-    const { window } = this.props;
-    return window.canvasIndex > 0;
+    const { canvasIndex } = this.props;
+    return canvasIndex > 0;
   }
 
   /**
@@ -91,6 +91,7 @@ export class ViewerNavigation extends Component {
 
 ViewerNavigation.propTypes = {
   canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  canvasIndex: PropTypes.number.isRequired,
   setCanvas: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -37,11 +37,11 @@ export class WindowViewer extends Component {
    */
   componentDidUpdate(prevProps) {
     const {
-      currentCanvases, window, fetchInfoResponse, fetchAnnotation,
+      canvasIndex, currentCanvases, window, fetchInfoResponse, fetchAnnotation,
     } = this.props;
 
     if (prevProps.window.view !== window.view
-      || (prevProps.window.canvasIndex !== window.canvasIndex && !this.infoResponseIsInStore())
+      || (prevProps.canvasIndex !== canvasIndex && !this.infoResponseIsInStore())
     ) {
       currentCanvases.forEach((canvas) => {
         const manifestoCanvas = new ManifestoCanvas(canvas);
@@ -120,6 +120,7 @@ export class WindowViewer extends Component {
 }
 
 WindowViewer.propTypes = {
+  canvasIndex: PropTypes.number.isRequired,
   currentCanvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   fetchAnnotation: PropTypes.func.isRequired,
   fetchInfoResponse: PropTypes.func.isRequired,

--- a/src/containers/GalleryView.js
+++ b/src/containers/GalleryView.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend';
 import { GalleryView } from '../components/GalleryView';
-import { getManifestCanvases, getSelectedCanvasIndex } from '../state/selectors';
+import { getManifestCanvases, getCanvasIndex } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -13,7 +13,7 @@ import { getManifestCanvases, getSelectedCanvasIndex } from '../state/selectors'
 const mapStateToProps = (state, { windowId }) => (
   {
     canvases: getManifestCanvases(state, { windowId }),
-    selectedCanvasIndex: getSelectedCanvasIndex(state, { windowId }),
+    selectedCanvasIndex: getCanvasIndex(state, { windowId }),
   }
 );
 

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -21,7 +21,7 @@ import {
 const mapStateToProps = (state, { windowId }) => ({
   canvasWorld: new CanvasWorld(getSelectedCanvases(state, { windowId })),
   highlightedAnnotations: getHighlightedAnnotationsOnCanvases(state, { windowId }),
-  label: getCanvasLabel(state, { canvasIndex: 'selected', windowId }),
+  label: getCanvasLabel(state, { windowId }),
   selectedAnnotations: getSelectedAnnotationsOnCanvases(state, { windowId }),
   viewer: getViewer(state, { windowId }),
 });

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
-import { getWindow } from '../state/selectors';
+import { getWindow, getCanvasIndex } from '../state/selectors';
 import { ThumbnailCanvasGrouping } from '../components/ThumbnailCanvasGrouping';
 
 /**
@@ -22,6 +22,7 @@ const mapDispatchToProps = {
  * @private
  */
 const mapStateToProps = (state, { data }) => ({
+  canvasIndex: getCanvasIndex(state, { windowId: data.windowId }),
   window: getWindow(state, { windowId: data.windowId }),
 });
 

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -6,8 +6,7 @@ import { withPlugins } from '../extend';
 import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
 import { ThumbnailNavigation } from '../components/ThumbnailNavigation';
-import { getWindow } from '../state/selectors/windows';
-import { getManifestCanvases } from '../state/selectors/manifests';
+import { getManifestCanvases, getCanvasIndex, getWindow } from '../state/selectors';
 
 /**
  * mapStateToProps - used to hook up state to props
@@ -19,6 +18,7 @@ const mapStateToProps = (state, { windowId }) => ({
     getManifestCanvases(state, { windowId }),
     state.windows[windowId].view,
   ),
+  canvasIndex: getCanvasIndex(state, { windowId }),
   config: state.config,
   position: state.companionWindows[state.windows[windowId].thumbnailNavigationId].position,
   window: getWindow(state, { windowId }),

--- a/src/containers/ViewerInfo.js
+++ b/src/containers/ViewerInfo.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import { ViewerInfo } from '../components/ViewerInfo';
-import { getCanvasLabel, getManifestCanvases, getWindow } from '../state/selectors';
+import { getCanvasLabel, getManifestCanvases, getCanvasIndex } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -13,7 +13,7 @@ import { getCanvasLabel, getManifestCanvases, getWindow } from '../state/selecto
 const mapStateToProps = (state, props) => {
   const { windowId } = props;
   const canvases = getManifestCanvases(state, { windowId });
-  const { canvasIndex } = getWindow(state, { windowId });
+  const canvasIndex = getCanvasIndex(state, { windowId });
 
   return {
     canvasCount: canvases.length,

--- a/src/containers/ViewerNavigation.js
+++ b/src/containers/ViewerNavigation.js
@@ -3,12 +3,13 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
-import { getManifestCanvases } from '../state/selectors';
+import { getManifestCanvases, getCanvasIndex } from '../state/selectors';
 import { ViewerNavigation } from '../components/ViewerNavigation';
 
 /** */
 const mapStateToProps = (state, { window }) => ({
   canvases: getManifestCanvases(state, { windowId: window.id }),
+  canvasIndex: getCanvasIndex(state, { windowId: window.id }),
 });
 
 /**

--- a/src/containers/WindowAuthenticationControl.js
+++ b/src/containers/WindowAuthenticationControl.js
@@ -14,8 +14,8 @@ import { WindowAuthenticationControl } from '../components/WindowAuthenticationC
  * @private
  */
 const mapStateToProps = (state, { windowId }) => {
-  const service = selectCanvasAuthService(state, { canvasIndex: 'selected', windowId });
-  const infoResponse = selectInfoResponse(state, { canvasIndex: 'selected', windowId }) || {};
+  const service = selectCanvasAuthService(state, { windowId });
+  const infoResponse = selectInfoResponse(state, { windowId }) || {};
 
   return {
     confirmLabel: service && service.getConfirmLabel(),

--- a/src/containers/WindowCanvasNavigationControls.js
+++ b/src/containers/WindowCanvasNavigationControls.js
@@ -13,7 +13,6 @@ import { WindowCanvasNavigationControls } from '../components/WindowCanvasNaviga
 /** */
 const mapStateToProps = (state, { windowId }) => ({
   canvasLabel: getCanvasLabel(state, {
-    canvasIndex: 'selected',
     windowId,
   }),
   visible: state.workspace.focusedWindowId === windowId,

--- a/src/containers/WindowViewSettings.js
+++ b/src/containers/WindowViewSettings.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
-import { getWindowViewType } from '../state/selectors';
+import { getWindowViewType, getCanvasIndex } from '../state/selectors';
 import { WindowViewSettings } from '../components/WindowViewSettings';
 
 /**
@@ -21,6 +21,7 @@ const mapDispatchToProps = { setWindowViewType: actions.setWindowViewType };
  */
 const mapStateToProps = (state, { windowId }) => (
   {
+    canvasIndex: getCanvasIndex(state, { windowId }),
     windowViewType: getWindowViewType(state, { windowId }),
   }
 );

--- a/src/containers/WindowViewer.js
+++ b/src/containers/WindowViewer.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
 import { WindowViewer } from '../components/WindowViewer';
-import { getSelectedCanvases } from '../state/selectors';
+import { getSelectedCanvases, getCanvasIndex } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -12,6 +12,7 @@ import { getSelectedCanvases } from '../state/selectors';
  */
 const mapStateToProps = (state, { window }) => (
   {
+    canvasIndex: getCanvasIndex(state, { windowId: window.id }),
     currentCanvases: getSelectedCanvases(state, { windowId: window.id }),
     infoResponses: state.infoResponses,
   }

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -45,7 +45,7 @@ export function addWindow(options) {
     const cwDefault = `cw-${uuid()}`;
     const cwThumbs = `cw-${uuid()}`;
     const defaultOptions = {
-      canvasIndex: 0,
+      canvasIndex: undefined,
       collectionIndex: 0,
       companionAreaOpen: true,
       companionWindowIds: [cwDefault, cwThumbs],

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import { Utils } from 'manifesto.js';
 import CanvasGroupings from '../../lib/CanvasGroupings';
 import { getManifestoInstance } from './manifests';
+import { getCanvasIndex, getWindowViewType } from './windows';
 
 export const getCanvases = createSelector(
   [getManifestoInstance],
@@ -19,45 +20,17 @@ export const getCanvases = createSelector(
 export const getCanvas = createSelector(
   [
     getManifestoInstance,
-    (state, { windowId, canvasIndex }) => (
-      canvasIndex === 'selected'
-        ? state.windows[windowId].canvasIndex
-        : canvasIndex
-    ),
+    getCanvasIndex,
     (state, { canvasId }) => canvasId,
   ],
   (manifest, canvasIndex, canvasId) => {
     if (!manifest) return undefined;
 
     if (canvasId !== undefined) return manifest.getSequences()[0].getCanvasById(canvasId);
-    if (canvasIndex !== undefined) return manifest.getSequences()[0].getCanvasByIndex(canvasIndex);
 
-    return undefined;
+    return manifest.getSequences()[0].getCanvasByIndex(canvasIndex);
   },
 );
-
-/**
-* Return the current canvas selected in a window
-* @param {object} state
-* @param {object} props
-* @param {string} props.manifestId
-* @param {string} props.windowId
-* @return {Object}
-*/
-export function getSelectedCanvas(state, props) {
-  return getCanvas(state, { ...props, canvasIndex: 'selected' });
-}
-
-/**
-* Return the selected canvas index for a window
-* @param {object} state
-* @param {object} props
-* @param {string} props.windowId
-* @return {Object}
-*/
-export function getSelectedCanvasIndex({ windows }, { windowId }) {
-  return windows[windowId].canvasIndex;
-}
 
 /**
 * Return the current canvases selected in a window
@@ -71,14 +44,14 @@ export function getSelectedCanvasIndex({ windows }, { windowId }) {
 export const getSelectedCanvases = createSelector(
   [
     getCanvases,
-    getSelectedCanvasIndex,
-    (state, { windowId }) => state.windows[windowId].view,
+    getCanvasIndex,
+    getWindowViewType,
   ],
   (canvases, canvasIndex, view) => canvases
-    && new CanvasGroupings(
-      canvases,
-      view,
-    ).getCanvases(canvasIndex),
+      && new CanvasGroupings(
+        canvases,
+        view,
+      ).getCanvases(canvasIndex),
 );
 
 /**

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -4,7 +4,7 @@ import ManifestoCanvas from '../../lib/ManifestoCanvas';
 
 /** Get the relevant manifest information */
 export function getManifest(state, { manifestId, windowId }) {
-  return state.manifests[
+  return state.manifests && state.manifests[
     manifestId
     || (windowId && state.windows && state.windows[windowId] && state.windows[windowId].manifestId)
   ];
@@ -349,4 +349,34 @@ function getLocales(resource) {
 export const getMetadataLocales = createSelector(
   [getManifestoInstance],
   manifest => getLocales(manifest),
+);
+
+/**
+ * Returns the starting canvas index specified in the manifest
+ * @param {object} state
+ * @param {object} props
+ * @param {string} props.manifestId
+ * @param {string} props.windowId
+ * @return {Number}
+ */
+export const getManifestStartCanvasIndex = createSelector(
+  [getManifestoInstance],
+  (manifest) => {
+    if (!manifest) return 0;
+
+    let canvasId;
+
+    // IIIF v2
+    canvasId = manifest.getSequences()[0].getProperty('startCanvas');
+
+    if (!canvasId) {
+      // IIIF v3
+      const start = manifest.getProperty('start')
+      || manifest.getSequences()[0].getProperty('start');
+
+      canvasId = start && (start.id || start.source);
+    }
+
+    return ((canvasId && manifest.getSequences()[0].getCanvasById(canvasId)) || {}).index;
+  },
 );

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -22,6 +22,18 @@ export function getWindow(state, { windowId }) {
   return state.windows && state.windows[windowId];
 }
 
+export const getCanvasIndex = createSelector(
+  [
+    getWindow,
+    (state, { canvasIndex }) => canvasIndex,
+  ],
+  (window, canvasIndex) => (
+    canvasIndex === 'selected' || canvasIndex === undefined
+      ? window.canvasIndex
+      : canvasIndex
+  ),
+);
+
 /** Return position of thumbnail navigation in a certain window.
 * @param {object} state
 * @param {String} windowId

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { getManifestTitle } from './manifests';
+import { getManifestTitle, getManifestStartCanvasIndex } from './manifests';
 import { getWorkspaceType } from './config';
 
 /**
@@ -22,15 +22,19 @@ export function getWindow(state, { windowId }) {
   return state.windows && state.windows[windowId];
 }
 
+/** Return the canvas index for a certain window.
+* @param {object} state
+* @param {String} windowId
+* @param {Number}
+*/
 export const getCanvasIndex = createSelector(
   [
     getWindow,
     (state, { canvasIndex }) => canvasIndex,
+    getManifestStartCanvasIndex,
   ],
-  (window, canvasIndex) => (
-    canvasIndex === 'selected' || canvasIndex === undefined
-      ? window.canvasIndex
-      : canvasIndex
+  (window, providedCanvasIndex, defaultIndex) => (
+    providedCanvasIndex || (window && window.canvasIndex) || defaultIndex || 0
   ),
 );
 


### PR DESCRIPTION
The IIIF spec says we should respect the value of startcanvas (v2)/start (v3):

https://iiif.io/api/presentation/2.1/#startcanvas
https://iiif.io/api/presentation/3.0/#start

I have no idea if there's one of these in the wild; I put out a call in #general and haven't heard back.