### PR TITLE
Refactor components to avoid passing through the whole window object

### DIFF
--- a/__tests__/src/components/PrimaryWindow.test.js
+++ b/__tests__/src/components/PrimaryWindow.test.js
@@ -9,7 +9,7 @@ import GalleryView from '../../../src/containers/GalleryView';
 function createWrapper(props) {
   return shallow(
     <PrimaryWindow
-      window={{ id: 'window-1' }}
+      windowId="window-1"
       manifest={{}}
       {...props}
     />,
@@ -32,8 +32,7 @@ describe('PrimaryWindow', () => {
   });
   it('should render <GalleryView> if manifest is present and view is gallery', () => {
     const manifest = { id: 456, isFetching: false };
-    const window = { id: 'window-2', view: 'gallery' };
-    const wrapper = createWrapper({ manifest, window });
+    const wrapper = createWrapper({ manifest, view: 'gallery', windowId: 'window-2' });
     expect(wrapper.find(GalleryView)).toHaveLength(1);
   });
 });

--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -16,9 +16,6 @@ function createWrapper(props) {
         height: 90,
         width: 100,
       }}
-      window={{
-        id: 'foobar',
-      }}
       {...props}
     />,
   );
@@ -50,7 +47,7 @@ describe('ThumbnailCanvasGrouping', () => {
   it('when clicked, updates the current canvas', () => {
     wrapper = createWrapper({ data, index: 0, setCanvas });
     wrapper.find('.mirador-thumbnail-nav-canvas-0').simulate('click', { currentTarget: { dataset: { canvasIndex: '0' } } });
-    expect(setCanvas).toHaveBeenCalledWith('foobar', 0);
+    expect(setCanvas).toHaveBeenCalledWith(0);
   });
   describe('attributes based off far-bottom position', () => {
     it('in button div', () => {

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -14,9 +14,7 @@ function createWrapper(props) {
       }
       canvasIndex={1}
       classes={{}}
-      window={{
-        id: 'foobar',
-      }}
+      windowId="foobar"
       config={{ thumbnailNavigation: { height: 150, width: 100 } }}
       position="far-bottom"
       t={k => k}
@@ -49,11 +47,7 @@ describe('ThumbnailNavigation', () => {
     wrapper.instance().gridRef = { current: { resetAfterIndex: mockReset } };
     wrapper.setProps({
       canvasIndex: 1,
-      window: {
-        id: 'foobar',
-        thumbnailNavigationPosition: 'far-bottom',
-        view: 'book',
-      },
+      view: 'book',
     });
     expect(mockReset).toHaveBeenCalled();
   });
@@ -62,10 +56,6 @@ describe('ThumbnailNavigation', () => {
     wrapper.instance().gridRef = { current: { scrollToItem: mockScroll } };
     wrapper.setProps({
       canvasIndex: 3,
-      window: {
-        id: 'foobar',
-        thumbnailNavigationPosition: 'far-bottom',
-      },
     });
     expect(mockScroll).toHaveBeenCalled();
   });
@@ -86,11 +76,7 @@ describe('ThumbnailNavigation', () => {
       wrapper.instance().gridRef = { current: { resetAfterIndex: mockReset } };
       wrapper.setProps({
         canvasIndex: 1,
-        window: {
-          id: 'foobar',
-          thumbnailNavigationPosition: 'far-bottom',
-          view: 'book',
-        },
+        view: 'book',
       });
       expect(wrapper.instance().rightWidth()).toEqual(200);
     });
@@ -117,23 +103,20 @@ describe('ThumbnailNavigation', () => {
         canvasIndex: 1,
         position: 'far-right',
         setCanvas: rightSetCanvas,
-        window: {
-          id: 'foobat',
-        },
       });
     });
     describe('handleKeyUp', () => {
       it('next', () => {
         wrapper.instance().handleKeyUp({ key: 'ArrowRight' });
-        expect(setCanvas).toHaveBeenCalledWith('foobar', 2);
+        expect(setCanvas).toHaveBeenCalledWith(2);
         rightWrapper.instance().handleKeyUp({ key: 'ArrowDown' });
-        expect(rightSetCanvas).toHaveBeenCalledWith('foobat', 2);
+        expect(rightSetCanvas).toHaveBeenCalledWith(2);
       });
       it('previous', () => {
         wrapper.instance().handleKeyUp({ key: 'ArrowLeft' });
-        expect(setCanvas).toHaveBeenCalledWith('foobar', 0);
+        expect(setCanvas).toHaveBeenCalledWith(0);
         rightWrapper.instance().handleKeyUp({ key: 'ArrowUp' });
-        expect(rightSetCanvas).toHaveBeenCalledWith('foobat', 0);
+        expect(rightSetCanvas).toHaveBeenCalledWith(0);
       });
     });
   });

--- a/__tests__/src/components/ViewerNavigation.test.js
+++ b/__tests__/src/components/ViewerNavigation.test.js
@@ -8,7 +8,6 @@ function createWrapper(props) {
     <ViewerNavigation
       canvases={[1, 2]}
       setCanvas={() => {}}
-      window={{}}
       t={k => (k)}
       {...props}
     />,
@@ -23,9 +22,6 @@ describe('ViewerNavigation', () => {
     wrapper = createWrapper({
       canvasIndex: 0,
       setCanvas,
-      window: {
-        id: 'foo',
-      },
     });
   });
   it('renders the component', () => {
@@ -38,16 +34,13 @@ describe('ViewerNavigation', () => {
     });
     it('setCanvas function is called after click', () => {
       wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvas).toHaveBeenCalledWith('foo', 1);
+      expect(setCanvas).toHaveBeenCalledWith(1);
     });
   });
   describe('when next canvases are not present', () => {
     it('nextCanvas button is disabled', () => {
       const endWrapper = createWrapper({
         canvasIndex: 1,
-        window: {
-          id: 'foo',
-        },
       });
       expect(endWrapper.find('.mirador-next-canvas-button').prop('disabled')).toBe(true);
     });
@@ -67,26 +60,20 @@ describe('ViewerNavigation', () => {
         canvases: [1, 2, 3],
         canvasIndex: 0,
         setCanvas,
-        window: {
-          id: 'foo',
-          view: 'book',
-        },
+        view: 'book',
       });
       wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvas).toHaveBeenCalledWith('foo', 2);
+      expect(setCanvas).toHaveBeenCalledWith(2);
     });
     it('setCanvas function is called after click for previous', () => {
       wrapper = createWrapper({
         canvasIndex: 5,
         setCanvas,
-        window: {
-          id: 'foo',
-          view: 'book',
-        },
+        view: 'book',
       });
       wrapper.find('.mirador-previous-canvas-button').simulate('click');
       expect(wrapper.find('.mirador-previous-canvas-button').prop('aria-label')).toBe('previousCanvas');
-      expect(setCanvas).toHaveBeenCalledWith('foo', 3);
+      expect(setCanvas).toHaveBeenCalledWith(3);
     });
   });
 });

--- a/__tests__/src/components/Window.test.js
+++ b/__tests__/src/components/Window.test.js
@@ -8,7 +8,8 @@ import PrimaryWindow from '../../../src/containers/PrimaryWindow';
 function createWrapper(props, context) {
   return shallow(
     <Window
-      window={window}
+      windowId="123"
+      manifestId="foo"
       classes={{}}
       t={k => k}
       fetchManifest={() => {}}
@@ -20,41 +21,28 @@ function createWrapper(props, context) {
 
 describe('Window', () => {
   let wrapper;
-  const window = {
-    height: 400,
-    id: 123,
-    manifestId: 'foo',
-    maximized: false,
-    width: 400,
-    x: 2700,
-    y: 2700,
-  };
-  it('should render nothing, if provided with no window data', () => {
-    wrapper = createWrapper({ window: null });
-    expect(wrapper.find('.mirador-window')).toHaveLength(0);
-  });
   it('should render outer element', () => {
-    wrapper = createWrapper({ window });
+    wrapper = createWrapper();
     expect(wrapper.find('.mirador-window')).toHaveLength(1);
   });
   it('should render <WindowTopBar>', () => {
-    wrapper = createWrapper({ window });
+    wrapper = createWrapper();
     expect(wrapper.find(WindowTopBar)).toHaveLength(1);
   });
   it('should render <PrimaryWindow>', () => {
-    wrapper = createWrapper({ window });
+    wrapper = createWrapper();
     expect(wrapper.find(PrimaryWindow)).toHaveLength(1);
   });
   it('should dispatch fetchManifest when component mounts but manifest is not preset', () => {
     const mockFetchManifest = jest.fn();
-    wrapper = createWrapper({ fetchManifest: mockFetchManifest, window });
+    wrapper = createWrapper({ fetchManifest: mockFetchManifest });
     expect(mockFetchManifest).toHaveBeenCalled();
   });
   describe('when workspaceType is mosaic', () => {
     it('calls the context mosaicWindowActions connectDragSource method to make WindowTopBar draggable', () => {
       const connectDragSource = jest.fn(component => component);
       wrapper = createWrapper(
-        { window, windowDraggable: true, workspaceType: 'mosaic' }, { mosaicWindowActions: { connectDragSource } },
+        { windowDraggable: true, workspaceType: 'mosaic' }, { mosaicWindowActions: { connectDragSource } },
       );
       expect(wrapper.find(WindowTopBar)).toHaveLength(1);
       expect(connectDragSource).toHaveBeenCalled();
@@ -63,7 +51,7 @@ describe('Window', () => {
     it('does not call the context mosaicWindowActions connectDragSource when the windowDraggable is set to false', () => {
       const connectDragSource = jest.fn(component => component);
       wrapper = createWrapper(
-        { window, windowDraggable: false, workspaceType: 'mosaic' }, { mosaicWindowActions: { connectDragSource } },
+        { windowDraggable: false, workspaceType: 'mosaic' }, { mosaicWindowActions: { connectDragSource } },
       );
       expect(wrapper.find(WindowTopBar)).toHaveLength(1);
       expect(connectDragSource).not.toHaveBeenCalled();

--- a/__tests__/src/components/WindowCanvasNavigationControls.test.js
+++ b/__tests__/src/components/WindowCanvasNavigationControls.test.js
@@ -13,7 +13,7 @@ function createWrapper(props) {
       canvases={[]}
       canvasLabel="label"
       size={{ width: 300 }}
-      window={{}}
+      windowId="abc"
       zoomToWorld={() => {}}
       {...props}
     />,

--- a/__tests__/src/components/WindowViewer.test.js
+++ b/__tests__/src/components/WindowViewer.test.js
@@ -11,10 +11,6 @@ import otherContentFixture from '../../fixtures/version-2/299843.json';
 
 let currentCanvases = manifesto.create(fixture).getSequences()[0].getCanvases();
 
-let mockWindow = {
-  view: 'single',
-};
-
 /** create wrapper */
 function createWrapper(props) {
   return shallow(
@@ -25,7 +21,8 @@ function createWrapper(props) {
       fetchInfoResponse={() => {}}
       fetchAnnotation={() => {}}
       currentCanvases={[currentCanvases[1]]}
-      window={mockWindow}
+      view="single"
+      windowId="xyz"
       {...props}
     />,
   );
@@ -58,9 +55,7 @@ describe('WindowViewer', () => {
                 isFetching: true,
               },
             },
-            window: {
-              view: 'book',
-            },
+            view: 'book',
           },
         );
         expect(wrapper.instance().currentInfoResponses().length).toEqual(1);
@@ -77,9 +72,7 @@ describe('WindowViewer', () => {
                 isFetching: false,
               },
             },
-            window: {
-              view: 'book',
-            },
+            view: 'book',
           },
         );
         expect(wrapper.instance().currentInfoResponses().length).toEqual(1);
@@ -97,9 +90,7 @@ describe('WindowViewer', () => {
                 isFetching: false,
               },
             },
-            window: {
-              view: 'book',
-            },
+            view: 'book',
           },
         );
         expect(wrapper.instance().currentInfoResponses().length).toEqual(1);
@@ -115,15 +106,12 @@ describe('WindowViewer', () => {
 
       currentCanvases = [canvases[0]];
 
-      mockWindow = {
-        view: 'single',
-      };
       wrapper = createWrapper(
         {
           canvasIndex: 0,
           currentCanvases,
           fetchInfoResponse: mockFnCanvas0,
-          window: mockWindow,
+          view: 'single',
         },
       );
       expect(mockFnCanvas0).toHaveBeenCalledTimes(1);
@@ -134,7 +122,7 @@ describe('WindowViewer', () => {
           canvasIndex: 2,
           currentCanvases,
           fetchInfoResponse: mockFnCanvas2,
-          window: { view: 'single' },
+          view: 'single',
         },
       );
       expect(mockFnCanvas2).toHaveBeenCalledTimes(0);
@@ -156,19 +144,16 @@ describe('WindowViewer', () => {
       const mockFn = jest.fn();
       const canvases = manifesto.create(emptyCanvasFixture).getSequences()[0].getCanvases();
       currentCanvases = [canvases[2]];
-      mockWindow = {
-        view: 'single',
-      };
       wrapper = createWrapper(
         {
           canvasIndex: 2,
           currentCanvases,
           fetchInfoResponse: mockFn,
-          window: mockWindow,
+          view: 'single',
         },
       );
 
-      wrapper.setProps({ canvasIndex: 3, currentCanvases: [canvases[3]], window: { view: 'single' } });
+      wrapper.setProps({ canvasIndex: 3, currentCanvases: [canvases[3]], view: 'single' });
 
       expect(mockFn).toHaveBeenCalledTimes(0);
     });

--- a/__tests__/src/components/Workspace.test.js
+++ b/__tests__/src/components/Workspace.test.js
@@ -57,8 +57,8 @@ describe('Workspace', () => {
       expect(wrapper.matchesElement(
         <div className="mirador-workspace-viewport mirador-workspace-with-control-panel">
           <Typography>miradorViewer</Typography>
-          <Window window={{ id: 1 }} />
-          <Window window={{ id: 2 }} />
+          <Window windowId="1" />
+          <Window windowId="2" />
         </div>,
       )).toBe(true);
     });
@@ -69,7 +69,7 @@ describe('Workspace', () => {
       expect(wrapper.matchesElement(
         <div className="mirador-workspace-viewport mirador-workspace-with-control-panel">
           <Typography>miradorViewer</Typography>
-          <Window window={{ id: 1, maximized: true }} className="mirador-workspace-maximized-window" />
+          <Window windowId="1" className="mirador-workspace-maximized-window" />
         </div>,
       )).toBe(true);
     });

--- a/src/components/PrimaryWindow.js
+++ b/src/components/PrimaryWindow.js
@@ -17,18 +17,18 @@ export class PrimaryWindow extends Component {
    * @return {(String|null)}
    */
   renderViewer() {
-    const { manifest, window } = this.props;
+    const { manifest, view, windowId } = this.props;
     if (manifest && manifest.isFetching === false) {
-      if (window.view === 'gallery') {
+      if (view === 'gallery') {
         return (
           <GalleryView
-            windowId={window.id}
+            windowId={windowId}
           />
         );
       }
       return (
         <WindowViewer
-          windowId={window.id}
+          windowId={windowId}
         />
       );
     }
@@ -39,11 +39,11 @@ export class PrimaryWindow extends Component {
    * Render the component
    */
   render() {
-    const { window } = this.props;
+    const { windowId } = this.props;
     return (
       <div className={ns('primary-window')}>
-        <WindowSideBar windowId={window.id} />
-        <CompanionArea windowId={window.id} position="left" />
+        <WindowSideBar windowId={windowId} />
+        <CompanionArea windowId={windowId} position="left" />
         {this.renderViewer()}
       </div>
     );
@@ -52,9 +52,11 @@ export class PrimaryWindow extends Component {
 
 PrimaryWindow.propTypes = {
   manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  view: PropTypes.string,
+  windowId: PropTypes.string.isRequired,
 };
 
 PrimaryWindow.defaultProps = {
   manifest: null,
+  view: undefined,
 };

--- a/src/components/PrimaryWindow.js
+++ b/src/components/PrimaryWindow.js
@@ -28,7 +28,7 @@ export class PrimaryWindow extends Component {
       }
       return (
         <WindowViewer
-          window={window}
+          windowId={window.id}
         />
       );
     }

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -15,8 +15,8 @@ export class ThumbnailCanvasGrouping extends PureComponent {
 
   /** */
   setCanvas(e) {
-    const { setCanvas, window } = this.props;
-    setCanvas(window.id, parseInt(e.currentTarget.dataset.canvasIndex, 10));
+    const { setCanvas } = this.props;
+    setCanvas(parseInt(e.currentTarget.dataset.canvasIndex, 10));
   }
 
   /**
@@ -92,5 +92,4 @@ ThumbnailCanvasGrouping.propTypes = {
   index: PropTypes.number.isRequired,
   setCanvas: PropTypes.func.isRequired,
   style: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -30,13 +30,13 @@ export class ThumbnailNavigation extends Component {
    * of the grids
    */
   componentDidUpdate(prevProps) {
-    const { canvasIndex, position, window } = this.props;
-    if (prevProps.window.view !== window.view && position !== 'off') {
+    const { canvasIndex, position, view } = this.props;
+    if (prevProps.view !== view && position !== 'off') {
       this.gridRef.current.resetAfterIndex(0);
     }
     if (prevProps.canvasIndex !== canvasIndex) {
       let index = canvasIndex;
-      if (window.view === 'book') index = Math.ceil(index / 2);
+      if (view === 'book') index = Math.ceil(index / 2);
       this.gridRef.current.scrollToItem(index, 'center');
     }
   }
@@ -79,8 +79,8 @@ export class ThumbnailNavigation extends Component {
 
   /** */
   rightWidth() {
-    const { window, config } = this.props;
-    switch (window.view) {
+    const { view, config } = this.props;
+    switch (view) {
       case 'book':
         return (config.thumbnailNavigation.width * 2);
       default:
@@ -149,9 +149,9 @@ export class ThumbnailNavigation extends Component {
   /**
    */
   nextCanvas() {
-    const { window, canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvas } = this.props;
     if (this.hasNextCanvas()) {
-      setCanvas(window.id, canvasIndex + this.canvasIncrementor());
+      setCanvas(canvasIndex + this.canvasIncrementor());
     }
   }
 
@@ -165,9 +165,9 @@ export class ThumbnailNavigation extends Component {
   /**
    */
   previousCanvas() {
-    const { window, canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvas } = this.props;
     if (this.hasPreviousCanvas()) {
-      setCanvas(window.id, Math.max(0, canvasIndex - this.canvasIncrementor()));
+      setCanvas(Math.max(0, canvasIndex - this.canvasIncrementor()));
     }
   }
 
@@ -181,8 +181,8 @@ export class ThumbnailNavigation extends Component {
   /**
    */
   canvasIncrementor() {
-    const { window } = this.props;
-    switch (window.view) {
+    const { view } = this.props;
+    switch (view) {
       case 'book':
         return 2;
       default:
@@ -200,7 +200,7 @@ export class ThumbnailNavigation extends Component {
       classes,
       config,
       position,
-      window,
+      windowId,
     } = this.props;
     if (position === 'off') {
       return <></>;
@@ -233,7 +233,7 @@ export class ThumbnailNavigation extends Component {
                 config,
                 height: config.thumbnailNavigation.height - this.spacing - this.scrollbarSize,
                 position,
-                windowId: window.id,
+                windowId,
               }}
               ref={this.gridRef}
             >
@@ -254,5 +254,10 @@ ThumbnailNavigation.propTypes = {
   position: PropTypes.string.isRequired,
   setCanvas: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  view: PropTypes.string,
+  windowId: PropTypes.string.isRequired,
+};
+
+ThumbnailNavigation.defaultProps = {
+  view: undefined,
 };

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -19,9 +19,9 @@ export class ViewerNavigation extends Component {
   /**
    */
   nextCanvas() {
-    const { window, canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvas } = this.props;
     if (this.hasNextCanvas()) {
-      setCanvas(window.id, canvasIndex + this.canvasIncrementor());
+      setCanvas(canvasIndex + this.canvasIncrementor());
     }
   }
 
@@ -35,9 +35,9 @@ export class ViewerNavigation extends Component {
   /**
    */
   previousCanvas() {
-    const { window, canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvas } = this.props;
     if (this.hasPreviousCanvas()) {
-      setCanvas(window.id, Math.max(0, canvasIndex - this.canvasIncrementor()));
+      setCanvas(Math.max(0, canvasIndex - this.canvasIncrementor()));
     }
   }
 
@@ -51,8 +51,8 @@ export class ViewerNavigation extends Component {
   /**
    */
   canvasIncrementor() {
-    const { window } = this.props;
-    switch (window.view) {
+    const { view } = this.props;
+    switch (view) {
       case 'book':
         return 2;
       default:
@@ -94,5 +94,9 @@ ViewerNavigation.propTypes = {
   canvasIndex: PropTypes.number.isRequired,
   setCanvas: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  view: PropTypes.string,
+};
+
+ViewerNavigation.defaultProps = {
+  view: undefined,
 };

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -15,9 +15,9 @@ import CompanionArea from '../containers/CompanionArea';
 export class Window extends Component {
   /** */
   componentDidMount(prevProps) {
-    const { fetchManifest, manifest, window } = this.props;
-    if (window && window.manifestId && (!manifest || !manifest.isFetching)) {
-      fetchManifest(window.manifestId);
+    const { fetchManifest, manifest, manifestId } = this.props;
+    if (manifestId && (!manifest || !manifest.isFetching)) {
+      fetchManifest(manifestId);
     }
   }
 
@@ -27,13 +27,13 @@ export class Window extends Component {
    */
   wrappedTopBar() {
     const {
-      manifest, window, workspaceType, windowDraggable,
+      manifest, windowId, workspaceType, windowDraggable,
     } = this.props;
     const { mosaicWindowActions } = this.context;
     const topBar = (
       <div>
         <WindowTopBar
-          windowId={window.id}
+          windowId={windowId}
           manifest={manifest}
           windowDraggable={windowDraggable}
         />
@@ -52,22 +52,18 @@ export class Window extends Component {
    */
   render() {
     const {
-      focusWindow, label, manifest, window, classes, t,
+      focusWindow, label, manifest, maximized, sideBarOpen, view, windowId, classes, t,
     } = this.props;
-
-    if (!window) {
-      return <></>;
-    }
 
     return (
       <Paper
         onFocus={focusWindow}
         component="section"
         elevation={1}
-        id={window.id}
+        id={windowId}
         className={
           cn(classes.window, ns('window'),
-            window.maximized ? ns('workspace-maximized-window') : null)}
+            maximized ? ns('workspace-maximized-window') : null)}
         aria-label={t('window', { label })}
       >
         {this.wrappedTopBar()}
@@ -75,22 +71,22 @@ export class Window extends Component {
           <div className={classes.middleLeft}>
             <div className={classes.primaryWindow}>
               <PrimaryWindow
-                view={window.view}
-                windowId={window.id}
+                view={view}
+                windowId={windowId}
                 manifest={manifest}
-                sideBarOpen={window.sideBarOpen}
+                sideBarOpen={sideBarOpen}
               />
             </div>
             <div className={classes.companionAreaBottom}>
-              <CompanionArea windowId={window.id} position="bottom" />
+              <CompanionArea windowId={windowId} position="bottom" />
             </div>
           </div>
           <div className={classes.companionAreaRight}>
-            <CompanionArea windowId={window.id} position="right" />
-            <CompanionArea windowId={window.id} position="far-right" />
+            <CompanionArea windowId={windowId} position="right" />
+            <CompanionArea windowId={windowId} position="far-right" />
           </div>
         </div>
-        <CompanionArea windowId={window.id} position="far-bottom" />
+        <CompanionArea windowId={windowId} position="far-bottom" />
       </Paper>
     );
   }
@@ -109,9 +105,13 @@ Window.propTypes = {
   focusWindow: PropTypes.func,
   label: PropTypes.string,
   manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  manifestId: PropTypes.string,
+  maximized: PropTypes.bool,
+  sideBarOpen: PropTypes.bool,
   t: PropTypes.func.isRequired,
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  view: PropTypes.string,
   windowDraggable: PropTypes.bool,
+  windowId: PropTypes.string.isRequired,
   workspaceType: PropTypes.string,
 };
 
@@ -120,6 +120,10 @@ Window.defaultProps = {
   focusWindow: () => {},
   label: null,
   manifest: null,
+  manifestId: undefined,
+  maximized: false,
+  sideBarOpen: false,
+  view: undefined,
   windowDraggable: null,
   workspaceType: null,
 };

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -75,7 +75,8 @@ export class Window extends Component {
           <div className={classes.middleLeft}>
             <div className={classes.primaryWindow}>
               <PrimaryWindow
-                window={window}
+                view={window.view}
+                windowId={window.id}
                 manifest={manifest}
                 sideBarOpen={window.sideBarOpen}
               />

--- a/src/components/WindowCanvasNavigationControls.js
+++ b/src/components/WindowCanvasNavigationControls.js
@@ -35,7 +35,7 @@ export class WindowCanvasNavigationControls extends Component {
           windowId={window.id}
           zoomToWorld={zoomToWorld}
         />
-        <ViewerNavigation window={window} />
+        <ViewerNavigation windowId={window.id} />
         <ViewerInfo windowId={window.id} />
       </Paper>
     );

--- a/src/components/WindowCanvasNavigationControls.js
+++ b/src/components/WindowCanvasNavigationControls.js
@@ -23,7 +23,7 @@ export class WindowCanvasNavigationControls extends Component {
   /** */
   render() {
     const {
-      classes, visible, window, zoomToWorld,
+      classes, visible, windowId, zoomToWorld,
     } = this.props;
 
     if (!visible) return (<></>);
@@ -32,11 +32,11 @@ export class WindowCanvasNavigationControls extends Component {
       <Paper square className={classNames(classes.controls, ns('canvas-nav'), this.canvasNavControlsAreStacked() ? ns('canvas-nav-stacked') : null)} elevation={0}>
         <ZoomControls
           displayDivider={!this.canvasNavControlsAreStacked()}
-          windowId={window.id}
+          windowId={windowId}
           zoomToWorld={zoomToWorld}
         />
-        <ViewerNavigation windowId={window.id} />
-        <ViewerInfo windowId={window.id} />
+        <ViewerNavigation windowId={windowId} />
+        <ViewerInfo windowId={windowId} />
       </Paper>
     );
   }
@@ -47,7 +47,7 @@ WindowCanvasNavigationControls.propTypes = {
   classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   size: PropTypes.shape({ width: PropTypes.number }).isRequired,
   visible: PropTypes.bool,
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  windowId: PropTypes.string.isRequired,
   zoomToWorld: PropTypes.func.isRequired,
 };
 

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -37,10 +37,10 @@ export class WindowViewer extends Component {
    */
   componentDidUpdate(prevProps) {
     const {
-      canvasIndex, currentCanvases, window, fetchInfoResponse, fetchAnnotation,
+      canvasIndex, currentCanvases, view, fetchInfoResponse, fetchAnnotation,
     } = this.props;
 
-    if (prevProps.window.view !== window.view
+    if (prevProps.view !== view
       || (prevProps.canvasIndex !== canvasIndex && !this.infoResponseIsInStore())
     ) {
       currentCanvases.forEach((canvas) => {
@@ -104,16 +104,16 @@ export class WindowViewer extends Component {
    * Renders things
    */
   render() {
-    const { window } = this.props;
+    const { windowId } = this.props;
     return (
       <>
         <OSDViewer
           tileSources={this.tileInfoFetchedFromStore()}
-          windowId={window.id}
+          windowId={windowId}
         >
-          <WindowCanvasNavigationControls key="canvas_nav" windowId={window.id} />
+          <WindowCanvasNavigationControls key="canvas_nav" windowId={windowId} />
         </OSDViewer>
-        <WindowAuthenticationControl key="auth" windowId={window.id} />
+        <WindowAuthenticationControl key="auth" windowId={windowId} />
       </>
     );
   }
@@ -125,5 +125,6 @@ WindowViewer.propTypes = {
   fetchAnnotation: PropTypes.func.isRequired,
   fetchInfoResponse: PropTypes.func.isRequired,
   infoResponses: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  view: PropTypes.string.isRequired,
+  windowId: PropTypes.string.isRequired,
 };

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -31,10 +31,10 @@ export class Workspace extends React.Component {
       case 'mosaic':
         return <WorkspaceMosaic windows={windows} />;
       default:
-        return Object.values(windows).map(window => (
+        return Object.keys(windows).map(windowId => (
           <Window
-            key={`${window.id}-${workspaceId}`}
-            window={window}
+            key={`${windowId}-${workspaceId}`}
+            windowId={windowId}
           />
         ));
     }
@@ -75,13 +75,12 @@ export class Workspace extends React.Component {
     const { windows, workspaceId } = this.props;
     const windowKeys = Object.keys(windows).sort();
     const maximizedWindows = windowKeys
-      .map(id => windows[id])
-      .filter(window => window.maximized === true);
+      .filter(windowId => windows[windowId].maximized === true);
     if (maximizedWindows.length) {
-      return Object.values(maximizedWindows).map(window => (
+      return maximizedWindows.map(windowId => (
         <Window
-          key={`${window.id}-${workspaceId}`}
-          window={window}
+          key={`${windowId}-${workspaceId}`}
+          windowId={windowId}
           className={classNames(ns('workspace-maximized-window'))}
         />
       ));

--- a/src/containers/CompanionArea.js
+++ b/src/containers/CompanionArea.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state, { windowId, position }) => ({
   companionAreaOpen: getCompanionAreaVisibility(state, { position, windowId }),
   companionWindows: getCompanionWindowsOfWindow(state, { windowId })
     .filter(cw => cw && cw.position === position),
-  sideBarOpen: getWindow(state, { windowId }).sideBarOpen,
+  sideBarOpen: (getWindow(state, { windowId }) || {}).sideBarOpen,
 });
 
 const mapDispatchToProps = ({

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -12,9 +12,9 @@ import { ThumbnailCanvasGrouping } from '../components/ThumbnailCanvasGrouping';
  * @memberof ThumbnailCanvasGrouping
  * @private
  */
-const mapDispatchToProps = {
-  setCanvas: actions.setCanvas,
-};
+const mapDispatchToProps = (dispatch, { data }) => ({
+  setCanvas: (...args) => dispatch(actions.setCanvas(data.windowId, ...args)),
+});
 
 /**
  * mapStateToProps - used to hook up state to props

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -6,7 +6,7 @@ import { withPlugins } from '../extend';
 import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
 import { ThumbnailNavigation } from '../components/ThumbnailNavigation';
-import { getManifestCanvases, getCanvasIndex, getWindow } from '../state/selectors';
+import { getManifestCanvases, getCanvasIndex, getWindowViewType } from '../state/selectors';
 
 /**
  * mapStateToProps - used to hook up state to props
@@ -21,7 +21,7 @@ const mapStateToProps = (state, { windowId }) => ({
   canvasIndex: getCanvasIndex(state, { windowId }),
   config: state.config,
   position: state.companionWindows[state.windows[windowId].thumbnailNavigationId].position,
-  window: getWindow(state, { windowId }),
+  view: getWindowViewType(state, { windowId }),
 });
 
 /**
@@ -29,9 +29,9 @@ const mapStateToProps = (state, { windowId }) => ({
  * @memberof ThumbnailNavigation
  * @private
  */
-const mapDispatchToProps = {
-  setCanvas: actions.setCanvas,
-};
+const mapDispatchToProps = (dispatch, { windowId }) => ({
+  setCanvas: (...args) => dispatch(actions.setCanvas(windowId, ...args)),
+});
 
 /**
  * Styles for withStyles HOC

--- a/src/containers/ViewerNavigation.js
+++ b/src/containers/ViewerNavigation.js
@@ -3,13 +3,15 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
-import { getManifestCanvases, getCanvasIndex } from '../state/selectors';
+import { getManifestCanvases, getCanvasIndex, getWindowViewType } from '../state/selectors';
 import { ViewerNavigation } from '../components/ViewerNavigation';
 
 /** */
-const mapStateToProps = (state, { window }) => ({
-  canvases: getManifestCanvases(state, { windowId: window.id }),
-  canvasIndex: getCanvasIndex(state, { windowId: window.id }),
+const mapStateToProps = (state, { windowId }) => ({
+  canvases: getManifestCanvases(state, { windowId }),
+  canvasIndex: getCanvasIndex(state, { windowId }),
+  view: getWindowViewType(state, { windowId }),
+  windowId: window.id,
 });
 
 /**
@@ -17,9 +19,9 @@ const mapStateToProps = (state, { window }) => ({
  * @memberof ManifestForm
  * @private
  */
-const mapDispatchToProps = {
-  setCanvas: actions.setCanvas,
-};
+const mapDispatchToProps = (dispatch, { windowId }) => ({
+  setCanvas: (...args) => dispatch(actions.setCanvas(windowId, ...args)),
+});
 
 const enhance = compose(
   withTranslation(),

--- a/src/containers/Window.js
+++ b/src/containers/Window.js
@@ -7,7 +7,7 @@ import * as actions from '../state/actions';
 import { Window } from '../components/Window';
 import {
   getManifest, getManifestTitle, getThumbnailNavigationPosition, getWindow,
-  getWorkspaceType, getWindowDraggability,
+  getWorkspaceType, getWindowDraggability, getWindowViewType,
 } from '../state/selectors';
 
 
@@ -19,7 +19,11 @@ import {
 const mapStateToProps = (state, { windowId }) => ({
   label: getManifestTitle(state, { windowId }),
   manifest: getManifest(state, { windowId }),
+  manifestId: (getWindow(state, { windowId }) || {}).manifestId,
+  maximized: (getWindow(state, { windowId }) || {}).maximized,
+  sideBarOpen: (getWindow(state, { windowId }) || {}).sideBarOpen,
   thumbnailNavigationPosition: getThumbnailNavigationPosition(state, { windowId }),
+  view: getWindowViewType(state, { windowId }),
   window: getWindow(state, { windowId }),
   windowDraggable: getWindowDraggability(state, { windowId }),
   workspaceType: getWorkspaceType(state),

--- a/src/containers/WindowCanvasNavigationControls.js
+++ b/src/containers/WindowCanvasNavigationControls.js
@@ -6,7 +6,6 @@ import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withPlugins } from '../extend';
 import {
   getCanvasLabel,
-  getWindow,
 } from '../state/selectors';
 import { WindowCanvasNavigationControls } from '../components/WindowCanvasNavigationControls';
 
@@ -16,7 +15,6 @@ const mapStateToProps = (state, { windowId }) => ({
     windowId,
   }),
   visible: state.workspace.focusedWindowId === windowId,
-  window: getWindow(state, { windowId }),
 });
 
 /**

--- a/src/containers/WindowSideBar.js
+++ b/src/containers/WindowSideBar.js
@@ -13,8 +13,8 @@ import { getWindow } from '../state/selectors';
  */
 const mapStateToProps = (state, { windowId }) => (
   {
-    sideBarOpen: getWindow(state, { windowId }).sideBarOpen,
-    sideBarPanel: getWindow(state, { windowId }).sideBarPanel,
+    sideBarOpen: (getWindow(state, { windowId }) || {}).sideBarOpen,
+    sideBarPanel: (getWindow(state, { windowId }) || {}).sideBarPanel,
   }
 );
 

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -13,7 +13,7 @@ const mapStateToProps = (state, { windowId }) => ({
   allowMaximize: state.config.window.allowMaximize,
   focused: state.workspace.focusedWindowId === windowId,
   manifestTitle: getManifestTitle(state, { windowId }),
-  maximized: getWindow(state, { windowId }).maximized,
+  maximized: (getWindow(state, { windowId }) || {}).maximized,
 });
 
 /**

--- a/src/containers/WindowViewer.js
+++ b/src/containers/WindowViewer.js
@@ -3,18 +3,19 @@ import { connect } from 'react-redux';
 import { withPlugins } from '../extend';
 import * as actions from '../state/actions';
 import { WindowViewer } from '../components/WindowViewer';
-import { getSelectedCanvases, getCanvasIndex } from '../state/selectors';
+import { getSelectedCanvases, getCanvasIndex, getWindowViewType } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
  * @memberof WindowViewer
  * @private
  */
-const mapStateToProps = (state, { window }) => (
+const mapStateToProps = (state, { windowId }) => (
   {
-    canvasIndex: getCanvasIndex(state, { windowId: window.id }),
-    currentCanvases: getSelectedCanvases(state, { windowId: window.id }),
+    canvasIndex: getCanvasIndex(state, { windowId }),
+    currentCanvases: getSelectedCanvases(state, { windowId }),
     infoResponses: state.infoResponses,
+    view: getWindowViewType(state, { windowId }),
   }
 );
 

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -124,7 +124,9 @@ export const getCompanionAreaVisibility = createSelector(
     (state, { position }) => position,
     getWindow,
   ],
-  (position, { companionAreaOpen, sideBarOpen }) => {
+  (position, window) => {
+    if (!window) return false;
+    const { companionAreaOpen, sideBarOpen } = window;
     if (position !== 'left') return true;
     return !!(companionAreaOpen && sideBarOpen);
   },


### PR DESCRIPTION
- [x] WindowViewer
- [x] PrimaryWindow
- [x] ThumbnailCanvasGrouping
- [x] ThumbnailNavigation
- [x] ViewerNavigation
- [x] Window
- [x] WindowCanvasNavigationControls

Also fixed #2485 