### PR TITLE
Add an active state to manifest list items that are already open in the workspace

### DIFF
--- a/__tests__/src/components/ManifestListItem.test.js
+++ b/__tests__/src/components/ManifestListItem.test.js
@@ -25,6 +25,10 @@ describe('ManifestListItem', () => {
     expect(wrapper.find('WithStyles(ButtonBase)').length).toBe(1);
     expect(wrapper.find('WithStyles(ButtonBase) WithStyles(Typography)').children().text()).toEqual('xyz');
   });
+  it('adds a class when the item is active', () => {
+    const wrapper = createWrapper({ active: true, classes: { active: 'active' } });
+    expect(wrapper.find('.active').length).toEqual(1);
+  });
   it('renders a placeholder element until real data is available', () => {
     const wrapper = createWrapper({ ready: false });
 

--- a/__tests__/src/selectors/windows.test.js
+++ b/__tests__/src/selectors/windows.test.js
@@ -13,6 +13,7 @@ import {
   getWindowDraggability,
   selectCompanionWindowDimensions,
   getCanvasIndex,
+  getWindowManifests,
 } from '../../../src/state/selectors/windows';
 
 
@@ -36,6 +37,21 @@ describe('getWindowTitles', () => {
       a: 'Bodleian Library Human Freaks 2 (33)',
       b: 'Test 2 Manifest: Metadata Pairs',
     });
+  });
+});
+
+describe('getWindowManifests', () => {
+  it('should return manifest titles for the open windows', () => {
+    const state = {
+      windows: {
+        a: { manifestId: 'amanifest' },
+        b: { manifestId: 'bmanifest' },
+      },
+    };
+
+    const received = getWindowManifests(state);
+
+    expect(received).toEqual(['amanifest', 'bmanifest']);
   });
 });
 

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -37,6 +37,7 @@ export class ManifestListItem extends React.Component {
   /** */
   render() {
     const {
+      active,
       manifestId,
       ready,
       title,
@@ -77,7 +78,7 @@ export class ManifestListItem extends React.Component {
     }
 
     return (
-      <ListItem divider elevation={1} className={classes.root} data-manifestid={manifestId}>
+      <ListItem divider elevation={1} className={[classes.root, active ? classes.active : ''].join(' ')} data-manifestid={manifestId}>
         <ReactPlaceholder
           showLoadingAnimation
           delay={500}
@@ -140,6 +141,7 @@ export class ManifestListItem extends React.Component {
 }
 
 ManifestListItem.propTypes = {
+  active: PropTypes.bool,
   addWindow: PropTypes.func.isRequired,
   classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   error: PropTypes.string,
@@ -157,6 +159,7 @@ ManifestListItem.propTypes = {
 };
 
 ManifestListItem.defaultProps = {
+  active: false,
   classes: {},
   error: null,
   handleClose: () => {},

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -6,13 +6,14 @@ import { withPlugins } from '../extend';
 import {
   getManifest,
   getManifestTitle, getManifestThumbnail, getManifestCanvases,
-  getManifestLogo, getManifestProvider,
+  getManifestLogo, getManifestProvider, getWindowManifests,
 } from '../state/selectors';
 import * as actions from '../state/actions';
 import { ManifestListItem } from '../components/ManifestListItem';
 
 /** */
 const mapStateToProps = (state, { manifestId }) => ({
+  active: getWindowManifests(state).includes(manifestId),
   error: getManifest(state, { manifestId }).error,
   isFetching: getManifest(state, { manifestId }).isFetching,
   manifestLogo: getManifestLogo(state, { manifestId }),
@@ -37,6 +38,7 @@ const mapDispatchToProps = { addWindow: actions.addWindow, fetchManifest: action
  * @returns {{root: {}, label: {textAlign: string, textTransform: string}}}
  */
 const styles = theme => ({
+  active: {},
   label: {
     textAlign: 'left',
     textTransform: 'initial',
@@ -50,6 +52,10 @@ const styles = theme => ({
   },
   root: {
     ...theme.mixins.gutters(),
+    '&$active': {
+      borderLeft: `4px solid ${theme.palette.secondary.main}`,
+    },
+    borderLeft: '4px solid transparent',
   },
 });
 

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -17,6 +17,15 @@ export function getWindowTitles(state) {
   return result;
 }
 
+/**
+ * Return the manifest titles for all open windows
+ * @param {object} state
+ * @return {object}
+ */
+export function getWindowManifests(state) {
+  return Object.values(state.windows).map(window => window.manifestId);
+}
+
 /** */
 export function getWindow(state, { windowId }) {
   return state.windows && state.windows[windowId];


### PR DESCRIPTION
fixes #2495

<img width="698" alt="Screen Shot 2019-04-12 at 12 28 07" src="https://user-images.githubusercontent.com/111218/56061518-85668000-5d1e-11e9-9cf7-94b187e4e177.png">
