### PR TITLE
 Reserve 235 pixels for the left companion windows to avoid flashes of content window

### DIFF
--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -47,7 +47,7 @@ export class CompanionArea extends Component {
           )
         }
         <Slide in={companionAreaOpen} direction="right">
-          <div className={[ns('companion-windows'), this.areaLayoutClass()].join(' ')} style={{ display: companionAreaOpen ? 'flex' : 'none' }}>
+          <div className={[ns('companion-windows'), companionWindowIds.length > 0 && classes[position], this.areaLayoutClass()].join(' ')} style={{ display: companionAreaOpen ? 'flex' : 'none' }}>
             {
               companionWindowIds.map(id => (
                 <CompanionWindowFactory id={id} key={id} windowId={windowId} />

--- a/src/containers/CompanionArea.js
+++ b/src/containers/CompanionArea.js
@@ -24,6 +24,9 @@ const styles = theme => ({
     flexDirection: 'column',
     width: '100%',
   },
+  left: {
+    width: 235,
+  },
   root: {
     display: 'flex',
     minHeight: 0,

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -18,7 +18,7 @@ import { WindowSideBarButtons } from '../components/WindowSideBarButtons';
  */
 const mapDispatchToProps = (dispatch, { windowId }) => ({
   addCompanionWindow: content => dispatch(
-    actions.addCompanionWindow(windowId, { content, position: 'left' }),
+    actions.addOrUpdateCompanionWindow(windowId, { content, position: 'left' }),
   ),
 });
 

--- a/src/state/actions/companionWindow.js
+++ b/src/state/actions/companionWindow.js
@@ -1,5 +1,6 @@
 import uuid from 'uuid/v4';
 import ActionTypes from './action-types';
+import { getCompanionWindowsForPosition } from '../selectors';
 
 const defaultProps = {
   content: null,
@@ -19,6 +20,22 @@ export function addCompanionWindow(windowId, payload, defaults = defaultProps) {
       type: ActionTypes.ADD_COMPANION_WINDOW,
       windowId,
     });
+  };
+}
+
+/** */
+export function addOrUpdateCompanionWindow(windowId, payload, defaults = defaultProps) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const { position } = payload;
+
+    const updatableWindow = position === 'left' && getCompanionWindowsForPosition(state, { position, windowId })[0];
+
+    if (updatableWindow) {
+      dispatch(updateCompanionWindow(windowId, updatableWindow.id, payload));
+    } else {
+      dispatch(addCompanionWindow(windowId, payload, defaults));
+    }
   };
 }
 


### PR DESCRIPTION
Fixes #2491 