### PR TITLE
Reduces our bundle size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-transform-runtime", "lodash"],
+  "plugins": [
+    "@babel/plugin-transform-runtime",
+    ["lodash", { "id": [
+      "lodash", "@material-ui/core", "react-placeholder",
+      ]}
+    ]],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-transform-runtime"],
+  "plugins": ["@babel/plugin-transform-runtime", "lodash"],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
     "@babel/plugin-transform-runtime",
     "transform-react-remove-prop-types",
     ["lodash", { "id": [
-      "lodash", "@material-ui/core", "react-placeholder",
+      "lodash", "react-placeholder",
       ]}
     ]],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["@babel/preset-env", "@babel/preset-react"],
   "plugins": [
     "@babel/plugin-transform-runtime",
+    "transform-react-remove-prop-types",
     ["lodash", { "id": [
       "lodash", "@material-ui/core", "react-placeholder",
       ]}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "babel-eslint": "10.0.1",
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.4",
+    "babel-plugin-lodash": "^3.3.4",
     "bundlewatch": "^0.2.1",
     "chalk": "^2.4.2",
     "codecov": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.4",
     "babel-plugin-lodash": "^3.3.4",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "bundlewatch": "^0.2.1",
     "chalk": "^2.4.2",
     "codecov": "^3.1.0",

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -4,7 +4,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import ReactPlaceholder from 'react-placeholder';
+import { ReactPlaceholder } from 'react-placeholder/lib';
 import { TextBlock, TextRow, RectShape } from 'react-placeholder/lib/placeholders';
 import Img from 'react-image';
 import ManifestListItemError from '../containers/ManifestListItemError';


### PR DESCRIPTION
Reduces our bundle size in the following ways:

1.5M - starting
1.43M - lodash cherry-picking
1.37M - material-ui/core cherry-picking
1.36M - react-placeholder cherry-picking
1.35M - transform-react-remove-prop-types
1.41M - add back material-ui/core cherry-pick until issues can be resolved

9768126e3c0073943105c1dbacb62c816999362b reverts the `@material-ui/core` updates. There were some issues with the test suite. Will look into this later when we have more time.