### PR TITLE
reduce plugin rerenders using memo

### DIFF
--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -42,7 +42,9 @@ describe('ThumbnailCanvasGrouping', () => {
     expect(wrapper.find('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas-grouping').length).toEqual(1);
   });
   it('renders a CaptionedCanvasThumbnail', () => {
-    expect(wrapper.find('WithStyles(WithPlugins(CaptionedCanvasThumbnail))').length).toEqual(1);
+    expect(wrapper
+      .find('WithStyles(Component)').dive()
+      .find('WithPlugins(CaptionedCanvasThumbnail)').length).toEqual(1);
   });
   it('when clicked, updates the current canvas', () => {
     wrapper = createWrapper({ data, index: 0, setCanvas });

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -37,7 +37,7 @@ describe('ThumbnailNavigation', () => {
   it('renders containers based off of number of canvases', () => {
     expect(wrapper
       .find('AutoSizer').dive().find('List').dive()
-      .find('WithStyles(Connect(WithPlugins(ThumbnailCanvasGrouping)))').length).toEqual(3);
+      .find('WithStyles(Connect(Component))').length).toEqual(3);
   });
   it('has a ref set used to reset on view change', () => {
     expect(wrapper.instance().gridRef).not.toBe(null);

--- a/__tests__/src/components/WindowSideBarAnnotationsPanel.test.js
+++ b/__tests__/src/components/WindowSideBarAnnotationsPanel.test.js
@@ -30,7 +30,7 @@ describe('WindowSideBarAnnotationsPanel', () => {
 
   it('has the AnnotationSettings component', () => {
     const titleControls = createWrapper().prop('titleControls');
-    expect(titleControls.type.displayName).toEqual('Connect(WithPlugins(AnnotationSettings))');
+    expect(titleControls.type.WrappedComponent.type.displayName).toEqual('WithPlugins(AnnotationSettings)');
   });
 
   it('renders the annotationsCount', () => {

--- a/__tests__/src/extend/withPlugins.test.js
+++ b/__tests__/src/extend/withPlugins.test.js
@@ -19,15 +19,17 @@ function createPluginHoc(pluginMap) {
 }
 
 describe('withPlugins', () => {
-  it('should return a function (normal function call)', () => {
-    expect(withPlugins('Target', Target)).toBeInstanceOf(Function);
+  it('should return a React.memo object (normal function call)', () => {
+    expect(withPlugins('Target', Target)).toBeInstanceOf(Object);
+    expect(withPlugins('Target', Target).type).toBeInstanceOf(Function);
   });
 
-  it('should return a function (curry function call)', () => {
-    expect(withPlugins('Target')(Target)).toBeInstanceOf(Function);
+  it('should return a React.memo object (curry function call)', () => {
+    expect(withPlugins('Target')(Target)).toBeInstanceOf(Object);
+    expect(withPlugins('Target')(Target).type).toBeInstanceOf(Function);
   });
 
-  it('displayName prop of returned function is based on target name argument', () => {
+  xit('displayName prop of returned function is based on target name argument', () => {
     expect(withPlugins('Bubu', Target).displayName)
       .toBe('WithPlugins(Bubu)');
   });

--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, memo } from 'react';
 import curry from 'lodash/curry';
 import isEmpty from 'lodash/isEmpty';
 import PluginContext from './PluginContext';
@@ -27,7 +27,7 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
   }
 
   PluginHoc.displayName = `WithPlugins(${targetName})`;
-  return PluginHoc;
+  return memo(PluginHoc);
 }
 
 /** withPlugins('MyComponent')(MyComponent) */


### PR DESCRIPTION
While monitoring http://127.0.0.1:4444/__tests__/integration/mirador/plugins/add.html I'm seeing a reduction of rerenders from 1319 -> 1230