### PR TITLE
Support theme-based overrides beyond light/dark mode

### DIFF
--- a/__tests__/src/components/ChangeThemeDialog.test.js
+++ b/__tests__/src/components/ChangeThemeDialog.test.js
@@ -10,7 +10,7 @@ function createWrapper(props) {
     <ChangeThemeDialog
       classes={{ darkColor: '#000000', lightColor: '#ffffff' }}
       handleClose={() => {}}
-      updateConfig={() => {}}
+      setSelectedTheme={() => {}}
       t={t => (t)}
       theme="light"
       {...props}
@@ -33,5 +33,14 @@ describe('ChangeThemeDialog', () => {
     expect(wrapper.find('WithStyles(ListItemText)').length).toBe(2);
     expect(wrapper.find('WithStyles(ListItemText)').first().render().text()).toBe('light');
     expect(wrapper.find('WithStyles(ListItemText)').last().render().text()).toBe('dark');
+  });
+
+  it('shows up theme selection properly', () => {
+    const setSelectedTheme = jest.fn();
+
+    wrapper = createWrapper({ setSelectedTheme });
+    wrapper.find('ListKeyboardNavigation').first().simulate('change', 'light');
+
+    expect(setSelectedTheme).toHaveBeenCalledWith('light');
   });
 });

--- a/__tests__/src/selectors/config.test.js
+++ b/__tests__/src/selectors/config.test.js
@@ -44,8 +44,8 @@ describe('getShowZoomControlsConfig', () => {
 
 describe('getTheme', () => {
   it('returns the theme', () => {
-    const state = { config: { theme: 'dark' } };
-    expect(getTheme(state)).toEqual('dark');
+    const state = { config: { theme: { whatever: 'dark' } } };
+    expect(getTheme(state)).toEqual({ whatever: 'dark' });
   });
 });
 

--- a/src/components/ChangeThemeDialog.js
+++ b/src/components/ChangeThemeDialog.js
@@ -27,9 +27,9 @@ export class ChangeThemeDialog extends Component {
    * Propagate theme palette type selection into the global state
    */
   handleThemeChange(theme) {
-    const { updateConfig, handleClose } = this.props;
+    const { setSelectedTheme, handleClose } = this.props;
 
-    updateConfig({ selectedTheme: theme });
+    setSelectedTheme(theme);
     handleClose();
   }
 
@@ -77,9 +77,9 @@ ChangeThemeDialog.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
+  setSelectedTheme: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   theme: PropTypes.string.isRequired,
-  updateConfig: PropTypes.func.isRequired,
 };
 
 ChangeThemeDialog.defaultProps = {

--- a/src/components/ChangeThemeDialog.js
+++ b/src/components/ChangeThemeDialog.js
@@ -29,13 +29,7 @@ export class ChangeThemeDialog extends Component {
   handleThemeChange(theme) {
     const { updateConfig, handleClose } = this.props;
 
-    updateConfig({
-      theme: {
-        palette: {
-          type: theme,
-        },
-      },
-    });
+    updateConfig({ selectedTheme: theme });
     handleClose();
   }
 

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -3,9 +3,18 @@ export default {
     height: 50,
     width: 50,
   },
+  selectedTheme: 'light', // dark also available
   theme: { // Sets up a MaterialUI theme. See https://material-ui.com/customization/default-theme/
+    dark: {
+      palette: {
+        type: 'dark',
+        primary: {
+          main: '#4db6ac',
+        }
+      }
+    },
     palette: {
-      type: 'light', // dark also available
+      type: 'light',
       primary: {
         main: '#1967d2',
       },

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -2,6 +2,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
+import { getTheme } from '../state/selectors';
 import { App } from '../components/App';
 
 
@@ -14,7 +15,7 @@ const mapStateToProps = state => (
   {
     isFullscreenEnabled: state.workspace.isFullscreenEnabled,
     language: state.config.language,
-    theme: state.config.theme,
+    theme: getTheme(state),
     translations: state.config.translations,
   }
 );

--- a/src/containers/ChangeThemeDialog.js
+++ b/src/containers/ChangeThemeDialog.js
@@ -11,9 +11,9 @@ import { ChangeThemeDialog } from '../components/ChangeThemeDialog';
  * @memberof ChangeThemeDialog
  * @private
  */
-const mapDispatchToProps = {
-  updateConfig: actions.updateConfig,
-};
+const mapDispatchToProps = (dispatch, { windowId }) => ({
+  setSelectedTheme: theme => dispatch(actions.updateConfig({ selectedTheme: theme })),
+});
 
 /**
  * mapStateToProps - to hook up connect

--- a/src/containers/ChangeThemeDialog.js
+++ b/src/containers/ChangeThemeDialog.js
@@ -21,7 +21,7 @@ const mapDispatchToProps = {
  * @private
  */
 const mapStateToProps = state => ({
-  theme: state.config.theme.palette.type,
+  theme: state.config.selectedTheme,
 });
 
 /** */

--- a/src/state/selectors/config.js
+++ b/src/state/selectors/config.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import deepmerge from 'deepmerge';
 
 /** */
 function getConfig(state) {
@@ -26,7 +27,7 @@ export const getShowZoomControlsConfig = createSelector(
 
 export const getTheme = createSelector(
   [getConfig],
-  ({ theme }) => theme,
+  ({ theme, selectedTheme }) => deepmerge(theme, theme[selectedTheme] || {}),
 );
 
 export const getWorkspaceType = createSelector(


### PR DESCRIPTION
This allows e.g. the primary color to change between light + dark modes.

![2019-04-16 07-56-56 2019-04-16 07_58_28](https://user-images.githubusercontent.com/111218/56220538-74b75200-601d-11e9-8c77-1906f05a92e2.gif)
