### PR TITLE
Make left companion windows resizable

### DIFF
--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -33,6 +33,10 @@ export class CompanionWindow extends Component {
       return { ...base, left: true };
     }
 
+    if (position === 'left') {
+      return { ...base, right: true };
+    }
+
     if (position === 'bottom' || position === 'far-bottom') {
       return { ...base, top: true };
     }
@@ -71,7 +75,7 @@ export class CompanionWindow extends Component {
           disableDragging
           enableResizing={this.resizeHandles()}
           minHeight={50}
-          minWidth={100}
+          minWidth={position === 'left' ? 235 : 100}
         >
 
           <Toolbar className={[classes.toolbar, size.width < 370 ? classes.small : null, ns('companion-window-header')].join(' ')} disableGutters>

--- a/src/containers/CompanionArea.js
+++ b/src/containers/CompanionArea.js
@@ -25,7 +25,7 @@ const styles = theme => ({
     width: '100%',
   },
   left: {
-    width: 235,
+    minWidth: 235,
   },
   root: {
     display: 'flex',


### PR DESCRIPTION
This ends up somewhat breaking the fix from 5995291, though, where people have resized the companion window... it seems like we need to get much more clever about positioning the hide/show toggle.