### PR TITLE
Update hover active states to outline for ThumbnailNavigation

### DIFF
--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -58,9 +58,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
           onClick={this.setCanvas}
           tabIndex={-1}
           style={{
-            display: 'inline-block',
             height: (position === 'far-right') ? 'auto' : `${height - SPACING}px`,
-            whiteSpace: 'nowrap',
             width: (position === 'far-bottom') ? 'auto' : `${style.width}px`,
           }}
           className={classNames(

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -32,12 +32,19 @@ const mapStateToProps = (state, { data }) => ({
 const styles = theme => ({
   canvas: {
     '&$currentCanvas': {
-      border: `2px solid ${theme.palette.secondary.main}`,
+      outline: `2px solid ${theme.palette.secondary.main}`,
+      outlineOffset: '3px',
     },
-    border: '2px solid transparent',
+    '&:hover': {
+      outline: '9px solid rgba(0, 0, 0, 0.08)',
+      outlineOffset: '-2px',
+    },
     boxSizing: 'border-box',
     color: theme.palette.common.white,
     cursor: 'pointer',
+    display: 'inline-block',
+    outline: 0,
+    whiteSpace: 'nowrap',
   },
   currentCanvas: {
   },


### PR DESCRIPTION
We should wait on #2520 as that will have implications on the dark mode needs.