### PR TITLE
Sets paged view by default for manifests and sequences

### DIFF
--- a/__tests__/fixtures/version-2/015.json
+++ b/__tests__/fixtures/version-2/015.json
@@ -1,0 +1,57 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json", 
+  "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/15/manifest.json", 
+  "@type": "sc:Manifest", 
+  "label": "Test 15 Manifest: ViewingHint: paged (Modified to be on sequence also)",
+  "within": "http://iiif.io/api/presentation/2.0/example/fixtures/collection.json",
+  "viewingHint": "individuals",
+  "sequences": [
+    {
+      "@type": "sc:Sequence", 
+      "label": "Test 15 Sequence 1", 
+      "viewingHint": "paged",
+      "canvases": [
+        {
+          "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c1.json", 
+          "@type": "sc:Canvas", 
+          "label": "Test 15 Canvas: 1", 
+          "height": 1800, 
+          "width": 1200, 
+          "images": [
+            {
+              "@type": "oa:Annotation", 
+              "motivation": "sc:painting", 
+              "resource": {
+                "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/resources/page1-full.png", 
+                "@type": "dctypes:Image", 
+                "height": 1800, 
+                "width": 1200
+              }, 
+              "on": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c1.json"
+            }
+          ]
+        }, 
+        {
+          "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c2.json", 
+          "@type": "sc:Canvas", 
+          "label": "Test 15 Canvas: 2", 
+          "height": 1800, 
+          "width": 1200, 
+          "images": [
+            {
+              "@type": "oa:Annotation", 
+              "motivation": "sc:painting", 
+              "resource": {
+                "@id": "http://iiif.io/api/presentation/2.0/example/fixtures/resources/page2-full.png", 
+                "@type": "dctypes:Image", 
+                "height": 1800, 
+                "width": 1200
+              }, 
+              "on": "http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c2.json"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/src/actions/window.test.js
+++ b/__tests__/src/actions/window.test.js
@@ -106,7 +106,6 @@ describe('window actions', () => {
           rangeId: null,
           rotation: null,
           sideBarPanel: 'info',
-          view: 'single',
         },
       };
 

--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -1,6 +1,7 @@
 import manifesto from 'manifesto.js';
 import manifestFixture001 from '../../fixtures/version-2/001.json';
 import manifestFixture002 from '../../fixtures/version-2/002.json';
+import manifestFixture015 from '../../fixtures/version-2/015.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import manifestFixtureSn904cj3429 from '../../fixtures/version-2/sn904cj3429.json';
 import manifestFixturev3001 from '../../fixtures/version-3/001.json';
@@ -21,6 +22,7 @@ import {
   getManifestRelatedContent,
   getManifestRenderings,
   getManifestUrl,
+  getManifestViewingHint,
   getMetadataLocales,
   getRequiredStatement,
   getRights,
@@ -439,5 +441,22 @@ describe('getManifestStartCanvasIndex', () => {
   it('is undefined if no start canvas is specified', () => {
     const state = { manifests: { x: { json: manifestFixture001 } } };
     expect(getManifestStartCanvasIndex(state, { manifestId: 'x' })).toEqual(undefined);
+  });
+});
+
+describe('getManifestViewingHint', () => {
+  it('gets from the manifest', () => {
+    const state = { manifests: { x: { json: manifestFixture001 } } };
+    expect(getManifestViewingHint(state, { manifestId: 'x' })).toEqual('individuals');
+  });
+
+  it('gets from the sequence', () => {
+    const state = { manifests: { x: { json: manifestFixture015 } } };
+    expect(getManifestViewingHint(state, { manifestId: 'x' })).toEqual('paged');
+  });
+
+  it('is null if no viewingHint is specified', () => {
+    const state = { manifests: { x: { json: manifestFixture019 } } };
+    expect(getManifestViewingHint(state, { manifestId: 'x' })).toBeNull();
   });
 });

--- a/__tests__/src/selectors/windows.test.js
+++ b/__tests__/src/selectors/windows.test.js
@@ -1,5 +1,6 @@
 import manifestFixture001 from '../../fixtures/version-2/001.json';
 import manifestFixture002 from '../../fixtures/version-2/002.json';
+import manifestFixture015 from '../../fixtures/version-2/015.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import {
   getWindowTitles,
@@ -112,9 +113,16 @@ describe('getCanvasIndex', () => {
 
 describe('getWindowViewType', () => {
   const state = {
+    manifests: {
+      x: { json: { ...manifestFixture001 } },
+      y: { json: { ...manifestFixture015 } },
+    },
     windows: {
       a: { id: 'a', view: 'single' },
       b: { id: 'b' },
+      d: { id: 'd', manifestId: 'x' },
+      e: { id: 'e', manifestId: 'x', view: 'book' },
+      f: { id: 'f', manifestId: 'y' },
     },
   };
 
@@ -131,6 +139,21 @@ describe('getWindowViewType', () => {
   it('should return undefined if window does not exists', () => {
     const received = getWindowViewType(state, { windowId: 'c' });
     expect(received).toBeUndefined();
+  });
+
+  it('should return modified viewingHint if view type does not exist', () => {
+    const received = getWindowViewType(state, { windowId: 'd' });
+    expect(received).toEqual('single');
+  });
+
+  it('should return window view type even if viewingHint is available', () => {
+    const received = getWindowViewType(state, { windowId: 'e' });
+    expect(received).toEqual('book');
+  });
+
+  it('should return modified viewingHint for a book', () => {
+    const received = getWindowViewType(state, { windowId: 'f' });
+    expect(received).toEqual('book');
   });
 });
 

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -13,16 +13,19 @@ import { getManifestCanvases, getCanvasIndex, getWindowViewType } from '../state
  * @memberof ThumbnailNavigation
  * @private
  */
-const mapStateToProps = (state, { windowId }) => ({
-  canvasGroupings: new CanvasGroupings(
-    getManifestCanvases(state, { windowId }),
-    state.windows[windowId].view,
-  ),
-  canvasIndex: getCanvasIndex(state, { windowId }),
-  config: state.config,
-  position: state.companionWindows[state.windows[windowId].thumbnailNavigationId].position,
-  view: getWindowViewType(state, { windowId }),
-});
+const mapStateToProps = (state, { windowId }) => {
+  const viewType = getWindowViewType(state, { windowId });
+  return {
+    canvasGroupings: new CanvasGroupings(
+      getManifestCanvases(state, { windowId }),
+      viewType,
+    ),
+    canvasIndex: getCanvasIndex(state, { windowId }),
+    config: state.config,
+    position: state.companionWindows[state.windows[windowId].thumbnailNavigationId].position,
+    view: viewType,
+  };
+};
 
 /**
  * mapDispatchToProps - used to hook up connect to action creators

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -60,7 +60,6 @@ export function addWindow(options) {
       selectedAnnotations: {},
       sideBarPanel: 'info',
       thumbnailNavigationId: cwThumbs,
-      view: 'single',
     };
 
     const elasticLayout = {

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -380,3 +380,21 @@ export const getManifestStartCanvasIndex = createSelector(
     return ((canvasId && manifest.getSequences()[0].getCanvasById(canvasId)) || {}).index;
   },
 );
+
+/**
+ * Returns the viewing hint for the first sequence in the manifest or the manifest
+ * @param {object} state
+ * @param {object} props
+ * @param {string} props.manifestId
+ * @param {string} props.windowId
+ * @return {Number}
+ */
+export const getManifestViewingHint = createSelector(
+  [getManifestoInstance],
+  (manifest) => {
+    if (!manifest) return null;
+    const viewingHint = manifest.getSequences()[0].getViewingHint() || manifest.getViewingHint();
+    if (viewingHint) return viewingHint.value;
+    return null;
+  },
+);

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { getManifestTitle, getManifestStartCanvasIndex } from './manifests';
+import { getManifestTitle, getManifestStartCanvasIndex, getManifestViewingHint } from './manifests';
 import { getWorkspaceType } from './config';
 
 /**
@@ -74,8 +74,14 @@ export const getCanvasIndex = createSelector(
 * @param {String}
 */
 export const getWindowViewType = createSelector(
-  [getWindow],
-  window => window && window.view,
+  [getWindow, getManifestViewingHint],
+  (window, manifestViewingHint) => {
+    const lookup = {
+      individuals: 'single',
+      paged: 'book',
+    };
+    return (window && window.view) || lookup[manifestViewingHint];
+  },
 );
 
 export const getViewer = createSelector(


### PR DESCRIPTION
For IIIF manifests and sequence that set a viewingHint to paged,
Mirador3 will now automatically put the view into "book" view.
Fixes #1443
Fixes #1440

A user action here will always override the manifest behavior.

![paged by default](https://user-images.githubusercontent.com/1656824/56309672-3e560180-6107-11e9-882f-0a236d957dfa.gif)
