### PR TITLE
Update Export workspace dialog for dark theme; fixes #2560

### DIFF
--- a/__tests__/src/components/WorkspaceImport.test.js
+++ b/__tests__/src/components/WorkspaceImport.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { WorkspaceImport } from '../../../src/components/WorkspaceImport';
+
+describe('WorkspaceImport', () => {
+  let wrapper;
+  let handleClose;
+  let mockState;
+
+  beforeEach(() => {
+    handleClose = jest.fn();
+    mockState = {
+      configImportValue: {},
+    };
+
+    wrapper = shallow(
+      <WorkspaceImport
+        open
+        handleClose={handleClose}
+        state={mockState}
+      />,
+    );
+  });
+
+  it('renders without an error', () => {
+    expect(wrapper.find('WithStyles(Dialog)').length).toBe(1);
+  });
+});

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -64,7 +64,7 @@ export class WorkspaceExport extends Component {
           </pre>
         </DialogContent>
         <DialogActions>
-          <Button color="primary" onClick={() => handleClose()}>{t('cancel')}</Button>
+          <Button className={classes.cancelBtn} onClick={() => handleClose()}>{t('cancel')}</Button>
           <CopyToClipboard
             text={exportableState}
           >

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -41,7 +41,7 @@ export class WorkspaceExport extends Component {
    */
   render() {
     const {
-      children, container, handleClose, open, t,
+      children, classes, container, handleClose, open, t,
     } = this.props;
     const exportableState = this.exportableState();
     return (
@@ -55,7 +55,9 @@ export class WorkspaceExport extends Component {
         <DialogTitle id="form-dialog-title" disableTypography>
           <Typography variant="h2">{t('downloadExport')}</Typography>
         </DialogTitle>
-        <DialogContent>
+        <DialogContent
+          className={classes.dialogcontent}
+        >
           {children}
           <pre>
             {exportableState}
@@ -76,6 +78,7 @@ export class WorkspaceExport extends Component {
 
 WorkspaceExport.propTypes = {
   children: PropTypes.node,
+  classes: PropTypes.objectOf(PropTypes.string),
   container: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
@@ -85,6 +88,7 @@ WorkspaceExport.propTypes = {
 
 WorkspaceExport.defaultProps = {
   children: null,
+  classes: {},
   container: null,
   open: false,
   t: key => key,

--- a/src/components/WorkspaceImport.js
+++ b/src/components/WorkspaceImport.js
@@ -88,7 +88,7 @@ export class WorkspaceImport extends Component {
           <DialogContentText className={classes.hint}>{t('importWorkspaceHint')}</DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button color="primary" onClick={handleClose}>
+          <Button className={classes.cancelBtn} onClick={handleClose}>
             {t('cancel')}
           </Button>
           <Button color="primary" onClick={this.handleImportConfig} variant="contained">

--- a/src/components/WorkspaceImport.js
+++ b/src/components/WorkspaceImport.js
@@ -102,7 +102,7 @@ export class WorkspaceImport extends Component {
 
 WorkspaceImport.propTypes = {
   addError: PropTypes.func.isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  classes: PropTypes.objectOf(PropTypes.string),
   handleClose: PropTypes.func.isRequired,
   importConfig: PropTypes.func.isRequired,
   open: PropTypes.bool,
@@ -110,6 +110,7 @@ WorkspaceImport.propTypes = {
 };
 
 WorkspaceImport.defaultProps = {
+  classes: {},
   open: false,
   t: key => key,
 };

--- a/src/containers/WorkspaceExport.js
+++ b/src/containers/WorkspaceExport.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend/withPlugins';
 import { WorkspaceExport } from '../components/WorkspaceExport';
 
@@ -11,8 +12,20 @@ import { WorkspaceExport } from '../components/WorkspaceExport';
  */
 const mapStateToProps = state => ({ state });
 
+/**
+ *
+ * @param theme
+ */
+const styles = theme => ({
+  dialogcontent: {
+    backgroundColor: theme.palette.shades.light,
+    color: theme.palette.text.primary,
+  },
+});
+
 const enhance = compose(
   withTranslation(),
+  withStyles(styles),
   connect(mapStateToProps, {}),
   withPlugins('WorkspaceExport'),
 );

--- a/src/containers/WorkspaceExport.js
+++ b/src/containers/WorkspaceExport.js
@@ -17,6 +17,9 @@ const mapStateToProps = state => ({ state });
  * @param theme
  */
 const styles = theme => ({
+  cancelBtn: {
+    color: theme.palette.text.primary,
+  },
   dialogcontent: {
     backgroundColor: theme.palette.shades.light,
     color: theme.palette.text.primary,

--- a/src/containers/WorkspaceImport.js
+++ b/src/containers/WorkspaceImport.js
@@ -18,6 +18,9 @@ const mapDispatchToProps = {
 
 /** */
 const styles = theme => ({
+  cancelBtn: {
+    color: theme.palette.text.primary,
+  },
   hint: {
     maxWidth: '400px',
   },


### PR DESCRIPTION
Fixes #2560

This PR connects the `WorkspaceExport` component to the theme and improves color contrast for the "Export workspace" dialog in the dark theme.

## Before
<img width="613" alt="dark-theme-before" src="https://user-images.githubusercontent.com/5402927/56329327-c8b65980-6137-11e9-8edd-b766caec20e9.png">

## After
<img width="604" alt="dark-theme-with-improved-color-contrast" src="https://user-images.githubusercontent.com/5402927/56329329-c8b65980-6137-11e9-93d8-2d721897ae6a.png">