### PR TITLE
Handle initial focus/selection of the WindowList component.

### DIFF
--- a/__tests__/src/components/WindowList.test.js
+++ b/__tests__/src/components/WindowList.test.js
@@ -81,25 +81,21 @@ describe('WindowList', () => {
     });
   });
 
-  describe('with multiple windows', () => {
-    beforeEach(() => {
-      titles = { xyz: 'Some title' };
+  describe('focus2ndListIitem', () => {
+    const mockListItem = jest.fn();
+    /** */
+    const mockSingleItemMenu = { querySelectorAll: () => [{ focus: mockListItem }] };
+    /** */
+    const mockMultiItemMenu = { querySelectorAll: () => ['Header', { focus: mockListItem }] };
 
-      wrapper = shallow(
-        <WindowList
-          containerId="mirador"
-          anchorEl={{}}
-          titles={titles}
-          windowIds={['xyz', 'zyx']}
-          handleClose={handleClose}
-          focusWindow={focusWindow}
-        />,
-      );
+    it('does not set focus if there is only one list item (the header)', () => {
+      WindowList.focus2ndListIitem(mockSingleItemMenu);
+      expect(mockListItem).not.toHaveBeenCalled();
     });
 
-    it('has the first window in the list selected', () => {
-      expect(wrapper.find('WithStyles(MenuItem)').first().props().selected).toBe(true);
-      expect(wrapper.find('WithStyles(MenuItem)').last().props().selected).toBe(false);
+    it('sets focus on the 2nd list item', () => {
+      WindowList.focus2ndListIitem(mockMultiItemMenu);
+      expect(mockListItem).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/WindowList.js
+++ b/src/components/WindowList.js
@@ -10,6 +10,16 @@ import ns from '../config/css-ns';
  */
 export class WindowList extends Component {
   /**
+   * Given the menuElement passed in by the onEntering callback,
+   * find the 2nd ListItem element (avoiding the header) and focus it
+  */
+  static focus2ndListIitem(menuElement) {
+    if (!menuElement.querySelectorAll('li') || menuElement.querySelectorAll('li').length < 2) return;
+
+    menuElement.querySelectorAll('li')[1].focus(); // The 2nd LI
+  }
+
+  /**
    * Get the title for a window from its manifest title
    * @private
    */
@@ -40,9 +50,11 @@ export class WindowList extends Component {
         }}
         id="window-list-menu"
         container={document.querySelector(`#${containerId} .${ns('viewer')}`)}
+        disableAutoFocusItem
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleClose}
+        onEntering={WindowList.focus2ndListIitem}
       >
         <ListSubheader role="presentation" selected={false} disabled tabIndex="-1">
           {t('openWindows')}
@@ -51,7 +63,6 @@ export class WindowList extends Component {
           windowIds.map((windowId, i) => (
             <MenuItem
               key={windowId}
-              selected={i === 0}
               onClick={(e) => { focusWindow(windowId, true); handleClose(e); }}
             >
               <ListItemText primaryTypographyProps={{ variant: 'body1' }}>


### PR DESCRIPTION
- DisableAutoFocus on menu
- Remove selected prop from first ListItem
- Add custom onEntering function to focus the 2nd ListItem

Part of #2479 

## Before
Notice that the darker, active color is applied to the Van Gogh self portrait. However, if you look at the workspace, the focused window is actually the illustration of Krishna and Radha. 
![confusing-selection](https://user-images.githubusercontent.com/5402927/56438801-fb2b9800-6298-11e9-8996-a864fda6695c.gif)

## After

### Menu navigated by mouse
![fixed-selection](https://user-images.githubusercontent.com/5402927/56438807-0088e280-6299-11e9-82bc-db10ac5c33b4.gif)

### Menu navigated by keyboard
![keyboard-selection](https://user-images.githubusercontent.com/5402927/56439036-a76d7e80-6299-11e9-9557-0d0c8a64a4d3.gif)
