### PR TITLE
Add the correct button styling to workspace control panel buttons…

### DIFF
--- a/__tests__/src/components/WorkspaceOptionsButton.test.js
+++ b/__tests__/src/components/WorkspaceOptionsButton.test.js
@@ -8,6 +8,7 @@ import { WorkspaceOptionsButton } from '../../../src/components/WorkspaceOptions
 function createShallow(props) {
   return shallow(
     <WorkspaceOptionsButton
+      classes={{}}
       t={k => k}
       {...props}
     />,

--- a/src/components/WindowListButton.js
+++ b/src/components/WindowListButton.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import BookmarksIcon from '@material-ui/icons/BookmarksSharp';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import WindowList from '../containers/WindowList';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 
@@ -42,6 +43,9 @@ export class WindowListButton extends Component {
           aria-haspopup="true"
           aria-label={t('listAllOpenWindows')}
           aria-owns={windowListAnchor ? 'window-list' : null}
+          className={
+            classNames(classes.ctrlBtn, (windowListAnchor ? classes.ctrlBtnSelected : null))
+          }
           disabled={disabled}
           badge
           BadgeProps={{ badgeContent: windowCount, classes: { badge: classes.badge } }}

--- a/src/components/WorkspaceOptionsButton.js
+++ b/src/components/WorkspaceOptionsButton.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import MoreHorizontalIcon from '@material-ui/icons/MoreHorizSharp';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 import WorkspaceOptionsMenu from '../containers/WorkspaceOptionsMenu';
@@ -40,13 +41,16 @@ export class WorkspaceOptionsButton extends Component {
    * Returns the rendered component
   */
   render() {
-    const { t } = this.props;
+    const { classes, t } = this.props;
     const { anchorEl } = this.state;
 
     return (
       <>
         <MiradorMenuButton
           aria-label={t('workspaceOptions')}
+          className={
+            classNames(classes.ctrlBtn, (anchorEl ? classes.ctrlBtnSelected : null))
+          }
           onClick={this.handleMenuClick}
         >
           <MoreHorizontalIcon />
@@ -62,5 +66,6 @@ export class WorkspaceOptionsButton extends Component {
 }
 
 WorkspaceOptionsButton.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
   t: PropTypes.func.isRequired,
 };

--- a/src/containers/WindowListButton.js
+++ b/src/containers/WindowListButton.js
@@ -20,6 +20,12 @@ const styles = theme => ({
   badge: {
     paddingLeft: 12,
   },
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+  ctrlBtnSelected: {
+    backgroundColor: theme.palette.action.selected,
+  },
 });
 
 const enhance = compose(

--- a/src/containers/WorkspaceOptionsButton.js
+++ b/src/containers/WorkspaceOptionsButton.js
@@ -1,9 +1,25 @@
 import { compose } from 'redux';
 import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { WorkspaceOptionsButton } from '../components/WorkspaceOptionsButton';
 
+/**
+ *
+ * @param theme
+ */
+const styles = theme => ({
+  ctrlBtn: {
+    margin: theme.spacing.unit,
+  },
+  ctrlBtnSelected: {
+    backgroundColor: theme.palette.action.selected,
+  },
+});
+
+
 const enhance = compose(
+  withStyles(styles),
   withTranslation(),
   withPlugins('WorkspaceOptionsButton'),
 );


### PR DESCRIPTION
… (so they don't get wide focus backgrounds).

## Before
<img width="65" alt="before" src="https://user-images.githubusercontent.com/96776/56391084-7ed67d80-61e2-11e9-961d-b99c1e122578.png">

## After
<img width="64" alt="after" src="https://user-images.githubusercontent.com/96776/56391087-80a04100-61e2-11e9-8975-afe80a84dc01.png">
