### PR TITLE
Update palette-to-component mappings

### DIFF
--- a/__tests__/src/components/WindowThumbnailSettings.test.js
+++ b/__tests__/src/components/WindowThumbnailSettings.test.js
@@ -29,13 +29,13 @@ describe('WindowThumbnailSettings', () => {
     expect(labels.at(2).props().value).toBe('far-right');
   });
 
-  it('should set the correct label active (by setting the primary color)', () => {
+  it('should set the correct label active (by setting the secondary color)', () => {
     let wrapper = createWrapper({ thumbnailNavigationPosition: 'far-bottom' });
-    expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).toEqual('primary');
-    expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).not.toEqual('primary');
+    expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).toEqual('secondary');
+    expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).not.toEqual('secondary');
 
     wrapper = createWrapper({ thumbnailNavigationPosition: 'far-right' });
-    expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).toEqual('primary');
+    expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).toEqual('secondary');
   });
 
   it('updates state when the thumbnail config selection changes', () => {

--- a/__tests__/src/components/WindowViewSettings.test.js
+++ b/__tests__/src/components/WindowViewSettings.test.js
@@ -29,16 +29,16 @@ describe('WindowViewSettings', () => {
     expect(labels.at(2).props().value).toBe('gallery');
   });
 
-  it('should set the correct label active (by setting the primary color)', () => {
+  it('should set the correct label active (by setting the secondary color)', () => {
     let wrapper = createWrapper({ windowViewType: 'single' });
-    expect(wrapper.find(FormControlLabel).at(0).props().control.props.color).toEqual('primary');
-    expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).not.toEqual('primary');
+    expect(wrapper.find(FormControlLabel).at(0).props().control.props.color).toEqual('secondary');
+    expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).not.toEqual('secondary');
 
     wrapper = createWrapper({ windowViewType: 'book' });
-    expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).toEqual('primary');
+    expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).toEqual('secondary');
 
     wrapper = createWrapper({ windowViewType: 'gallery' });
-    expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).toEqual('primary');
+    expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).toEqual('secondary');
   });
 
   it('updates state when the view config selection changes', () => {

--- a/src/components/AnnotationSettings.js
+++ b/src/components/AnnotationSettings.js
@@ -24,7 +24,7 @@ export class AnnotationSettings extends Component {
             disabled={displayAllDisabled}
             onChange={toggleAnnotationDisplay}
             value={displayAll ? 'all' : 'select'}
-            color="primary"
+            color="secondary"
           />
         )}
         label={t('displayAllAnnotations')}

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -179,7 +179,7 @@ export class WindowSideBarButtons extends Component {
           <TabButton
             value="annotations"
             icon={(
-              <Badge color="secondary" invisible={!hasAnnotations} variant="dot">
+              <Badge classes={{ badge: classes.badge }} invisible={!hasAnnotations} variant="dot">
                 <AnnotationIcon />
               </Badge>
             )}

--- a/src/components/WindowThumbnailSettings.js
+++ b/src/components/WindowThumbnailSettings.js
@@ -46,7 +46,7 @@ export class WindowThumbnailSettings extends Component {
             value="off"
             classes={{ label: thumbnailNavigationPosition === 'off' ? classes.selectedLabel : classes.label }}
             control={
-              <ThumbnailsOffIcon color={thumbnailNavigationPosition === 'off' ? 'primary' : undefined} />
+              <ThumbnailsOffIcon color={thumbnailNavigationPosition === 'off' ? 'secondary' : undefined} />
             }
             label={t('off')}
             labelPlacement="bottom"
@@ -57,7 +57,7 @@ export class WindowThumbnailSettings extends Component {
             value="far-bottom"
             classes={{ label: thumbnailNavigationPosition === 'far-bottom' ? classes.selectedLabel : classes.label }}
             control={
-              <ThumbnailNavigationBottomIcon color={thumbnailNavigationPosition === 'far-bottom' ? 'primary' : undefined} />
+              <ThumbnailNavigationBottomIcon color={thumbnailNavigationPosition === 'far-bottom' ? 'secondary' : undefined} />
             }
             label={t('bottom')}
             labelPlacement="bottom"
@@ -68,7 +68,7 @@ export class WindowThumbnailSettings extends Component {
             value="far-right"
             classes={{ label: thumbnailNavigationPosition === 'far-right' ? classes.selectedLabel : classes.label }}
             control={
-              <ThumbnailNavigationRightIcon color={thumbnailNavigationPosition === 'far-right' ? 'primary' : undefined} />
+              <ThumbnailNavigationRightIcon color={thumbnailNavigationPosition === 'far-right' ? 'secondary' : undefined} />
             }
             label={t('right')}
             labelPlacement="bottom"

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -70,7 +70,7 @@ export class WindowViewSettings extends Component {
           <FormControlLabel
             value="single"
             classes={{ label: windowViewType === 'single' ? classes.selectedLabel : classes.label }}
-            control={<SingleIcon color={windowViewType === 'single' ? 'primary' : undefined} />}
+            control={<SingleIcon color={windowViewType === 'single' ? 'secondary' : undefined} />}
             label={t('single')}
             labelPlacement="bottom"
           />
@@ -79,7 +79,7 @@ export class WindowViewSettings extends Component {
           <FormControlLabel
             value="book"
             classes={{ label: windowViewType === 'book' ? classes.selectedLabel : classes.label }}
-            control={<BookViewIcon color={windowViewType === 'book' ? 'primary' : undefined} />}
+            control={<BookViewIcon color={windowViewType === 'book' ? 'secondary' : undefined} />}
             label={t('book')}
             labelPlacement="bottom"
           />
@@ -88,7 +88,7 @@ export class WindowViewSettings extends Component {
           <FormControlLabel
             value="gallery"
             classes={{ label: windowViewType === 'gallery' ? classes.selectedLabel : classes.label }}
-            control={<GalleryViewIcon color={windowViewType === 'gallery' ? 'primary' : undefined} />}
+            control={<GalleryViewIcon color={windowViewType === 'gallery' ? 'secondary' : undefined} />}
             label={t('gallery')}
             labelPlacement="bottom"
           />

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -44,6 +44,9 @@ export default {
       error: {
         main: '#b00020',
       },
+      notification: { // Color used in MUI Badge dots
+        main: '#ffa224'
+      },
       section_divider: 'rgba(0, 0, 0, 0.25)',
     },
     typography: {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -31,10 +31,10 @@ export default {
     palette: {
       type: 'light',
       primary: {
-        main: '#1967d2',
+        main: '#1967d2', // Controls the color of the Add button and current window indicator
       },
       secondary: {
-        main: '#1967d2',
+        main: '#1967d2', // Controls the color of Selects and FormControls
       },
       shades: { // Shades that can be used to offset color areas of the Workspace / Window
         dark: '#eeeeee',

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -11,6 +11,9 @@ export default {
         primary: {
           main: '#4db6ac',
         },
+        secondary: {
+          main: '#4db6ac',
+        },
         shades: {
           dark: '#000000',
           main: '#424242',
@@ -31,7 +34,7 @@ export default {
         main: '#1967d2',
       },
       secondary: {
-        main: '#ffa224',
+        main: '#1967d2',
       },
       shades: { // Shades that can be used to offset color areas of the Workspace / Window
         dark: '#eeeeee',

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -36,6 +36,9 @@ const mapStateToProps = (state, { windowId }) => ({
 
 /** */
 const style = theme => ({
+  badge: {
+    backgroundColor: theme.palette.notification.main,
+  },
   tab: {
     '&:active': {
       backgroundColor: theme.palette.action.active,

--- a/src/containers/WindowThumbnailSettings.js
+++ b/src/containers/WindowThumbnailSettings.js
@@ -34,8 +34,8 @@ const styles = theme => ({
     display: 'inline',
   },
   selectedLabel: {
-    borderBottom: `2px solid ${theme.palette.primary.main}`,
-    color: theme.palette.primary.main,
+    borderBottom: `2px solid ${theme.palette.secondary.main}`,
+    color: theme.palette.secondary.main,
   },
 });
 

--- a/src/containers/WindowViewSettings.js
+++ b/src/containers/WindowViewSettings.js
@@ -35,8 +35,8 @@ const styles = theme => ({
     display: 'inline',
   },
   selectedLabel: {
-    borderBottom: `2px solid ${theme.palette.primary.main}`,
-    color: theme.palette.primary.main,
+    borderBottom: `2px solid ${theme.palette.secondary.main}`,
+    color: theme.palette.secondary.main,
   },
 });
 


### PR DESCRIPTION
Closes #2563

This PR:
- Sets the same hex value for `primary.main` and `secondary.main` in Mirador's default settings. Sets the Selects and FormControls to `secondary.main`. This will give implementers a little more flexibility in customizing their Mirador instances (see description in #2563). 
- Adds a `notification.main` color to the palette and wires it up to the annotations icon

To test out the new mapping,  change the secondary color in your browser console:

```javascript
var action = miradorInstance.actions.updateConfig({
  theme: {
    palette: {
      secondary: {
        main: '#ba55d3',
      },
    },
  },
});
miradorInstance.store.dispatch(action);
```
### Example with custom `secondary.main` value
![Screenshot illustrating palette mappings](https://user-images.githubusercontent.com/5402927/56397519-f31c1b80-61f8-11e9-8070-96c8f00b8061.png)
