### PR TITLE
Disable ripple on the WindowSideBar tabs and add a focus style to …

### DIFF
--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -145,7 +145,7 @@ export class WindowSideBarButtons extends Component {
           aria-label={
             t('openCompanionWindow', { context: props.value })
           }
-          TouchRippleProps={{ classes: { child: classes.tabRipple } }}
+          disableRipple
           onKeyUp={this.handleKeyUp}
         />
       </Tooltip>

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -43,6 +43,14 @@ const style = theme => ({
     '&:active': {
       backgroundColor: theme.palette.action.active,
     },
+    '&:focus': {
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+      backgroundColor: theme.palette.action.hover,
+      textDecoration: 'none',
+      // Reset on touch devices, it doesn't add specificity
+    },
     '&:hover': {
       '@media (hover: none)': {
         backgroundColor: 'transparent',
@@ -54,9 +62,6 @@ const style = theme => ({
 
     borderRight: '2px solid transparent',
     minWidth: 'auto',
-  },
-  tabRipple: {
-    backgroundColor: theme.palette.action.active,
   },
   tabSelected: {
     borderRight: `2px solid ${theme.palette.primary.main}`,


### PR DESCRIPTION
…match the tab's current hover style.

Part of #2479 

## Before
![before](https://user-images.githubusercontent.com/96776/56440531-8a877a00-629e-11e9-85a5-d6ef288bc796.gif)

## After
![after](https://user-images.githubusercontent.com/96776/56440532-8a877a00-629e-11e9-816c-a78adbaacb1c.gif)
