### PR TITLE
Disable the pulsating button animation.

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -168,6 +168,14 @@ export default {
           },
         },
       },
+      MuiTouchRipple: {
+        childPulsate: {
+          animation: 'none',
+        },
+        rippleVisible: {
+          animation: 'none',
+        },
+      },
     },
     props: {
       MuiButtonBase: {


### PR DESCRIPTION
This still retains the focus background, just stops the animation.

Part of #2479 