### PR TITLE
Make MuiListSubheaders that have role=presentation have no focus …

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -146,6 +146,13 @@ export default {
       useNextVariants: true // set so that console deprecation warning is removed
     },
     overrides: {
+      MuiListSubheader: {
+        root: {
+          '&[role="presentation"]:focus': {
+            outline: 0,
+          },
+        },
+      },
       MuiTooltip: { // Overridden from https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js#L40-L70
         tooltipPlacementLeft: {
           ['@media (min-width:600px)']: {


### PR DESCRIPTION
…outline.

Part of #2479 

## Before
![beforeFocus](https://user-images.githubusercontent.com/96776/56444787-08538180-62af-11e9-8341-3728fc4b9508.gif)

## After
![afterFocus](https://user-images.githubusercontent.com/96776/56444786-08538180-62af-11e9-8366-9475497f9b96.gif)

