### PR TITLE
Prevent OSD from performing click-to-zoom when the window just received focus.

### DIFF
--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -20,6 +20,7 @@ import {
  */
 const mapStateToProps = (state, { windowId }) => ({
   canvasWorld: new CanvasWorld(getSelectedCanvases(state, { windowId })),
+  focused: state.workspace.focusedWindowId === windowId,
   highlightedAnnotations: getHighlightedAnnotationsOnCanvases(state, { windowId }),
   label: getCanvasLabel(state, { windowId }),
   selectedAnnotations: getSelectedAnnotationsOnCanvases(state, { windowId }),


### PR DESCRIPTION
(Note: this is targeting `2573-preventDefaultAction)

I don't know if this fixes the most annoying part of #2573 (where clicking a window to get focus also ends up zooming the canvas) without disabling click-to-zoom for all other uses.

If it's acceptable, I can fix up the tests as needed.