### PR TITLE
Enables custom manifestHeaders to be sent from configuration Fixes #1969

### DIFF
--- a/__tests__/src/actions/manifest.test.js
+++ b/__tests__/src/actions/manifest.test.js
@@ -38,6 +38,13 @@ describe('manifest actions', () => {
     beforeEach(() => {
       store = mockStore({});
     });
+    describe('custom resourceHeaders', () => {
+      it('are sent', () => {
+        store = mockStore({ config: { resourceHeaders: { Accept: 'hello' } } });
+        store.dispatch(actions.fetchManifest('https://purl.stanford.edu/sn904cj3429/iiif/manifest'));
+        expect(fetch.mock.calls[0][1].headers).toEqual({ Accept: 'hello' });
+      });
+    });
     describe('success response', () => {
       beforeEach(() => {
         fetch.mockResponseOnce(JSON.stringify({ data: '12345' })); // eslint-disable-line no-undef

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -196,6 +196,7 @@ export default {
     en: 'English',
   },
   displayAllAnnotations: false, // Configure if annotations to be displayed on the canvas by default when fetched
+  resourceHeaders: {}, // Headers to send with IIIF Presentation API resource requests
   translations: { // Translations can be added to inject new languages or override existing labels
   },
   window: {

--- a/src/state/actions/manifest.js
+++ b/src/state/actions/manifest.js
@@ -52,10 +52,10 @@ export function receiveManifestFailure(manifestId, error) {
  * @memberof ActionCreators
  */
 export function fetchManifest(manifestId, properties) {
-  return ((dispatch) => {
+  return ((dispatch, getState) => {
     dispatch(requestManifest(manifestId, { ...properties, isFetching: true }));
-
-    return fetch(manifestId)
+    const { config = {} } = getState();
+    return fetch(manifestId, { headers: config.resourceHeaders })
       .then(response => response.json())
       .then(json => dispatch(receiveManifest(manifestId, json)))
       .catch((error) => {


### PR DESCRIPTION
Fixes #1969
This also enables IIIF v3 requests using content negotiation

```diff
-  resourceHeaders: {}, // Headers to send with IIIF Presentation API resource requests
+   resourceHeaders: {, // Headers to send with IIIF Presentation API resource requests
+   Accept: 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"',
+ }
```