### PR TITLE
Create plugin list item component. Part of #2395.

### DIFF
--- a/src/components/PluginListItem.js
+++ b/src/components/PluginListItem.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MenuItem from '@material-ui/core/MenuItem';
+import Typography from '@material-ui/core/Typography';
+import ExtensionIcon from '@material-ui/icons/ExtensionOutlined';
+
+/** */
+function PluginListItem(props) {
+  const { onClick, icon, title } = props;
+  return (
+    <MenuItem onClick={onClick}>
+      { icon || <ExtensionIcon /> }
+      <Typography inline style={{ paddingLeft: '12px' }}>
+        { title }
+      </Typography>
+    </MenuItem>
+  );
+}
+
+PluginListItem.propTypes = {
+  icon: PropTypes.node,
+  onClick: PropTypes.func,
+  title: PropTypes.string,
+};
+
+PluginListItem.defaultProps = {
+  icon: null,
+  onClick: null,
+  title: 'Plugin without title',
+};
+
+export default PluginListItem;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 import init from './init';
 import * as actions from './state/actions';
 import * as selectors from './state/selectors';
+import PluginListItem from './components/PluginListItem';
 
 export * from './state/reducers';
 
 const exports = {
   actions,
+  components: {
+    PluginListItem,
+  },
   selectors,
   viewer: init,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,11 @@
 import init from './init';
 import * as actions from './state/actions';
 import * as selectors from './state/selectors';
-import PluginListItem from './components/PluginListItem';
 
 export * from './state/reducers';
 
 const exports = {
   actions,
-  components: {
-    PluginListItem,
-  },
   selectors,
   viewer: init,
 };


### PR DESCRIPTION
Create a component that can be used by adopters to match mirador style guides while adding a plugin to a menu.

![pluginlistitem](https://user-images.githubusercontent.com/11216290/56595218-8a64e280-65ee-11e9-9f58-8cb9dac1a56f.png)
