### PR TITLE
Modify // comments so webpack css-loader works

### DIFF
--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -9,11 +9,6 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
   /** */
   function PluginHoc(props) {
     const pluginMap = useContext(PluginContext);
-
-    if (isEmpty(pluginMap)) {
-      return <TargetComponent {...props} />;
-    }
-
     const plugins = pluginMap[targetName];
 
     if (isEmpty(plugins)) {

--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -9,6 +9,11 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
   /** */
   function PluginHoc(props) {
     const pluginMap = useContext(PluginContext);
+
+    if (isEmpty(pluginMap)) {
+      return <TargetComponent {...props} />;
+    }
+
     const plugins = pluginMap[targetName];
 
     if (isEmpty(plugins)) {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -38,8 +38,9 @@
     }
   }
 
+  // The height of the control panel
   &-workspace-with-control-panel {
-    padding-top: 74px; // The height of the control panel
+    padding-top: 74px; 
   }
 
   &-workspace-add {
@@ -105,7 +106,7 @@
   }
 }
 
-// override react-mosaic styles to mimic MUI's elevation
+// override react-mosaic styles to mimic MUIs elevation
 .mosaic {
   &-tile {
     $start: rgba(0, 0, 0, .2);


### PR DESCRIPTION
While bundling Mirador v3.0.0-alpha.7 for use in a React app with webpack 4.29.0, the `css-loader` errors when parsing these two comments; the suggested changes make the errors go away.