### PR TITLE
Check whether pluginMap is empty

### DIFF
--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -9,11 +9,6 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
   /** */
   function PluginHoc(props) {
     const pluginMap = useContext(PluginContext);
-
-    if (isEmpty(pluginMap)) {
-      return <TargetComponent {...props} />;
-    }
-
     const plugins = pluginMap[targetName];
 
     if (isEmpty(plugins)) {

--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -9,6 +9,11 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
   /** */
   function PluginHoc(props) {
     const pluginMap = useContext(PluginContext);
+
+    if (isEmpty(pluginMap)) {
+      return <TargetComponent {...props} />;
+    }
+
     const plugins = pluginMap[targetName];
 
     if (isEmpty(plugins)) {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -38,8 +38,9 @@
     }
   }
 
+  // The height of the control panel
   &-workspace-with-control-panel {
-    padding-top: 74px; // The height of the control panel
+    padding-top: 74px; 
   }
 
   &-workspace-add {
@@ -105,7 +106,7 @@
   }
 }
 
-// override react-mosaic styles to mimic MUI's elevation
+// override react-mosaic styles to mimic MUIs elevation
 .mosaic {
   &-tile {
     $start: rgba(0, 0, 0, .2);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -38,9 +38,8 @@
     }
   }
 
-  // The height of the control panel
   &-workspace-with-control-panel {
-    padding-top: 74px; 
+    padding-top: 74px; // The height of the control panel
   }
 
   &-workspace-add {
@@ -106,7 +105,7 @@
   }
 }
 
-// override react-mosaic styles to mimic MUIs elevation
+// override react-mosaic styles to mimic MUI's elevation
 .mosaic {
   &-tile {
     $start: rgba(0, 0, 0, .2);


### PR DESCRIPTION
Using Mirador v3.0.0-alpha.7 as an embedded component in a React app, based on the instructions in [this](https://github.com/ProjectMirador/mirador/wiki/M3-Embedding-in-Another-Environment) doc from the wiki, the following error is generated in the browser, breaking the app:

`TypeError: pluginMap is undefined
    PluginHoc webpack:///./node_modules/mirador/dist/es/src/extend/withPlugins.js?:29`

Note that the example from the documentation does not deal with plugins. Adding an `isEmpty` check for the `pluginMap` in `withPlugins.js` makes this error go away, and the viewer loads properly. The effect on plugin functionality is undetermined.