### PR TITLE
Add isEmpty() check for pluginMap

### DIFF
--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -9,6 +9,11 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
   /** */
   function PluginHoc(props) {
     const pluginMap = useContext(PluginContext);
+
+    if (isEmpty(pluginMap)) {
+      return <TargetComponent {...props} />;
+    }
+
     const plugins = pluginMap[targetName];
 
     if (isEmpty(plugins)) {


### PR DESCRIPTION
Using Mirador v3.0.0-alpha.7 as an embedded component in a React app, based on the instructions in [this](https://github.com/ProjectMirador/mirador/wiki/M3-Embedding-in-Another-Environment) doc from the wiki, the following error is generated in the browser, breaking the app:

`TypeError: pluginMap is undefined PluginHoc webpack:///./node_modules/mirador/dist/es/src/extend/withPlugins.js?:29`

Note that the example from the documentation does not deal with plugins. Adding an `isEmpty()` check for the `pluginMap` in `withPlugins.js` makes this error go away, and the viewer loads properly in this case.

See also the discussion around closed PR https://github.com/ProjectMirador/mirador/pull/2618