### PR TITLE
Adds a configuration setting for hiding the window top bar title

### DIFF
--- a/__tests__/src/components/WindowTopBar.test.js
+++ b/__tests__/src/components/WindowTopBar.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Typography from '@material-ui/core/Typography';
 import Toolbar from '@material-ui/core/Toolbar';
 import AppBar from '@material-ui/core/AppBar';
 
 import WindowTopMenuButton from '../../../src/containers/WindowTopMenuButton';
 import WindowTopBarButtons from '../../../src/containers/WindowTopBarButtons';
+import WindowTopBarTitle from '../../../src/containers/WindowTopBarTitle';
 import MiradorMenuButton from '../../../src/containers/MiradorMenuButton';
 import { WindowTopBar } from '../../../src/components/WindowTopBar';
 
@@ -14,7 +14,6 @@ import { WindowTopBar } from '../../../src/components/WindowTopBar';
 function createWrapper(props) {
   return shallow(
     <WindowTopBar
-      manifestTitle="awesome manifest"
       windowId="xyz"
       classes={{}}
       t={str => str}
@@ -34,7 +33,7 @@ describe('WindowTopBar', () => {
     expect(wrapper.find(AppBar).length).toBe(1);
     expect(wrapper.find(Toolbar).length).toBe(1);
     expect(wrapper.find(MiradorMenuButton).length).toBe(3);
-    expect(wrapper.find(Typography).length).toBe(1);
+    expect(wrapper.find(WindowTopBarTitle).length).toBe(1);
     expect(wrapper.find(WindowTopBarButtons).length).toBe(1);
     expect(wrapper.find(WindowTopMenuButton).length).toBe(1);
   });
@@ -50,11 +49,6 @@ describe('WindowTopBar', () => {
     const toggleWindowSideBar = jest.fn();
     const wrapper = createWrapper({ toggleWindowSideBar });
     expect(wrapper.find(MiradorMenuButton).first().props().onClick).toBe(toggleWindowSideBar);
-  });
-
-  it('passes correct props to <Typography/>', () => {
-    const wrapper = createWrapper();
-    expect(wrapper.find(Typography).first().render().text()).toBe('awesome manifest');
   });
 
   it('passes correct props to <WindowTopBarButtons/>', () => {

--- a/__tests__/src/components/WindowTopBarTitle.test.js
+++ b/__tests__/src/components/WindowTopBarTitle.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Typography from '@material-ui/core/Typography';
+
+import { WindowTopBarTitle } from '../../../src/components/WindowTopBarTitle';
+
+/** create wrapper */
+function createWrapper(props) {
+  return shallow(
+    <WindowTopBarTitle
+      manifestTitle="awesome manifest"
+      windowId="xyz"
+      classes={{}}
+      {...props}
+    />,
+  );
+}
+
+describe('WindowTopBarTitle', () => {
+  it('renders all needed elements', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(Typography).length).toBe(1);
+  });
+
+  it('passes correct props to <Typography/>', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(Typography).first().render().text()).toBe('awesome manifest');
+  });
+});

--- a/__tests__/src/components/WindowTopBarTitle.test.js
+++ b/__tests__/src/components/WindowTopBarTitle.test.js
@@ -27,4 +27,8 @@ describe('WindowTopBarTitle', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(Typography).first().render().text()).toBe('awesome manifest');
   });
+
+  it('title is configurable', () => {
+    expect(createWrapper({ hideWindowTitle: true }).find(Typography).length).toEqual(0);
+  });
 });

--- a/__tests__/src/components/WindowTopBarTitle.test.js
+++ b/__tests__/src/components/WindowTopBarTitle.test.js
@@ -30,5 +30,6 @@ describe('WindowTopBarTitle', () => {
 
   it('title is configurable', () => {
     expect(createWrapper({ hideWindowTitle: true }).find(Typography).length).toEqual(0);
+    expect(createWrapper({ hideWindowTitle: true }).find('div').length).toEqual(1);
   });
 });

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Typography from '@material-ui/core/Typography';
 import MenuIcon from '@material-ui/icons/MenuSharp';
 import CloseIcon from '@material-ui/icons/CloseSharp';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -8,6 +7,7 @@ import AppBar from '@material-ui/core/AppBar';
 import classNames from 'classnames';
 import WindowTopMenuButton from '../containers/WindowTopMenuButton';
 import WindowTopBarButtons from '../containers/WindowTopBarButtons';
+import WindowTopBarTitle from '../containers/WindowTopBarTitle';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 import WindowMaxIcon from './icons/WindowMaxIcon';
 import WindowMinIcon from './icons/WindowMinIcon';
@@ -24,7 +24,7 @@ export class WindowTopBar extends Component {
    */
   render() {
     const {
-      removeWindow, windowId, classes, toggleWindowSideBar, t, manifestTitle, windowDraggable,
+      removeWindow, windowId, classes, toggleWindowSideBar, t, windowDraggable,
       maximizeWindow, maximized, minimizeWindow, focused, allowClose, allowMaximize,
       focusWindow,
     } = this.props;
@@ -49,9 +49,9 @@ export class WindowTopBar extends Component {
             >
               <MenuIcon />
             </MiradorMenuButton>
-            <Typography variant="h2" noWrap color="inherit" className={classes.title}>
-              {manifestTitle}
-            </Typography>
+            <WindowTopBarTitle
+              windowId={windowId}
+            />
             <WindowTopBarButtons windowId={windowId} />
             <WindowTopMenuButton className={ns('window-menu-btn')} windowId={windowId} />
             {allowMaximize && (
@@ -85,7 +85,6 @@ WindowTopBar.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   focused: PropTypes.bool,
   focusWindow: PropTypes.func,
-  manifestTitle: PropTypes.string,
   maximized: PropTypes.bool,
   maximizeWindow: PropTypes.func,
   minimizeWindow: PropTypes.func,
@@ -101,7 +100,6 @@ WindowTopBar.defaultProps = {
   allowMaximize: true,
   focused: false,
   focusWindow: () => {},
-  manifestTitle: '',
   maximized: false,
   maximizeWindow: () => {},
   minimizeWindow: () => {},

--- a/src/components/WindowTopBarTitle.js
+++ b/src/components/WindowTopBarTitle.js
@@ -14,11 +14,17 @@ export class WindowTopBarTitle extends Component {
     const {
       classes, hideWindowTitle, manifestTitle,
     } = this.props;
-    return !hideWindowTitle && (
-      <Typography variant="h2" noWrap color="inherit" className={classes.title}>
-        {manifestTitle}
-      </Typography>
-    );
+    let title = null;
+    if (hideWindowTitle) {
+      title = (<div className={classes.title} />);
+    } else {
+      title = (
+        <Typography variant="h2" noWrap color="inherit" className={classes.title}>
+          {manifestTitle}
+        </Typography>
+      );
+    }
+    return title;
   }
 }
 

--- a/src/components/WindowTopBarTitle.js
+++ b/src/components/WindowTopBarTitle.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+
+/**
+ * WindowTopBarTitle
+ */
+export class WindowTopBarTitle extends Component {
+  /**
+   * render
+   * @return
+   */
+  render() {
+    const {
+      classes, manifestTitle,
+    } = this.props;
+    return (
+      <Typography variant="h2" noWrap color="inherit" className={classes.title}>
+        {manifestTitle}
+      </Typography>
+    );
+  }
+}
+
+WindowTopBarTitle.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  manifestTitle: PropTypes.string,
+};
+
+WindowTopBarTitle.defaultProps = {
+  manifestTitle: '',
+};

--- a/src/components/WindowTopBarTitle.js
+++ b/src/components/WindowTopBarTitle.js
@@ -12,9 +12,9 @@ export class WindowTopBarTitle extends Component {
    */
   render() {
     const {
-      classes, manifestTitle,
+      classes, hideWindowTitle, manifestTitle,
     } = this.props;
-    return (
+    return !hideWindowTitle && (
       <Typography variant="h2" noWrap color="inherit" className={classes.title}>
         {manifestTitle}
       </Typography>
@@ -24,9 +24,11 @@ export class WindowTopBarTitle extends Component {
 
 WindowTopBarTitle.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  hideWindowTitle: PropTypes.bool,
   manifestTitle: PropTypes.string,
 };
 
 WindowTopBarTitle.defaultProps = {
+  hideWindowTitle: false,
   manifestTitle: '',
 };

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -209,6 +209,7 @@ export default {
     defaultSideBarPanel: 'info', // Configure which sidebar is selected by default. Options: info, rights, canvas, annotations
     defaultView: 'single',  // Configure which viewing mode (e.g. single, book, gallery) for windows to be opened in
     hideAnnotationsPanel: false, // Configure to hide the annotations panel in the WindowSideBarButtons
+    hideWindowTitle: false, // Configure if the window title is shown in the window title bar or not
     sideBarOpenByDefault: false, // Configure if the sidebar (and its content panel) is open by default
   },
   windows: [], // Array of windows to be open when mirador initializes (each object should at least provide a loadedManifest key with the value of the IIIF presentation manifest to load)

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -36,11 +36,6 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  */
 const styles = theme => ({
   focused: {},
-  title: {
-    ...theme.typography.h6,
-    flexGrow: 1,
-    paddingLeft: theme.spacing.unit / 2,
-  },
   windowTopBarStyle: {
     '&$focused': {
       borderTop: `2px solid ${theme.palette.primary.main}`,

--- a/src/containers/WindowTopBarTitle.js
+++ b/src/containers/WindowTopBarTitle.js
@@ -8,6 +8,7 @@ import { WindowTopBarTitle } from '../components/WindowTopBarTitle';
 
 /** mapStateToProps */
 const mapStateToProps = (state, { windowId }) => ({
+  hideWindowTitle: state.config.window.hideWindowTitle,
   manifestTitle: getManifestTitle(state, { windowId }),
 });
 

--- a/src/containers/WindowTopBarTitle.js
+++ b/src/containers/WindowTopBarTitle.js
@@ -1,0 +1,33 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core';
+import { withPlugins } from '../extend/withPlugins';
+import { getManifestTitle } from '../state/selectors';
+import { WindowTopBarTitle } from '../components/WindowTopBarTitle';
+
+/** mapStateToProps */
+const mapStateToProps = (state, { windowId }) => ({
+  manifestTitle: getManifestTitle(state, { windowId }),
+});
+
+
+/**
+ * @param theme
+ */
+const styles = theme => ({
+  title: {
+    ...theme.typography.h6,
+    flexGrow: 1,
+    paddingLeft: theme.spacing.unit / 2,
+  },
+});
+
+const enhance = compose(
+  withTranslation(),
+  withStyles(styles),
+  connect(mapStateToProps, null),
+  withPlugins('WindowTopBarTitle'),
+);
+
+export default enhance(WindowTopBarTitle);


### PR DESCRIPTION
Fixes #2623 

With `hideWindowTitle: true`

![Screen Shot 2019-05-30 at 7 13 41 AM](https://user-images.githubusercontent.com/1656824/58635189-7d50a880-82aa-11e9-8ea4-88c04fe0efe8.png)

A few questions come up:

 - Should we even render the component if `hideWindowTitle: true`? ~I don't think so now because of the spacing~ ✅ 
 - Should the buttons be pulled right? ~YES~  ✅ 