### PR TITLE
2503 fullscreen window

### DIFF
--- a/__tests__/src/components/FullScreenButton.test.js
+++ b/__tests__/src/components/FullScreenButton.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import MiradorMenuButton from '../../../src/containers/MiradorMenuButton';
-import { WorkspaceFullScreenButton } from '../../../src/components/WorkspaceFullScreenButton';
+import { FullScreenButton } from '../../../src/components/FullScreenButton';
 
 /** */
 function createWrapper(props) {
   return shallow(
-    <WorkspaceFullScreenButton
+    <FullScreenButton
       classes={{}}
       setWorkspaceFullscreen={() => {}}
       isFullscreenEnabled={false}
@@ -15,7 +15,7 @@ function createWrapper(props) {
   );
 }
 
-describe('WorkspaceFullScreenButton', () => {
+describe('FullScreenButton', () => {
   let wrapper;
   let menuButton;
 

--- a/__tests__/src/components/WindowTopBar.test.js
+++ b/__tests__/src/components/WindowTopBar.test.js
@@ -8,6 +8,7 @@ import WindowTopMenuButton from '../../../src/containers/WindowTopMenuButton';
 import WindowTopBarButtons from '../../../src/containers/WindowTopBarButtons';
 import WindowTopBarTitle from '../../../src/containers/WindowTopBarTitle';
 import MiradorMenuButton from '../../../src/containers/MiradorMenuButton';
+import FullScreenButton from '../../../src/containers/FullScreenButton';
 import { WindowTopBar } from '../../../src/components/WindowTopBar';
 
 /** create wrapper */
@@ -28,7 +29,7 @@ function createWrapper(props) {
 }
 
 describe('WindowTopBar', () => {
-  it('renders all needed elements', () => {
+  it('renders all default components', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(AppBar).length).toBe(1);
     expect(wrapper.find(Toolbar).length).toBe(1);
@@ -36,6 +37,7 @@ describe('WindowTopBar', () => {
     expect(wrapper.find(WindowTopBarTitle).length).toBe(1);
     expect(wrapper.find(WindowTopBarButtons).length).toBe(1);
     expect(wrapper.find(WindowTopMenuButton).length).toBe(1);
+    expect(wrapper.find(FullScreenButton).length).toBe(0);
   });
 
   it('triggers window focus when clicked', () => {
@@ -77,7 +79,11 @@ describe('WindowTopBar', () => {
     expect(createWrapper({ allowClose: false }).find('.mirador-window-close').length).toEqual(0);
   });
 
-  it('fullscreen button is configurable', () => {
+  it('maximize button is configurable', () => {
     expect(createWrapper({ allowMaximize: false }).find('.mirador-window-maximize').length).toEqual(0);
+  });
+
+  it('fullscreen button is configurable', () => {
+    expect(createWrapper({ allowFullscreen: true }).find(FullScreenButton).length).toEqual(1);
   });
 });

--- a/__tests__/src/components/WorkspaceControlPanelButtons.test.js
+++ b/__tests__/src/components/WorkspaceControlPanelButtons.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import WorkspaceMenuButton from '../../../src/containers/WorkspaceMenuButton';
-import WorkspaceFullScreenButton from '../../../src/containers/WorkspaceFullScreenButton';
+import FullScreenButton from '../../../src/containers/FullScreenButton';
 import { WorkspaceControlPanelButtons }
   from '../../../src/components/WorkspaceControlPanelButtons';
 
@@ -13,7 +13,7 @@ describe('WorkspaceControlPanelButtons', () => {
 
   it('render all needed elements', () => {
     expect(wrapper.find(WorkspaceMenuButton).length).toBe(1);
-    expect(wrapper.find(WorkspaceFullScreenButton).length).toBe(1);
+    expect(wrapper.find(FullScreenButton).length).toBe(1);
     expect(wrapper.find('PluginHook').length).toBe(1);
   });
 });

--- a/src/components/FullScreenButton.js
+++ b/src/components/FullScreenButton.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 /**
  */
-export class WorkspaceFullScreenButton extends Component {
+export class FullScreenButton extends Component {
   /**
    * render
    * @return
@@ -26,14 +26,14 @@ export class WorkspaceFullScreenButton extends Component {
   }
 }
 
-WorkspaceFullScreenButton.propTypes = {
+FullScreenButton.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   isFullscreenEnabled: PropTypes.bool,
   setWorkspaceFullscreen: PropTypes.func.isRequired,
   t: PropTypes.func,
 };
 
-WorkspaceFullScreenButton.defaultProps = {
+FullScreenButton.defaultProps = {
   isFullscreenEnabled: false,
   t: key => key,
 };

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -9,6 +9,7 @@ import WindowTopMenuButton from '../containers/WindowTopMenuButton';
 import WindowTopBarButtons from '../containers/WindowTopBarButtons';
 import WindowTopBarTitle from '../containers/WindowTopBarTitle';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
+import FullScreenButton from '../containers/FullScreenButton';
 import WindowMaxIcon from './icons/WindowMaxIcon';
 import WindowMinIcon from './icons/WindowMinIcon';
 import ns from '../config/css-ns';
@@ -26,7 +27,7 @@ export class WindowTopBar extends Component {
     const {
       removeWindow, windowId, classes, toggleWindowSideBar, t, windowDraggable,
       maximizeWindow, maximized, minimizeWindow, focused, allowClose, allowMaximize,
-      focusWindow,
+      focusWindow, allowFullscreen,
     } = this.props;
 
     return (
@@ -63,6 +64,9 @@ export class WindowTopBar extends Component {
                 {(maximized ? <WindowMinIcon /> : <WindowMaxIcon />)}
               </MiradorMenuButton>
             )}
+            {allowFullscreen && (
+              <FullScreenButton />
+            )}
             {allowClose && (
               <MiradorMenuButton
                 aria-label={t('closeWindow')}
@@ -81,6 +85,7 @@ export class WindowTopBar extends Component {
 
 WindowTopBar.propTypes = {
   allowClose: PropTypes.bool,
+  allowFullscreen: PropTypes.bool,
   allowMaximize: PropTypes.bool,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   focused: PropTypes.bool,
@@ -97,6 +102,7 @@ WindowTopBar.propTypes = {
 
 WindowTopBar.defaultProps = {
   allowClose: true,
+  allowFullscreen: false,
   allowMaximize: true,
   focused: false,
   focusWindow: () => {},

--- a/src/components/WorkspaceControlPanelButtons.js
+++ b/src/components/WorkspaceControlPanelButtons.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import WorkspaceFullScreenButton from '../containers/WorkspaceFullScreenButton';
+import FullScreenButton from '../containers/FullScreenButton';
 import WorkspaceMenuButton from '../containers/WorkspaceMenuButton';
 import WorkspaceOptionsButton from '../containers/WorkspaceOptionsButton';
 import WindowListButton from '../containers/WindowListButton';
@@ -20,7 +20,7 @@ export class WorkspaceControlPanelButtons extends Component {
         <WindowListButton />
         <WorkspaceMenuButton />
         <WorkspaceOptionsButton />
-        <WorkspaceFullScreenButton />
+        <FullScreenButton />
         <PluginHook {...this.props} />
       </>
     );

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -205,6 +205,7 @@ export default {
   },
   window: {
     allowClose: true, // Configure if windows can be closed or not
+    allowFullscreen: false, // Configure to show a "fullscreen" button in the WindowTopBar
     allowMaximize: true, // Configure if windows can be maximized or not
     defaultSideBarPanel: 'info', // Configure which sidebar is selected by default. Options: info, rights, canvas, annotations
     defaultView: 'single',  // Configure which viewing mode (e.g. single, book, gallery) for windows to be opened in

--- a/src/containers/FullScreenButton.js
+++ b/src/containers/FullScreenButton.js
@@ -5,12 +5,11 @@ import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
 import { getFullScreenEnabled } from '../state/selectors';
-import { WorkspaceFullScreenButton }
-  from '../components/WorkspaceFullScreenButton';
+import { FullScreenButton } from '../components/FullScreenButton';
 
 /**
  * mapStateToProps - to hook up connect
- * @memberof WorkspaceFullScreenButton
+ * @memberof FullScreenButton
  * @private
  */
 const mapStateToProps = state => ({
@@ -39,7 +38,7 @@ const enhance = compose(
   withTranslation(),
   withStyles(styles),
   connect(mapStateToProps, mapDispatchToProps),
-  withPlugins('WorkspaceFullScreenButton'),
+  withPlugins('FullScreenButton'),
 );
 
-export default enhance(WorkspaceFullScreenButton);
+export default enhance(FullScreenButton);

--- a/src/containers/WindowTopBar.js
+++ b/src/containers/WindowTopBar.js
@@ -10,6 +10,7 @@ import { WindowTopBar } from '../components/WindowTopBar';
 /** mapStateToProps */
 const mapStateToProps = (state, { windowId }) => ({
   allowClose: state.config.window.allowClose,
+  allowFullscreen: state.config.window.allowFullscreen,
   allowMaximize: state.config.window.allowMaximize,
   focused: state.workspace.focusedWindowId === windowId,
   manifestTitle: getManifestTitle(state, { windowId }),


### PR DESCRIPTION
Part of #2503 and will fix https://github.com/sul-dlss/sul-embed/issues/1000

Renames `WorkspaceFullScreenButton` to `FullScreenButton` to become more generic.

![allowfullscreen](https://user-images.githubusercontent.com/1656824/58737053-520aae00-83bd-11e9-8799-83c7c4ae2ab0.gif)
 