### PR TITLE
Generalize annotations a bit more to hopefully setup content search work

### DIFF
--- a/__tests__/src/actions/annotation.test.js
+++ b/__tests__/src/actions/annotation.test.js
@@ -10,19 +10,19 @@ const mockStore = configureMockStore(middlewares);
 describe('annotation actions', () => {
   describe('requestAnnotation', () => {
     it('requests an annotation from given a url', () => {
-      const canvasId = 'foo';
+      const targetId = 'foo';
       const annotationId = 'abc123';
       const expectedAction = {
         annotationId,
-        canvasId,
+        targetId,
         type: ActionTypes.REQUEST_ANNOTATION,
       };
-      expect(actions.requestAnnotation(canvasId, annotationId)).toEqual(expectedAction);
+      expect(actions.requestAnnotation(targetId, annotationId)).toEqual(expectedAction);
     });
   });
   describe('receiveAnnotation', () => {
     it('recieves an annotation', () => {
-      const canvasId = 'foo';
+      const targetId = 'foo';
       const annotationId = 'abc123';
       const json = {
         annotationId,
@@ -31,10 +31,10 @@ describe('annotation actions', () => {
       const expectedAction = {
         annotationId,
         annotationJson: json,
-        canvasId,
+        targetId,
         type: ActionTypes.RECEIVE_ANNOTATION,
       };
-      expect(actions.receiveAnnotation(canvasId, annotationId, json)).toEqual(expectedAction);
+      expect(actions.receiveAnnotation(targetId, annotationId, json)).toEqual(expectedAction);
     });
   });
   describe('fetchAnnotation', () => {
@@ -54,7 +54,7 @@ describe('annotation actions', () => {
         expect(store.getActions()).toEqual([
           {
             annotationId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174896',
-            canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
+            targetId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
             type: 'REQUEST_ANNOTATION',
           },
         ]);
@@ -69,13 +69,13 @@ describe('annotation actions', () => {
             expect(expectedActions).toEqual([
               {
                 annotationId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174896',
-                canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
+                targetId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
                 type: 'REQUEST_ANNOTATION',
               },
               {
                 annotationId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174896',
                 annotationJson: { data: '12345' },
-                canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
+                targetId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
                 type: 'RECEIVE_ANNOTATION',
               },
             ]);
@@ -93,13 +93,13 @@ describe('annotation actions', () => {
             expect(expectedActions).toEqual([
               {
                 annotationId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174896',
-                canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
+                targetId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
                 type: 'REQUEST_ANNOTATION',
               },
               {
                 annotationId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174896',
-                canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
                 error: new Error('invalid json response body at undefined reason: Unexpected end of JSON input'),
+                targetId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174896',
                 type: 'RECEIVE_ANNOTATION_FAILURE',
               },
             ]);
@@ -110,28 +110,28 @@ describe('annotation actions', () => {
 
   it('handles the selectAnnotation action', () => {
     const windowId = 'wId1';
-    const canvasId = 'cId1';
+    const targetId = 'cId1';
     const annotationId = 'aId1';
     const expectedAction = {
       annotationId,
-      canvasId,
+      targetId,
       type: ActionTypes.SELECT_ANNOTATION,
       windowId,
     };
-    expect(actions.selectAnnotation(windowId, canvasId, annotationId)).toEqual(expectedAction);
+    expect(actions.selectAnnotation(windowId, targetId, annotationId)).toEqual(expectedAction);
   });
 
   it('handles the deselectAnnotation action', () => {
     const windowId = 'wId1';
-    const canvasId = 'cId1';
+    const targetId = 'cId1';
     const annotationId = 'aId1';
     const expectedAction = {
       annotationId,
-      canvasId,
+      targetId,
       type: ActionTypes.DESELECT_ANNOTATION,
       windowId,
     };
-    expect(actions.deselectAnnotation(windowId, canvasId, annotationId)).toEqual(expectedAction);
+    expect(actions.deselectAnnotation(windowId, targetId, annotationId)).toEqual(expectedAction);
   });
 
   it('handles the toggleAnnotationDisplay action', () => {

--- a/__tests__/src/reducers/annotations.test.js
+++ b/__tests__/src/reducers/annotations.test.js
@@ -5,7 +5,7 @@ describe('annotation reducer', () => {
   it('should handle REQUEST_ANNOTATION', () => {
     expect(annotationsReducer({}, {
       annotationId: 'abc123',
-      canvasId: 'foo',
+      targetId: 'foo',
       type: ActionTypes.REQUEST_ANNOTATION,
     })).toEqual({
       foo: {
@@ -33,7 +33,7 @@ describe('annotation reducer', () => {
           content: 'anno stuff',
           id: 'abc123',
         },
-        canvasId: 'foo',
+        targetId: 'foo',
         type: ActionTypes.RECEIVE_ANNOTATION,
       },
     )).toMatchObject({
@@ -58,8 +58,8 @@ describe('annotation reducer', () => {
       },
       {
         annotationId: 'abc123',
-        canvasId: 'foo',
         error: "This institution didn't enable CORS.",
+        targetId: 'foo',
         type: ActionTypes.RECEIVE_ANNOTATION_FAILURE,
       },
     )).toEqual({

--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -303,7 +303,7 @@ describe('windows reducer', () => {
       const beforeState = { abc123: {} };
       const action = {
         annotationId: 'aId',
-        canvasId: 'cId',
+        targetId: 'cId',
         type: ActionTypes.SELECT_ANNOTATION,
         windowId: 'abc123',
       };
@@ -318,7 +318,7 @@ describe('windows reducer', () => {
       const beforeState = { abc123: { selectedAnnotations: { cId: ['prevId'] } } };
       const action = {
         annotationId: 'aId',
-        canvasId: 'cId',
+        targetId: 'cId',
         type: ActionTypes.SELECT_ANNOTATION,
         windowId: 'abc123',
       };
@@ -334,7 +334,7 @@ describe('windows reducer', () => {
         const beforeState = { abc123: { selectedAnnotations: { cId: ['aId1', 'aId2'] } } };
         const action = {
           annotationId: 'aId1',
-          canvasId: 'cId',
+          targetId: 'cId',
           type: ActionTypes.DESELECT_ANNOTATION,
           windowId: 'abc123',
         };
@@ -349,7 +349,7 @@ describe('windows reducer', () => {
         const beforeState = { abc123: { selectedAnnotations: { cId1: ['aId1'], cId2: ['aId2'] } } };
         const action = {
           annotationId: 'aId2',
-          canvasId: 'cId2',
+          targetId: 'cId2',
           type: ActionTypes.DESELECT_ANNOTATION,
           windowId: 'abc123',
         };

--- a/src/components/WindowSideBarAnnotationsPanel.js
+++ b/src/components/WindowSideBarAnnotationsPanel.js
@@ -31,7 +31,6 @@ export class WindowSideBarAnnotationsPanel extends Component {
 
         {selectedCanvases.map((canvas, index) => (
           <CanvasAnnotations
-            canvasId={canvas.id}
             canvasIndex={canvas.index}
             key={canvas.id}
             index={index}

--- a/src/state/actions/annotation.js
+++ b/src/state/actions/annotation.js
@@ -4,14 +4,14 @@ import ActionTypes from './action-types';
 /**
  * requestAnnotation - action creator
  *
- * @param  {String} canvasId
+ * @param  {String} targetId
  * @param  {String} annotationId
  * @memberof ActionCreators
  */
-export function requestAnnotation(canvasId, annotationId) {
+export function requestAnnotation(targetId, annotationId) {
   return {
     annotationId,
-    canvasId,
+    targetId,
     type: ActionTypes.REQUEST_ANNOTATION,
   };
 }
@@ -19,16 +19,16 @@ export function requestAnnotation(canvasId, annotationId) {
 /**
  * receiveAnnotation - action creator
  *
- * @param  {String} canvasId
+ * @param  {String} targetId
  * @param  {String} annotationId
  * @param  {Object} annotationJson
  * @memberof ActionCreators
  */
-export function receiveAnnotation(canvasId, annotationId, annotationJson) {
+export function receiveAnnotation(targetId, annotationId, annotationJson) {
   return {
     annotationId,
     annotationJson,
-    canvasId,
+    targetId,
     type: ActionTypes.RECEIVE_ANNOTATION,
   };
 }
@@ -36,16 +36,16 @@ export function receiveAnnotation(canvasId, annotationId, annotationJson) {
 /**
  * receiveAnnotationFailure - action creator
  *
- * @param  {String} canvasId
+ * @param  {String} targetId
  * @param  {String} annotationId
  * @param  {String} error
  * @memberof ActionCreators
  */
-export function receiveAnnotationFailure(canvasId, annotationId, error) {
+export function receiveAnnotationFailure(targetId, annotationId, error) {
   return {
     annotationId,
-    canvasId,
     error,
+    targetId,
     type: ActionTypes.RECEIVE_ANNOTATION_FAILURE,
   };
 }
@@ -56,13 +56,13 @@ export function receiveAnnotationFailure(canvasId, annotationId, error) {
  * @param  {String} annotationId
  * @memberof ActionCreators
  */
-export function fetchAnnotation(canvasId, annotationId) {
+export function fetchAnnotation(targetId, annotationId) {
   return ((dispatch) => {
-    dispatch(requestAnnotation(canvasId, annotationId));
+    dispatch(requestAnnotation(targetId, annotationId));
     return fetch(annotationId)
       .then(response => response.json())
-      .then(json => dispatch(receiveAnnotation(canvasId, annotationId, json)))
-      .catch(error => dispatch(receiveAnnotationFailure(canvasId, annotationId, error)));
+      .then(json => dispatch(receiveAnnotation(targetId, annotationId, json)))
+      .catch(error => dispatch(receiveAnnotationFailure(targetId, annotationId, error)));
   });
 }
 
@@ -70,14 +70,14 @@ export function fetchAnnotation(canvasId, annotationId) {
  * selectAnnotation - action creator
  *
  * @param  {String} windowId
- * @param  {String} canvasId
+ * @param  {String} targetId
  * @param  {String} annotationId
  * @memberof ActionCreators
  */
-export function selectAnnotation(windowId, canvasId, annotationId) {
+export function selectAnnotation(windowId, targetId, annotationId) {
   return {
     annotationId,
-    canvasId,
+    targetId,
     type: ActionTypes.SELECT_ANNOTATION,
     windowId,
   };
@@ -87,14 +87,14 @@ export function selectAnnotation(windowId, canvasId, annotationId) {
  * deselectAnnotation - action creator
  *
  * @param  {String} windowId
- * @param  {String} canvasId
+ * @param  {String} targetId
  * @param  {String} annotationId
  * @memberof ActionCreators
  */
-export function deselectAnnotation(windowId, canvasId, annotationId) {
+export function deselectAnnotation(windowId, targetId, annotationId) {
   return {
     annotationId,
-    canvasId,
+    targetId,
     type: ActionTypes.DESELECT_ANNOTATION,
     windowId,
   };

--- a/src/state/reducers/annotations.js
+++ b/src/state/reducers/annotations.js
@@ -8,7 +8,7 @@ export const annotationsReducer = (state = {}, action) => {
     case ActionTypes.REQUEST_ANNOTATION:
       return {
         ...state,
-        [action.canvasId]: {
+        [action.targetId]: {
           [action.annotationId]: {
             id: action.annotationId,
             isFetching: true,
@@ -18,7 +18,7 @@ export const annotationsReducer = (state = {}, action) => {
     case ActionTypes.RECEIVE_ANNOTATION:
       return {
         ...state,
-        [action.canvasId]: {
+        [action.targetId]: {
           [action.annotationId]: {
             id: action.annotationId,
             isFetching: false,
@@ -29,7 +29,7 @@ export const annotationsReducer = (state = {}, action) => {
     case ActionTypes.RECEIVE_ANNOTATION_FAILURE:
       return {
         ...state,
-        [action.canvasId]: {
+        [action.targetId]: {
           [action.annotationId]: {
             error: action.error,
             id: action.annotationId,

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -125,8 +125,8 @@ export const windowsReducer = (state = {}, action) => {
           ...state[action.windowId],
           selectedAnnotations: {
             ...state[action.windowId].selectedAnnotations,
-            [action.canvasId]: [
-              ...((state[action.windowId].selectedAnnotations || {})[action.canvasId] || []),
+            [action.targetId]: [
+              ...((state[action.windowId].selectedAnnotations || {})[action.targetId] || []),
               action.annotationId,
             ],
           },
@@ -168,21 +168,21 @@ export const windowsReducer = (state = {}, action) => {
 
 /**
  * Handle removing IDs from selectedAnnotations
- * where empty canvasIDs are removed from state as well
+ * where empty targetIds are removed from state as well
  */
 function updatedSelectedAnnotations(state, action) {
   const filteredIds = state[action.windowId]
-    .selectedAnnotations[action.canvasId]
+    .selectedAnnotations[action.targetId]
     .filter(id => id !== action.annotationId);
 
   if (filteredIds.length > 0) {
     return {
       ...state[action.windowId].selectedAnnotations,
-      [action.canvasId]: filteredIds,
+      [action.targetId]: filteredIds,
     };
   }
 
-  return remove(state[action.windowId].selectedAnnotations, action.canvasId);
+  return remove(state[action.windowId].selectedAnnotations, action.targetId);
 }
 
 /**


### PR DESCRIPTION
Without yet having designs for content search, the intent here is to generalize a bit how annotations are stored and selected. Rather than everything be tied to a `canvasId`, now we can use annotations based off of its `targetId`. Of course in our current cases this will be a `canvasId` but should allow for something like `http://example.com/contentsearch/id:foo/search?q=hello` also.