### PR TITLE
Refactor search selectors / state to key of window

### DIFF
--- a/__tests__/src/components/SearchPanelControls.js
+++ b/__tests__/src/components/SearchPanelControls.js
@@ -44,7 +44,6 @@ describe('SearchPanelControls', () => {
     const fetchSearch = jest.fn();
     const searchService = {
       id: 'http://www.example.com/search',
-      options: { resource: { id: 'example.com/manifest' } },
     };
     const wrapper = createWrapper({ fetchSearch, searchService });
     wrapper.setState({ search: 'asdf' });
@@ -52,7 +51,7 @@ describe('SearchPanelControls', () => {
     wrapper.setState({ search: 'yolo' });
 
     wrapper.find('form').simulate('submit', { preventDefault: () => {} });
-    expect(fetchSearch).toHaveBeenCalledWith('example.com/manifest', 'cw', 'http://www.example.com/search?q=yolo');
+    expect(fetchSearch).toHaveBeenCalledWith('window', 'cw', 'http://www.example.com/search?q=yolo');
     expect(wrapper.state().search).toBe('yolo');
   });
 });

--- a/__tests__/src/selectors/searches.test.js
+++ b/__tests__/src/selectors/searches.test.js
@@ -1,26 +1,21 @@
 import {
-  getSearchResultsForManifest,
-  getSearchHitsForManifest,
-  getSearchAnnotationsForManifest,
+  getSearchResultsForWindow,
+  getSearchHitsForCompanionWindow,
+  getSearchAnnotationsForWindow,
 } from '../../../src/state/selectors';
 
-describe('getSearchResultsForManifest', () => {
+describe('getSearchResultsForWindow', () => {
   const companionWindowId = 'cwid';
 
   it('returns flattened results for a manifest', () => {
     const state = {
-      manifests: {
-        'http://example.com/manifest/1': {
-          id: 'http://example.com/manifest/1',
-        },
-      },
       searches: {
-        'http://example.com/manifest/1': {
+        a: {
           [companionWindowId]: {
             json: { foo: 'bar' },
           },
         },
-        'http://example.com/manifest/2': {
+        b: {
           [companionWindowId]: {
             json: { foo: 'bar' },
           },
@@ -28,38 +23,27 @@ describe('getSearchResultsForManifest', () => {
       },
     };
     expect(
-      getSearchResultsForManifest(state, { companionWindowId, manifestId: 'http://example.com/manifest/1' }),
+      getSearchResultsForWindow(state, { windowId: 'a' }),
     ).toEqual({
-      json: { foo: 'bar' },
+      cwid: { json: { foo: 'bar' } },
     });
     expect(
-      getSearchResultsForManifest(state, { companionWindowId, manifestId: 'http://example.com/manifest/foo' }),
-    ).toEqual(null);
-    expect(
-      getSearchResultsForManifest({}, { companionWindowId, manifestId: 'http://example.com/manifest/1' }),
-    ).toEqual(null);
-    expect(
-      getSearchResultsForManifest({}, { manifestId: 'http://example.com/manifest/1' }),
-    ).toEqual(null);
+      getSearchResultsForWindow({}, { windowId: 'a' }),
+    ).toEqual([]);
   });
 });
 
-describe('getSearchHitsForManifest', () => {
+describe('getSearchHitsForCompanionWindow', () => {
   const companionWindowId = 'cwid';
   it('returns flattened hits for a manifest', () => {
     const state = {
-      manifests: {
-        'http://example.com/manifest/1': {
-          id: 'http://example.com/manifest/1',
-        },
-      },
       searches: {
-        'http://example.com/manifest/1': {
+        a: {
           [companionWindowId]: {
             json: { hits: [1, 2, 3] },
           },
         },
-        'http://example.com/manifest/2': {
+        b: {
           [companionWindowId]: {
             json: { foo: 'bar' },
           },
@@ -67,34 +51,29 @@ describe('getSearchHitsForManifest', () => {
       },
     };
     expect(
-      getSearchHitsForManifest(state, { companionWindowId, manifestId: 'http://example.com/manifest/1' }),
+      getSearchHitsForCompanionWindow(state, { companionWindowId, windowId: 'a' }),
     ).toEqual([1, 2, 3]);
     expect(
-      getSearchHitsForManifest(state, { companionWindowId, manifestId: 'http://example.com/manifest/foo' }),
+      getSearchHitsForCompanionWindow(state, { companionWindowId, windowId: 'b' }),
     ).toEqual([]);
     expect(
-      getSearchHitsForManifest({}, { companionWindowId, manifestId: 'http://example.com/manifest/1' }),
+      getSearchHitsForCompanionWindow({}, { companionWindowId, windowId: 'a' }),
     ).toEqual([]);
   });
 });
 
-describe('getSearchAnnotationsForManifest', () => {
+describe('getSearchAnnotationsForWindow', () => {
   const companionWindowId = 'cwid';
 
   it('returns results for a manifest', () => {
     const state = {
-      manifests: {
-        'http://example.com/manifest/1': {
-          id: 'http://example.com/manifest/1',
-        },
-      },
       searches: {
-        'http://example.com/manifest/1': {
+        a: {
           [companionWindowId]: {
             json: { '@id': 'yolo', resources: [{ '@id': 'annoId2' }] },
           },
         },
-        'http://example.com/manifest/2': {
+        b: {
           [companionWindowId]: {
             json: { foo: 'bar' },
           },
@@ -102,19 +81,19 @@ describe('getSearchAnnotationsForManifest', () => {
       },
     };
     expect(
-      getSearchAnnotationsForManifest(state, { companionWindowId, manifestId: 'http://example.com/manifest/1' }),
+      getSearchAnnotationsForWindow(state, { companionWindowId, windowId: 'a' }),
     ).toEqual([{
       id: 'yolo',
       resources: [{ resource: { '@id': 'annoId2' } }],
     }]);
     expect(
-      getSearchAnnotationsForManifest(state, { companionWindowId, manifestId: 'http://example.com/manifest/foo' }),
+      getSearchAnnotationsForWindow(state, { companionWindowId, windowId: 'b' }),
     ).toEqual([]);
     expect(
-      getSearchAnnotationsForManifest({}, { companionWindowId, manifestId: 'http://example.com/manifest/1' }),
+      getSearchAnnotationsForWindow({}, { companionWindowId, windowId: 'a' }),
     ).toEqual([]);
     expect(
-      getSearchAnnotationsForManifest({}, { manifestId: 'http://example.com/manifest/1' }),
+      getSearchAnnotationsForWindow({}, { windowId: 'a' }),
     ).toEqual([]);
   });
 });

--- a/src/components/SearchPanelControls.js
+++ b/src/components/SearchPanelControls.js
@@ -27,10 +27,12 @@ export class SearchPanelControls extends Component {
 
   /** */
   submitSearch(event) {
-    const { companionWindowId, fetchSearch, searchService } = this.props;
+    const {
+      companionWindowId, fetchSearch, searchService, windowId,
+    } = this.props;
     const { search } = this.state;
     event.preventDefault();
-    fetchSearch(searchService.options.resource.id, companionWindowId, `${searchService.id}?q=${search}`);
+    fetchSearch(windowId, companionWindowId, `${searchService.id}?q=${search}`);
   }
 
   /** */
@@ -68,9 +70,9 @@ SearchPanelControls.propTypes = {
   fetchSearch: PropTypes.func.isRequired,
   searchService: PropTypes.shape({
     id: PropTypes.string,
-    options: PropTypes.object,
   }).isRequired,
   t: PropTypes.func,
+  windowId: PropTypes.string.isRequired,
 };
 
 SearchPanelControls.defaultProps = {

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -11,8 +11,7 @@ import {
   getCanvasLabel,
   getSelectedCanvases,
   getViewer,
-  getSearchAnnotationsForManifest,
-  getCompanionWindowIdsForPosition,
+  getSearchAnnotationsForWindow,
 } from '../state/selectors';
 
 /**
@@ -24,12 +23,9 @@ const mapStateToProps = (state, { companionWindowId, windowId }) => ({
   canvasWorld: new CanvasWorld(getSelectedCanvases(state, { windowId })),
   highlightedAnnotations: getHighlightedAnnotationsOnCanvases(state, { windowId }),
   label: getCanvasLabel(state, { windowId }),
-  searchAnnotations: getSearchAnnotationsForManifest(
+  searchAnnotations: getSearchAnnotationsForWindow(
     state,
-    {
-      companionWindowId: getCompanionWindowIdsForPosition(state, { position: 'left', windowId })[0],
-      windowId,
-    },
+    { windowId },
   ),
   selectedAnnotations: getSelectedAnnotationsOnCanvases(state, { windowId }),
   viewer: getViewer(state, { windowId }),

--- a/src/containers/SearchResults.js
+++ b/src/containers/SearchResults.js
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { SearchResults } from '../components/SearchResults';
 import {
-  getSearchHitsForManifest,
+  getSearchHitsForCompanionWindow,
 } from '../state/selectors';
 
 /**
@@ -14,7 +14,7 @@ import {
  * @private
  */
 const mapStateToProps = (state, { companionWindowId, windowId }) => ({
-  searchHits: getSearchHitsForManifest(state, { companionWindowId, windowId }),
+  searchHits: getSearchHitsForCompanionWindow(state, { companionWindowId, windowId }),
 });
 
 const enhance = compose(


### PR DESCRIPTION
This offers us the flexibility to select search results based off a
windowId (needed for displaying in OpenSeadragonViewer) and a
companionId (needed for displaying in individual companion windows).

Fixes #2692

This enables multiple companion window searches to be open so that results from them can be displayed.