### PR TITLE
Add a hit counter to content search results

### DIFF
--- a/__tests__/src/components/SearchHit.test.js
+++ b/__tests__/src/components/SearchHit.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SearchHit } from '../../../src/components/SearchHit';
+
+
+/**
+ * Helper function to create a shallow wrapper around SearchResults
+ */
+function createWrapper(props) {
+  return shallow(
+    <SearchHit
+      hit={{
+        after: ', and start the chainsaw',
+        annotations: ['foo'],
+        before: 'Light up the',
+        match: 'moose',
+      }}
+      windowId="window"
+      selected
+      index={0}
+      {...props}
+    />,
+  );
+}
+
+describe('SearchHit', () => {
+  it('renders a ListItem for each hit', () => {
+    const selectContentSearchAnnotation = jest.fn();
+    const wrapper = createWrapper({ selectContentSearchAnnotation });
+    expect(wrapper.find('WithStyles(ForwardRef(ListItem))').length).toEqual(1);
+    expect(wrapper.find('WithStyles(ForwardRef(ListItem))').prop('selected')).toEqual(true);
+    expect(wrapper.find('WithStyles(ForwardRef(ListItemText))').render().text()).toEqual('1Light up the moose , and start the chainsaw more');
+    expect(wrapper.find('strong').length).toEqual(1);
+
+    wrapper.find('WithStyles(ForwardRef(ListItem))').simulate('click');
+    expect(selectContentSearchAnnotation).toHaveBeenCalledWith('window', ['foo']);
+  });
+});

--- a/__tests__/src/components/SearchResults.test.js
+++ b/__tests__/src/components/SearchResults.test.js
@@ -26,28 +26,21 @@ function createWrapper(props) {
 }
 
 describe('SearchResults', () => {
-  it('renders a ListItem for each hit', () => {
+  it('renders a SearchHit for each hit', () => {
     const selectContentSearchAnnotation = jest.fn();
     const wrapper = createWrapper({ selectContentSearchAnnotation });
-    expect(wrapper.find('WithStyles(ForwardRef(ListItem))').length).toEqual(1);
-    expect(wrapper.find('WithStyles(ForwardRef(ListItem))').prop('selected')).toEqual(true);
-    expect(wrapper.find('WithStyles(ForwardRef(ListItemText))').render().text()).toEqual('Light up the moose , and start the chainsaw more');
-    expect(wrapper.find('strong').length).toEqual(1);
-
-    wrapper.find('WithStyles(ForwardRef(ListItem))').simulate('click');
-    expect(selectContentSearchAnnotation).toHaveBeenCalledWith('window', ['foo']);
+    expect(wrapper.find('Connect(WithStyles(WithPlugins(SearchHit)))').length).toEqual(1);
+    expect(wrapper.find('Connect(WithStyles(WithPlugins(SearchHit)))').prop('index')).toEqual(0);
   });
 
   it('can focus on a single item', () => {
     const wrapper = createWrapper({});
-    expect(wrapper.find(Button).text()).toEqual('more');
-    wrapper.find(Button).simulate('click');
+    wrapper.find('Connect(WithStyles(WithPlugins(SearchHit)))').prop('showDetails')();
     expect(wrapper.state().focused).toEqual(true);
   });
 
   it('can return to the full list view', () => {
     const wrapper = createWrapper({});
-
     wrapper.setState({ focused: true });
     expect(wrapper.find(Button).text()).toEqual('backToResults');
     wrapper.find(Button).simulate('click');

--- a/src/components/SearchHit.js
+++ b/src/components/SearchHit.js
@@ -1,0 +1,93 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import Button from '@material-ui/core/Button';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Typography from '@material-ui/core/Typography';
+import Chip from '@material-ui/core/Chip';
+import SanitizedHtml from '../containers/SanitizedHtml';
+
+/** */
+export class SearchHit extends Component {
+  /** */
+  render() {
+    const {
+      classes,
+      hit,
+      focused,
+      index,
+      showDetails,
+      selected,
+      selectContentSearchAnnotation,
+      t,
+      truncated,
+      windowId,
+    } = this.props;
+
+    if (focused && !selected) return null;
+
+    return (
+      <ListItem
+        className={clsx(
+          classes.listItem,
+          {
+            [classes.selected]: selected,
+            [classes.focused]: focused,
+          },
+        )}
+        button={!selected}
+        component="li"
+        onClick={() => selectContentSearchAnnotation(windowId, hit.annotations)}
+        selected={selected}
+      >
+        <ListItemText primaryTypographyProps={{ variant: 'body2' }}>
+          <Typography>
+            <Chip component="span" label={index + 1} className={classes.hitCounter} />
+          </Typography>
+          <SanitizedHtml ruleSet="iiif" htmlString={hit.before} />
+          {' '}
+          <strong>
+            <SanitizedHtml ruleSet="iiif" htmlString={hit.match} />
+          </strong>
+          {' '}
+          <SanitizedHtml ruleSet="iiif" htmlString={hit.after} />
+          {' '}
+          { truncated && !focused && (
+            <Button className={classes.inlineButton} onClick={showDetails} color="secondary" size="small">
+              {t('more')}
+            </Button>
+          )}
+        </ListItemText>
+      </ListItem>
+    );
+  }
+}
+
+SearchHit.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string),
+  focused: PropTypes.bool,
+  hit: PropTypes.shape({
+    after: PropTypes.string,
+    before: PropTypes.string,
+    match: PropTypes.string,
+  }).isRequired,
+  index: PropTypes.number,
+  selectContentSearchAnnotation: PropTypes.func,
+  selected: PropTypes.bool,
+  showDetails: PropTypes.func,
+  t: PropTypes.func,
+  truncated: PropTypes.bool,
+  windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
+};
+
+SearchHit.defaultProps = {
+  classes: {},
+  focused: false,
+  index: undefined,
+  selectContentSearchAnnotation: () => {},
+  selected: false,
+  showDetails: () => {},
+  t: k => k,
+  truncated: true,
+};

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -1,14 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import Button from '@material-ui/core/Button';
 import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
 import BackIcon from '@material-ui/icons/ArrowBackSharp';
-import Typography from '@material-ui/core/Typography';
-import Chip from '@material-ui/core/Chip';
-import SanitizedHtml from '../containers/SanitizedHtml';
+import SearchHit from '../containers/SearchHit';
 
 /** */
 export class SearchResults extends Component {
@@ -18,7 +13,6 @@ export class SearchResults extends Component {
 
     this.state = { focused: false };
 
-    this.renderHit = this.renderHit.bind(this);
     this.toggleFocus = this.toggleFocus.bind(this);
   }
 
@@ -32,68 +26,12 @@ export class SearchResults extends Component {
   }
 
   /** */
-  renderHit(hit, index) {
-    const {
-      classes,
-      companionWindowId,
-      selectContentSearchAnnotation,
-      selectedContentSearchAnnotation,
-      t,
-      windowId,
-    } = this.props;
-
-    const {
-      focused,
-    } = this.state;
-
-    const selected = selectedContentSearchAnnotation[0] === hit.annotations[0];
-    const truncated = true;
-
-    if (focused && !selected) return null;
-
-    return (
-      <ListItem
-        className={clsx(
-          classes.listItem,
-          {
-            [classes.selected]: selected,
-            [classes.focused]: focused,
-          },
-        )}
-        button={!selected}
-        key={`${companionWindowId}-${hit.annotations[0]}`}
-        component="li"
-        onClick={() => selectContentSearchAnnotation(windowId, hit.annotations)}
-        selected={selected}
-      >
-        <ListItemText primaryTypographyProps={{ variant: 'body2' }}>
-          <Typography>
-            <Chip label={index + 1} className={classes.hitCounter} />
-          </Typography>
-          <SanitizedHtml ruleSet="iiif" htmlString={hit.before} />
-          {' '}
-          <strong>
-            <SanitizedHtml ruleSet="iiif" htmlString={hit.match} />
-          </strong>
-          {' '}
-          <SanitizedHtml ruleSet="iiif" htmlString={hit.after} />
-          {' '}
-          { truncated && !focused && (
-            <Button className={classes.inlineButton} onClick={this.toggleFocus} color="secondary" size="small">
-              {t('more')}
-            </Button>
-          )}
-        </ListItemText>
-      </ListItem>
-    );
-  }
-
-  /** */
   render() {
     const {
       classes,
       searchHits,
       t,
+      windowId,
     } = this.props;
 
     const {
@@ -110,7 +48,16 @@ export class SearchResults extends Component {
         )}
         <List>
           {
-            searchHits.map(this.renderHit)
+            searchHits.map((hit, index) => (
+              <SearchHit
+                key={hit.annotations[0]}
+                focused={focused}
+                hit={hit}
+                index={index}
+                windowId={windowId}
+                showDetails={this.toggleFocus}
+              />
+            ))
           }
         </List>
       </>
@@ -120,17 +67,12 @@ export class SearchResults extends Component {
 
 SearchResults.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
-  companionWindowId: PropTypes.string.isRequired,
   searchHits: PropTypes.arrayOf(PropTypes.object).isRequired,
-  selectContentSearchAnnotation: PropTypes.func,
-  selectedContentSearchAnnotation: PropTypes.arrayOf(PropTypes.string),
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
 };
 
 SearchResults.defaultProps = {
   classes: {},
-  selectContentSearchAnnotation: () => {},
-  selectedContentSearchAnnotation: [],
   t: k => k,
 };

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -6,6 +6,8 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import BackIcon from '@material-ui/icons/ArrowBackSharp';
+import Typography from '@material-ui/core/Typography';
+import Chip from '@material-ui/core/Chip';
 import SanitizedHtml from '../containers/SanitizedHtml';
 
 /** */
@@ -30,7 +32,7 @@ export class SearchResults extends Component {
   }
 
   /** */
-  renderHit(hit) {
+  renderHit(hit, index) {
     const {
       classes,
       companionWindowId,
@@ -65,6 +67,9 @@ export class SearchResults extends Component {
         selected={selected}
       >
         <ListItemText primaryTypographyProps={{ variant: 'body2' }}>
+          <Typography>
+            <Chip label={index + 1} className={classes.hitCounter} />
+          </Typography>
           <SanitizedHtml ruleSet="iiif" htmlString={hit.before} />
           {' '}
           <strong>

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -47,6 +47,11 @@ export default {
       notification: { // Color used in MUI Badge dots
         main: '#ffa224'
       },
+      hitCounter: {
+        default: '#bdbdbd',
+        selected: '#ffff00',
+        adjcaent: '#00BFFF',
+      },
       section_divider: 'rgba(0, 0, 0, 0.25)',
     },
     typography: {

--- a/src/containers/SearchHit.js
+++ b/src/containers/SearchHit.js
@@ -27,6 +27,7 @@ const styles = theme => ({
   focused: {},
   hitCounter: {
     ...theme.typography.h6,
+    backgroundColor: theme.palette.hitCounter.default,
   },
   inlineButton: {
     margin: 0,
@@ -37,7 +38,7 @@ const styles = theme => ({
   listItem: {
     '&$selected': {
       '& $hitCounter': {
-        backgroundColor: 'yellow',
+        backgroundColor: theme.palette.hitCounter.selected,
       },
       '&$focused': {
         '&:hover': {

--- a/src/containers/SearchHit.js
+++ b/src/containers/SearchHit.js
@@ -3,21 +3,19 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
-import { SearchResults } from '../components/SearchResults';
+import { SearchHit } from '../components/SearchHit';
 import * as actions from '../state/actions';
 import {
-  getSearchHitsForCompanionWindow,
   getSelectedContentSearchAnnotationIds,
 } from '../state/selectors';
 
 /**
  * mapStateToProps - used to hook up connect to state
- * @memberof SearchResult
+ * @memberof SearchHit
  * @private
  */
-const mapStateToProps = (state, { companionWindowId, windowId }) => ({
-  searchHits: getSearchHitsForCompanionWindow(state, { companionWindowId, windowId }),
-  selectedContentSearchAnnotation: getSelectedContentSearchAnnotationIds(state, { windowId }),
+const mapStateToProps = (state, { hit, companionWindowId, windowId }) => ({
+  selected: getSelectedContentSearchAnnotationIds(state, { windowId })[0] === hit.annotations[0],
 });
 
 const mapDispatchToProps = {
@@ -26,19 +24,37 @@ const mapDispatchToProps = {
 
 /** */
 const styles = theme => ({
-  navigation: {
+  focused: {},
+  hitCounter: {
+    ...theme.typography.h6,
+  },
+  inlineButton: {
+    margin: 0,
+    padding: 0,
+    textDecoration: 'underline',
     textTransform: 'none',
   },
-  toggleFocus: {
-    ...theme.typography.subtitle1,
+  listItem: {
+    '&$selected': {
+      '& $hitCounter': {
+        backgroundColor: 'yellow',
+      },
+      '&$focused': {
+        '&:hover': {
+          backgroundColor: 'inherit',
+        },
+        backgroundColor: 'inherit',
+      },
+    },
   },
+  selected: {},
 });
 
 const enhance = compose(
   connect(mapStateToProps, mapDispatchToProps),
   withStyles(styles),
   withTranslation(),
-  withPlugins('SearchResults'),
+  withPlugins('SearchHit'),
 );
 
-export default enhance(SearchResults);
+export default enhance(SearchHit);

--- a/src/containers/SearchResults.js
+++ b/src/containers/SearchResults.js
@@ -27,6 +27,9 @@ const mapDispatchToProps = {
 /** */
 const styles = theme => ({
   focused: {},
+  hitCounter: {
+    ...theme.typography.h6,
+  },
   inlineButton: {
     margin: 0,
     padding: 0,
@@ -35,6 +38,9 @@ const styles = theme => ({
   },
   listItem: {
     '&$selected': {
+      '& $hitCounter': {
+        backgroundColor: 'yellow',
+      },
       '&$focused': {
         '&:hover': {
           backgroundColor: 'inherit',


### PR DESCRIPTION
Part of #2683

- [x] Selected results change the hit counter background color to yellow
- [ ] ~Indicate results that are on the same page w/ a blue hit counter~ (will be split out to a different PR)
- [x] tests!