### PR TITLE
Fix issue in Chrome w/ tabs not working when a search service is present

### DIFF
--- a/__tests__/src/components/WindowSideBarButtons.test.js
+++ b/__tests__/src/components/WindowSideBarButtons.test.js
@@ -71,7 +71,7 @@ describe('WindowSideBarButtons (shallow)', () => {
       expect(wrapper.find('WithStyles(Tab)[value="search"]').length).toEqual(0);
     });
     it('can be configured to be on', () => {
-      wrapper = createWrapper({ hideSearchPanel: false, searchService: {}, windowId });
+      wrapper = createWrapper({ hasSearchService: true, hideSearchPanel: false, windowId });
       expect(wrapper.find('WithStyles(ForwardRef(Tab))[value="search"]').length).toEqual(1);
     });
   });

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -132,9 +132,9 @@ export class WindowSideBarButtons extends Component {
     const {
       classes,
       hasAnnotations,
+      hasSearchService,
       hideAnnotationsPanel,
       hideSearchPanel,
-      searchService,
       sideBarPanel,
       t,
     } = this.props;
@@ -188,7 +188,7 @@ export class WindowSideBarButtons extends Component {
             )}
           />
         )}
-        {!hideSearchPanel && searchService && (
+        {!hideSearchPanel && hasSearchService && (
           <TabButton
             value="search"
             icon={(<SearchIcon />)}
@@ -203,9 +203,9 @@ WindowSideBarButtons.propTypes = {
   addCompanionWindow: PropTypes.func.isRequired,
   classes: PropTypes.objectOf(PropTypes.string),
   hasAnnotations: PropTypes.bool,
+  hasSearchService: PropTypes.bool,
   hideAnnotationsPanel: PropTypes.bool,
   hideSearchPanel: PropTypes.bool,
-  searchService: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   sideBarPanel: PropTypes.string,
   t: PropTypes.func,
 };
@@ -213,6 +213,7 @@ WindowSideBarButtons.propTypes = {
 WindowSideBarButtons.defaultProps = {
   classes: {},
   hasAnnotations: false,
+  hasSearchService: false,
   hideAnnotationsPanel: false,
   hideSearchPanel: true,
   sideBarPanel: 'closed',

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -31,9 +31,9 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  */
 const mapStateToProps = (state, { windowId }) => ({
   hasAnnotations: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting'], windowId }).length > 0,
+  hasSearchService: getManifestSearchService(state, { windowId }) !== null,
   hideAnnotationsPanel: state.config.window.hideAnnotationsPanel,
   hideSearchPanel: state.config.window.hideSearchPanel,
-  searchService: getManifestSearchService(state, { windowId }),
   sideBarPanel: ((getCompanionWindowsForPosition(state, { position: 'left', windowId }))[0] || {}).content,
 });
 


### PR DESCRIPTION
Use a hasSearchService boolean prop to determine if we should render the Search tab instead of the SearchService object itself (which causes issues in chrome).

Fixes #2686 
