### PR TITLE
 Truncates plain text for a hit, to provide a more balanced before/after match

### DIFF
--- a/__tests__/src/components/SearchHit.test.js
+++ b/__tests__/src/components/SearchHit.test.js
@@ -29,7 +29,7 @@ describe('SearchHit', () => {
     const wrapper = createWrapper({ selectContentSearchAnnotation });
     expect(wrapper.find('WithStyles(ForwardRef(ListItem))').length).toEqual(1);
     expect(wrapper.find('WithStyles(ForwardRef(ListItem))').prop('selected')).toEqual(true);
-    expect(wrapper.find('WithStyles(ForwardRef(ListItemText))').render().text()).toEqual('1Light up the moose , and start  more');
+    expect(wrapper.find('WithStyles(ForwardRef(ListItemText))').render().text()).toEqual('1Light up the moose , and start the chai more');
     expect(wrapper.find('strong').length).toEqual(1);
 
     wrapper.find('WithStyles(ForwardRef(ListItem))').simulate('click');

--- a/__tests__/src/components/SearchHit.test.js
+++ b/__tests__/src/components/SearchHit.test.js
@@ -29,7 +29,7 @@ describe('SearchHit', () => {
     const wrapper = createWrapper({ selectContentSearchAnnotation });
     expect(wrapper.find('WithStyles(ForwardRef(ListItem))').length).toEqual(1);
     expect(wrapper.find('WithStyles(ForwardRef(ListItem))').prop('selected')).toEqual(true);
-    expect(wrapper.find('WithStyles(ForwardRef(ListItemText))').render().text()).toEqual('1Light up the moose , and start the chainsaw more');
+    expect(wrapper.find('WithStyles(ForwardRef(ListItemText))').render().text()).toEqual('1Light up the moose , and start  more');
     expect(wrapper.find('strong').length).toEqual(1);
 
     wrapper.find('WithStyles(ForwardRef(ListItem))').simulate('click');

--- a/__tests__/src/lib/TruncatedHit.test.js
+++ b/__tests__/src/lib/TruncatedHit.test.js
@@ -3,11 +3,17 @@ import TruncatedHit from '../../../src/lib/TruncatedHit';
 describe('TruncatedHit', () => {
   const th = new TruncatedHit({
     after: 'aaaaa', before: 'bbbbb', match: 'four',
-  }, 10);
+  }, 10, 1);
   const matchOnly = new TruncatedHit({ match: 'four' }, 10);
   describe('charsOnSide', () => {
     it('returns a balanced number of chars to put on each side of match', () => {
       expect(th.charsOnSide).toEqual(3);
+    });
+    it('uses a minimum value for each side to account for beginning/end', () => {
+      const min = new TruncatedHit({
+        after: 'aaaaa', before: 'bbbbb', match: 'four',
+      }, 10, 10);
+      expect(min.charsOnSide).toEqual(10);
     });
   });
   describe('before', () => {

--- a/__tests__/src/lib/TruncatedHit.test.js
+++ b/__tests__/src/lib/TruncatedHit.test.js
@@ -1,0 +1,34 @@
+import TruncatedHit from '../../../src/lib/TruncatedHit';
+
+describe('TruncatedHit', () => {
+  const th = new TruncatedHit({
+    after: 'aaaaa', before: 'bbbbb', match: 'four',
+  }, 10);
+  const matchOnly = new TruncatedHit({ match: 'four' }, 10);
+  describe('charsOnSide', () => {
+    it('returns a balanced number of chars to put on each side of match', () => {
+      expect(th.charsOnSide).toEqual(3);
+    });
+  });
+  describe('before', () => {
+    it('returns substring of before chars', () => {
+      expect(th.before).toEqual('bbb');
+    });
+    it('with only a match', () => {
+      expect(matchOnly.before).toEqual('');
+    });
+  });
+  describe('after', () => {
+    it('returns substring of after chars', () => {
+      expect(th.after).toEqual('aaa');
+    });
+    it('with only a match', () => {
+      expect(matchOnly.after).toEqual('');
+    });
+  });
+  describe('match', () => {
+    it('returns match', () => {
+      expect(th.match).toEqual('four');
+    });
+  });
+});

--- a/src/components/SearchHit.js
+++ b/src/components/SearchHit.js
@@ -7,6 +7,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import Chip from '@material-ui/core/Chip';
 import SanitizedHtml from '../containers/SanitizedHtml';
+import TruncatedHit from '../lib/TruncatedHit';
 
 /** */
 export class SearchHit extends Component {
@@ -27,6 +28,7 @@ export class SearchHit extends Component {
     } = this.props;
 
     if (focused && !selected) return null;
+    const truncatedHit = new TruncatedHit(hit);
 
     return (
       <ListItem
@@ -47,13 +49,13 @@ export class SearchHit extends Component {
             <Chip component="span" label={index + 1} className={classes.hitCounter} />
             {canvasLabel}
           </Typography>
-          <SanitizedHtml ruleSet="iiif" htmlString={hit.before} />
+          <SanitizedHtml ruleSet="iiif" htmlString={truncatedHit.before} />
           {' '}
           <strong>
-            <SanitizedHtml ruleSet="iiif" htmlString={hit.match} />
+            <SanitizedHtml ruleSet="iiif" htmlString={truncatedHit.match} />
           </strong>
           {' '}
-          <SanitizedHtml ruleSet="iiif" htmlString={hit.after} />
+          <SanitizedHtml ruleSet="iiif" htmlString={truncatedHit.after} />
           {' '}
           { truncated && !focused && (
             <Button className={classes.inlineButton} onClick={showDetails} color="secondary" size="small">

--- a/src/lib/TruncatedHit.js
+++ b/src/lib/TruncatedHit.js
@@ -1,16 +1,17 @@
 /** */
 export default class TruncatedHit {
   /** */
-  constructor(hit, maxChars = 200) {
+  constructor(hit, maxChars = 200, minimum = 20) {
     this.hit = hit;
     this.maxChars = maxChars;
+    this.minimum = minimum;
   }
 
   /** */
   get charsOnSide() {
     const resultingChars = (this.maxChars - this.hit.match.length) / 2;
     const measured = [this.hit.before.length, this.hit.after.length].filter(length => length > 0);
-    return Math.min(resultingChars, ...measured);
+    return Math.max(Math.min(resultingChars, ...measured), this.minimum);
   }
 
   /** */

--- a/src/lib/TruncatedHit.js
+++ b/src/lib/TruncatedHit.js
@@ -1,0 +1,36 @@
+/** */
+export default class TruncatedHit {
+  /** */
+  constructor(hit, maxChars = 200) {
+    this.hit = hit;
+    this.maxChars = maxChars;
+  }
+
+  /** */
+  get charsOnSide() {
+    const resultingChars = (this.maxChars - this.hit.match.length) / 2;
+    const measured = [this.hit.before.length, this.hit.after.length].filter(length => length > 0);
+    return Math.min(resultingChars, ...measured);
+  }
+
+  /** */
+  get before() {
+    if (!this.hit.before) return '';
+    return this.hit.before.substring(
+      this.hit.before.length - this.charsOnSide, this.hit.before.length,
+    );
+  }
+
+  /** */
+  get match() {
+    return this.hit.match;
+  }
+
+  /** */
+  get after() {
+    if (!this.hit.after) return '';
+    return this.hit.after.substring(
+      0, Math.min(this.hit.after.length, this.charsOnSide),
+    );
+  }
+}


### PR DESCRIPTION
Fixes #2698 
Fixes #2671 

![Screen Shot 2019-06-14 at 10 50 10 AM](https://user-images.githubusercontent.com/1656824/59524886-34941480-8e92-11e9-8cc2-b5f9827eb836.png)
