### PR TITLE
Tie search hit counters and annotation targets to the same palette

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -98,7 +98,7 @@ export class OpenSeadragonViewer extends Component {
     const {
       viewer,
       highlightedAnnotations, selectedAnnotations,
-      searchAnnotations, selectedContentSearchAnnotations,
+      searchAnnotations, selectedContentSearchAnnotations, palette,
     } = this.props;
     const highlightsUpdated = !OpenSeadragonViewer.annotationsMatch(
       highlightedAnnotations, prevProps.highlightedAnnotations,
@@ -119,8 +119,11 @@ export class OpenSeadragonViewer extends Component {
         this.osdCanvasOverlay.clear();
         this.osdCanvasOverlay.resize();
         this.osdCanvasOverlay.canvasUpdate(() => {
-          this.annotationsToContext(searchAnnotations, '#00BFFF');
-          this.annotationsToContext(selectedContentSearchAnnotations, 'yellow');
+          this.annotationsToContext(searchAnnotations, palette.highlights.primary);
+          this.annotationsToContext(
+            selectedContentSearchAnnotations,
+            palette.highlights.secondary,
+          );
         });
       };
       this.viewer.forceRedraw();
@@ -131,8 +134,8 @@ export class OpenSeadragonViewer extends Component {
         this.osdCanvasOverlay.clear();
         this.osdCanvasOverlay.resize();
         this.osdCanvasOverlay.canvasUpdate(() => {
-          this.annotationsToContext(highlightedAnnotations, '#00BFFF');
-          this.annotationsToContext(selectedAnnotations, 'yellow');
+          this.annotationsToContext(highlightedAnnotations, palette.highlights.primary);
+          this.annotationsToContext(selectedAnnotations, palette.highlights.secondary);
         });
       };
       this.viewer.forceRedraw();
@@ -309,6 +312,7 @@ OpenSeadragonViewer.defaultProps = {
   children: null,
   highlightedAnnotations: [],
   label: null,
+  palette: {},
   searchAnnotations: [],
   selectedAnnotations: [],
   selectedContentSearchAnnotations: [],
@@ -321,6 +325,7 @@ OpenSeadragonViewer.propTypes = {
   children: PropTypes.node,
   highlightedAnnotations: PropTypes.arrayOf(PropTypes.object),
   label: PropTypes.string,
+  palette: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   searchAnnotations: PropTypes.arrayOf(PropTypes.object),
   selectedAnnotations: PropTypes.arrayOf(PropTypes.object),
   selectedContentSearchAnnotations: PropTypes.arrayOf(PropTypes.object),

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -49,8 +49,10 @@ export default {
       },
       hitCounter: {
         default: '#bdbdbd',
-        selected: '#ffff00',
-        adjacent: '#00BFFF',
+      },
+      highlights: {
+        primary: '#ffff00',
+        secondary: '#00BFFF',
       },
       section_divider: 'rgba(0, 0, 0, 0.25)',
     },

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -13,6 +13,7 @@ import {
   getViewer,
   getSearchAnnotationsForWindow,
   getSelectedContentSearchAnnotations,
+  getTheme,
 } from '../state/selectors';
 
 /**
@@ -24,6 +25,7 @@ const mapStateToProps = (state, { companionWindowId, windowId }) => ({
   canvasWorld: new CanvasWorld(getSelectedCanvases(state, { windowId })),
   highlightedAnnotations: getHighlightedAnnotationsOnCanvases(state, { windowId }),
   label: getCanvasLabel(state, { windowId }),
+  palette: getTheme(state).palette,
   searchAnnotations: getSearchAnnotationsForWindow(
     state,
     { windowId },

--- a/src/containers/SearchHit.js
+++ b/src/containers/SearchHit.js
@@ -55,7 +55,7 @@ const styles = theme => ({
   listItem: {
     '&$selected': {
       '& $hitCounter': {
-        backgroundColor: theme.palette.hitCounter.selected,
+        backgroundColor: theme.palette.highlights.primary,
       },
       '&$focused': {
         '&:hover': {


### PR DESCRIPTION
Part of #2683 / follows on from #2699 

This PR ties the annotation target colors to the theme palette. The same colors are also used for hit counters.

Test this out in the browser console with the following:
```javascript
var action = miradorInstance.actions.updateConfig({
  themes: {
    light: {
      palette: {
        type: 'light',
        highlights: {
          primary: "#c0ffee",
          secondary: "#b00000",
        }
      },
    },
  },
});
miradorInstance.store.dispatch(action);
```

![altered annotation target colors](https://user-images.githubusercontent.com/5402927/59539704-1be82680-8eb3-11e9-8aa5-ae646e7956c8.png)
