### PR TITLE
Adds display for no results fixes #2720

### DIFF
--- a/__tests__/src/components/SearchResults.test.js
+++ b/__tests__/src/components/SearchResults.test.js
@@ -46,4 +46,44 @@ describe('SearchResults', () => {
     wrapper.find(Button).simulate('click');
     expect(wrapper.state().focused).toEqual(false);
   });
+
+  describe('no search results', () => {
+    it('shows no results', () => {
+      const wrapper = createWrapper({
+        searchHits: [],
+        searchResults: {
+          isFetching: false,
+          query: 'nope',
+        },
+      });
+      expect(wrapper.find('WithStyles(ForwardRef(Typography))').text()).toEqual('searchNoResults');
+    });
+    it('with hits', () => {
+      const wrapper = createWrapper({
+        searchResults: {
+          isFetching: false,
+          query: 'nope',
+        },
+      });
+      expect(wrapper.find('WithStyles(ForwardRef(Typography))').length).toEqual(0);
+    });
+    it('while fetching', () => {
+      const wrapper = createWrapper({
+        searchResults: {
+          isFetching: true,
+          query: 'nope',
+        },
+      });
+      expect(wrapper.find('WithStyles(ForwardRef(Typography))').length).toEqual(0);
+    });
+    it('without a query', () => {
+      const wrapper = createWrapper({
+        searchResults: {
+          isFetching: false,
+          query: '',
+        },
+      });
+      expect(wrapper.find('WithStyles(ForwardRef(Typography))').length).toEqual(0);
+    });
+  });
 });

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import List from '@material-ui/core/List';
+import Typography from '@material-ui/core/Typography';
 import BackIcon from '@material-ui/icons/ArrowBackSharp';
 import SearchHit from '../containers/SearchHit';
 
@@ -31,6 +32,7 @@ export class SearchResults extends Component {
       classes,
       companionWindowId,
       searchHits,
+      searchResults,
       t,
       windowId,
     } = this.props;
@@ -39,6 +41,10 @@ export class SearchResults extends Component {
       focused,
     } = this.state;
 
+    const noResultsState = (
+      searchResults && searchResults.query && !searchResults.isFetching && searchHits.length === 0
+    );
+
     return (
       <>
         { focused && (
@@ -46,6 +52,11 @@ export class SearchResults extends Component {
             <BackIcon />
             {t('backToResults')}
           </Button>
+        )}
+        {noResultsState && (
+          <Typography className={classes.noResults}>
+            {t('searchNoResults')}
+          </Typography>
         )}
         <List>
           {
@@ -71,6 +82,7 @@ SearchResults.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
   companionWindowId: PropTypes.string.isRequired,
   searchHits: PropTypes.arrayOf(PropTypes.object).isRequired,
+  searchResults: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
 };

--- a/src/containers/SearchResults.js
+++ b/src/containers/SearchResults.js
@@ -8,6 +8,7 @@ import * as actions from '../state/actions';
 import {
   getSearchHitsForCompanionWindow,
   getSelectedContentSearchAnnotationIds,
+  getSearchResultsForCompanionWindow,
 } from '../state/selectors';
 
 /**
@@ -17,6 +18,7 @@ import {
  */
 const mapStateToProps = (state, { companionWindowId, windowId }) => ({
   searchHits: getSearchHitsForCompanionWindow(state, { companionWindowId, windowId }),
+  searchResults: getSearchResultsForCompanionWindow(state, { companionWindowId, windowId }),
   selectedContentSearchAnnotation: getSelectedContentSearchAnnotationIds(state, { windowId }),
 });
 
@@ -28,6 +30,10 @@ const mapDispatchToProps = {
 const styles = theme => ({
   navigation: {
     textTransform: 'none',
+  },
+  noResults: {
+    ...theme.typography.h6,
+    padding: theme.spacing(2),
   },
   toggleFocus: {
     ...theme.typography.subtitle1,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -96,6 +96,7 @@
     "rights": "License",
     "searchInputLabel": "search terms",
     "searchNextResult": "Next result",
+    "searchNoResults": "No results found",
     "searchPageSeparator": "{{current}} of {{total}}",
     "searchPreviousResult": "Previous result",
     "searchSubmitAria": "Submit search",


### PR DESCRIPTION
There are still some interaction patterns that are odd w/ autocomplete but I believe they are resolved in #2716 

![no results](https://user-images.githubusercontent.com/1656824/59541367-23f99380-8ebe-11e9-869e-fe8bb54fa8af.gif)
