### PR TITLE
Do not force plugin components to be a function, they could also be a…

### DIFF
--- a/__tests__/src/extend/pluginValidation.test.js
+++ b/__tests__/src/extend/pluginValidation.test.js
@@ -55,15 +55,6 @@ describe('validatePlugin', () => {
     expect(validatePlugin(plugin)).toBe(true);
   });
 
-  it('component must be function', () => {
-    let plugin = createPlugin({ component: undefined });
-    expect(validatePlugin(plugin)).toBe(false);
-    plugin = createPlugin({ component: 'somethink' });
-    expect(validatePlugin(plugin)).toBe(false);
-    plugin = createPlugin({ component: x => x });
-    expect(validatePlugin(plugin)).toBe(true);
-  });
-
   it('mapStateToProps must be undefined, null or function', () => {
     let plugin = createPlugin({ mapStateToProps: undefined });
     expect(validatePlugin(plugin)).toBe(true);

--- a/src/extend/pluginValidation.js
+++ b/src/extend/pluginValidation.js
@@ -11,7 +11,6 @@ export const validatePlugin = plugin => [
   checkName,
   checkTarget,
   checkMode,
-  checkComponent,
   checkMapStateToProps,
   checkMapDispatchToProps,
   checkReducers,
@@ -36,12 +35,6 @@ const checkTarget = (plugin) => {
 const checkMode = (plugin) => {
   const { mode } = plugin;
   return ['add', 'wrap'].some(s => s === mode);
-};
-
-/** */
-const checkComponent = (plugin) => {
-  const { component } = plugin;
-  return isFunction(component);
 };
 
 /** */


### PR DESCRIPTION
… class

We are getting some validation errors when using plugins. They could be a component, no?