### PR TITLE
Add config option to initially show manifest list rather than windows. Closes #2759

### DIFF
--- a/__tests__/integration/mirador/index.html
+++ b/__tests__/integration/mirador/index.html
@@ -13,14 +13,9 @@
     <script type="text/javascript">
      var miradorInstance = Mirador.viewer({
        id: 'mirador',
-       windows: [{
-         loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
-         canvasIndex: 2,
-         thumbnailNavigationPosition: 'far-bottom',
+       workspace: {
+         isWorkspaceAddVisible: true,
        },
-       {
-         loadedManifest: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json',
-       }],
        window: {
          hideSearchPanel: false,
        },

--- a/__tests__/src/actions/config.test.js
+++ b/__tests__/src/actions/config.test.js
@@ -43,4 +43,17 @@ describe('config actions', () => {
       expect(actions.importMiradorState(state).type).toEqual(ActionTypes.IMPORT_MIRADOR_STATE);
     });
   });
+  describe('setWorkspaceAddVisibility', () => {
+    it('should set the the isWorkspaceAddVisible property', () => {
+      expect(actions.setWorkspaceAddVisibility(true)).toEqual({
+        config: { workspace: { isWorkspaceAddVisible: true } },
+        type: ActionTypes.UPDATE_CONFIG,
+      });
+
+      expect(actions.setWorkspaceAddVisibility(true)).toEqual({
+        config: { workspace: { isWorkspaceAddVisible: true } },
+        type: ActionTypes.UPDATE_CONFIG,
+      });
+    });
+  });
 });

--- a/__tests__/src/actions/workspace.test.js
+++ b/__tests__/src/actions/workspace.test.js
@@ -40,15 +40,6 @@ describe('workspace actions', () => {
       expect(actions.toggleZoomControls(true)).toEqual(expectedAction);
     });
   });
-  describe('setWorkspaceAddVisibility', () => {
-    it('should set the workspace add visibility', () => {
-      const expectedAction = {
-        isWorkspaceAddVisible: true,
-        type: ActionTypes.SET_WORKSPACE_ADD_VISIBILITY,
-      };
-      expect(actions.setWorkspaceAddVisibility(true)).toEqual(expectedAction);
-    });
-  });
   describe('setWorkspaceViewportDimensions', () => {
     it('should set the workspace add visibility', () => {
       const expectedAction = {

--- a/__tests__/src/reducers/workspace.test.js
+++ b/__tests__/src/reducers/workspace.test.js
@@ -71,14 +71,6 @@ describe('workspace reducer', () => {
       layout: { foo: 'bar' },
     });
   });
-  it('should handle SET_WORKSPACE_ADD_VISIBILITY', () => {
-    expect(workspaceReducer([], {
-      isWorkspaceAddVisible: true,
-      type: ActionTypes.SET_WORKSPACE_ADD_VISIBILITY,
-    })).toEqual({
-      isWorkspaceAddVisible: true,
-    });
-  });
   it('should handle SET_WORKSPACE_VIEWPORT_POSITION', () => {
     expect(workspaceReducer({ height: 5000, width: 5000 }, {
       payload: {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -230,6 +230,7 @@ export default {
   workspace: {
     showZoomControls: false, // Configure if zoom controls should be displayed by default
     type: 'mosaic', // Which workspace type to load by default. Other possible values are "elastic"
+    isWorkspaceAddVisible: false,
   },
   workspaceControlPanel: {
     enabled: true, // Configure if the control panel should be rendered.  Useful if you want to lock the viewer down to only the configured manifests

--- a/src/containers/WindowListButton.js
+++ b/src/containers/WindowListButton.js
@@ -6,8 +6,8 @@ import { withPlugins } from '../extend/withPlugins';
 import { WindowListButton } from '../components/WindowListButton';
 
 /** */
-const mapStateToProps = ({ windows, workspace }) => ({
-  disabled: workspace.isWorkspaceAddVisible,
+const mapStateToProps = ({ windows, config }) => ({
+  disabled: config.workspace.isWorkspaceAddVisible,
   windowCount: Object.keys(windows).length,
 });
 

--- a/src/containers/WorkspaceAddButton.js
+++ b/src/containers/WorkspaceAddButton.js
@@ -13,7 +13,7 @@ import { WorkspaceAddButton } from '../components/WorkspaceAddButton';
  * @private
  */
 const mapStateToProps = (state, { width }) => {
-  const { isWorkspaceAddVisible } = state.workspace;
+  const { isWorkspaceAddVisible } = state.config.workspace;
   return {
     isWorkspaceAddVisible,
     useExtendedFab: (

--- a/src/containers/WorkspaceArea.js
+++ b/src/containers/WorkspaceArea.js
@@ -12,8 +12,8 @@ import { WorkspaceArea } from '../components/WorkspaceArea';
  */
 const mapStateToProps = state => (
   {
-    controlPanelVariant: state.workspace.isWorkspaceAddVisible || Object.keys(state.windows).length > 0 ? undefined : 'wide',
-    isWorkspaceAddVisible: state.workspace.isWorkspaceAddVisible,
+    controlPanelVariant: state.config.workspace.isWorkspaceAddVisible || Object.keys(state.windows).length > 0 ? undefined : 'wide',
+    isWorkspaceAddVisible: state.config.workspace.isWorkspaceAddVisible,
     isWorkspaceControlPanelVisible: state.config.workspaceControlPanel.enabled,
   }
 );

--- a/src/containers/WorkspaceMenu.js
+++ b/src/containers/WorkspaceMenu.js
@@ -22,7 +22,7 @@ const mapDispatchToProps = {
  */
 const mapStateToProps = state => ({
   containerId: getContainerId(state),
-  isWorkspaceAddVisible: state.workspace.isWorkspaceAddVisible,
+  isWorkspaceAddVisible: state.config.workspace.isWorkspaceAddVisible,
   showThemePicker: getThemeIds(state).length > 0,
   showZoomControls: getShowZoomControlsConfig(state),
 });

--- a/src/state/actions/config.js
+++ b/src/state/actions/config.js
@@ -47,3 +47,15 @@ export function importMiradorState(state) {
   };
   return { state: newState, type: ActionTypes.IMPORT_MIRADOR_STATE };
 }
+
+/**
+ * @param  {Object} isWorkspaceAddVisible
+ * @memberof ActionCreators
+ */
+export function setWorkspaceAddVisibility(isWorkspaceAddVisible) {
+  return updateConfig({
+    workspace: {
+      isWorkspaceAddVisible,
+    },
+  });
+}

--- a/src/state/actions/workspace.js
+++ b/src/state/actions/workspace.js
@@ -30,16 +30,6 @@ export function updateWorkspaceMosaicLayout(layout) {
 }
 
 /**
- * updateWorkspaceMosaicLayout - action creator
- *
- * @param  {Object} isWorkspaceAddVisible
- * @memberof ActionCreators
- */
-export function setWorkspaceAddVisibility(isWorkspaceAddVisible) {
-  return { isWorkspaceAddVisible, type: ActionTypes.SET_WORKSPACE_ADD_VISIBILITY };
-}
-
-/**
  * setWorkspaceViewportPosition - action creator
  *
  * @param  {Object} position

--- a/src/state/reducers/workspace.js
+++ b/src/state/reducers/workspace.js
@@ -63,8 +63,6 @@ export const workspaceReducer = (
       return { ...state, showZoomControls: action.showZoomControls };
     case ActionTypes.UPDATE_WORKSPACE_MOSAIC_LAYOUT:
       return { ...state, layout: action.layout };
-    case ActionTypes.SET_WORKSPACE_ADD_VISIBILITY:
-      return { ...state, isWorkspaceAddVisible: action.isWorkspaceAddVisible };
     case ActionTypes.SET_WORKSPACE_VIEWPORT_POSITION:
       newWorkspaceDimensions = {};
 


### PR DESCRIPTION
Example usage:

```javascript
const config = {
  id: 'mirador',
  workspace: {
    isWorkspaceAddVisible: true,  // false by default
  },
  manifests: {
    "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
    "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
  },
}
```