### PR TITLE
Update readme to direct users to Glitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 # Mirador
 [![Build Status](https://travis-ci.org/ProjectMirador/mirador.svg?branch=master)](https://travis-ci.org/ProjectMirador/mirador) [![codecov](https://codecov.io/gh/ProjectMirador/mirador/branch/master/graph/badge.svg)](https://codecov.io/gh/ProjectMirador/mirador)
 
+## For Mirador Users
+You can quickly use and configure Mirador by remixing the [mirador-start](https://mirador-start.glitch.me/) Glitch.
+
 ## Running Mirador locally
 
 Mirador local development requires [nodejs](https://nodejs.org/en/download/) to be installed.


### PR DESCRIPTION
Fixes #521

End user use is simplified in Mirador 3. The readme update reflects that, to just direct them to glitch to remix and start.