### PR TITLE
Fixes an issue where book view navigation can be off

### DIFF
--- a/__tests__/src/components/ViewerNavigation.test.js
+++ b/__tests__/src/components/ViewerNavigation.test.js
@@ -28,11 +28,21 @@ describe('ViewerNavigation', () => {
     expect(wrapper.find('.mirador-osd-navigation').length).toBe(1);
   });
   describe('when next canvases are present', () => {
-    it('disabled on nextCanvas button', () => {
+    it('nextCanvas button is not disabled', () => {
       expect(wrapper.find('.mirador-next-canvas-button').prop('aria-label')).toBe('nextCanvas');
       expect(wrapper.find('.mirador-next-canvas-button').prop('disabled')).toBe(false);
     });
     it('setCanvas function is called after click', () => {
+      wrapper.find('.mirador-next-canvas-button').simulate('click');
+      expect(setCanvas).toHaveBeenCalledWith(1);
+    });
+    it('nextCanvas button is not disabled in bookview', () => {
+      wrapper = createWrapper({
+        canvases: [1, 2],
+        canvasIndex: 0,
+        setCanvas,
+        view: 'book',
+      });
       wrapper.find('.mirador-next-canvas-button').simulate('click');
       expect(setCanvas).toHaveBeenCalledWith(1);
     });

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -51,9 +51,11 @@ export class ViewerNavigation extends Component {
   /**
    */
   canvasIncrementor() {
-    const { view } = this.props;
+    const { canvasIndex, canvases, view } = this.props;
     switch (view) {
       case 'book':
+        // the case where the index is n - 1
+        if (canvasIndex === canvases.length - 2) return 1;
         return 2;
       default:
         return 1;


### PR DESCRIPTION
If an item in single view is on the second to last page, then switched to book view, the "next page" would be disabled. This fixes that issue.