### PR TITLE
Explicitly pass a handleClose prop through the plugin menu's…

### DIFF
--- a/__tests__/src/components/WindowTopBarPluginMenu.test.js
+++ b/__tests__/src/components/WindowTopBarPluginMenu.test.js
@@ -61,5 +61,14 @@ describe('WindowTopBarPluginMenu', () => {
       expect(wrapper.find(Menu).props().open).toBe(false);
       expect(wrapper.state().anchorEl).toBeNull();
     });
+
+    it('explicitly passes the local close handler to the PluginHook', () => {
+      wrapper = createWrapper({ PluginComponents });
+
+      wrapper.setState({ anchorEl: 'Button' });
+      expect(wrapper.state().anchorEl).toEqual('Button');
+      expect(wrapper.find(PluginHook).props().handleClose());
+      expect(wrapper.state().anchorEl).toBeNull();
+    });
   });
 });

--- a/src/components/WindowTopBarPluginMenu.js
+++ b/src/components/WindowTopBarPluginMenu.js
@@ -79,7 +79,7 @@ export class WindowTopBarPluginMenu extends Component {
           open={Boolean(anchorEl)}
           onClose={() => this.handleMenuClose()}
         >
-          <PluginHook {...this.props} />
+          <PluginHook handleClose={() => this.handleMenuClose()} {...this.props} />
         </Menu>
       </>
     );


### PR DESCRIPTION
…PluginHook.

This mimics the behavior that is happening in the other menu