### PR TITLE
Use linear and radial gradients to try to indicate there is scrollable...

### DIFF
--- a/__tests__/src/components/ScrollIndicatedDialogContent.test.js
+++ b/__tests__/src/components/ScrollIndicatedDialogContent.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import DialogContent from '@material-ui/core/DialogContent';
+import { ScrollIndicatedDialogContent } from '../../../src/components/ScrollIndicatedDialogContent';
+
+/** Utility function to wrap  */
+function createWrapper(props) {
+  return shallow(
+    <ScrollIndicatedDialogContent
+      classes={{ shadowScrollDialog: 'shadowScrollDialog' }}
+      {...props}
+    />,
+  );
+}
+
+describe('ScrollIndicatedDialogContent', () => {
+  let wrapper;
+
+  it('renders a DialogContnet component passing props', () => {
+    wrapper = createWrapper({ randomProp: 'randomPropValue' });
+
+    expect(wrapper.find(DialogContent).length).toBe(1);
+    expect(wrapper.find(DialogContent).props().randomProp).toEqual('randomPropValue');
+  });
+
+  it('provides a className to the DialogContent prop to style it', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find(DialogContent).props().className).toMatch('shadowScrollDialog');
+  });
+
+  it('joins an incoming className prop with our className', () => {
+    wrapper = createWrapper({ className: 'upstreamClassName' });
+
+    expect(wrapper.find(DialogContent).props().className).toMatch('upstreamClassName shadowScrollDialog');
+  });
+});

--- a/src/components/ScrollIndicatedDialogContent.js
+++ b/src/components/ScrollIndicatedDialogContent.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import DialogContent from '@material-ui/core/DialogContent';
+
+/**
+ * ScrollIndicatedDialogContent ~ Inject a style into the DialogContent component
+ *                                to indicate there is scrollable content
+*/
+export function ScrollIndicatedDialogContent(props) {
+  const { classes, className, ...otherProps } = props;
+  const ourClassName = [className, classes.shadowScrollDialog].join(' ');
+
+  return (
+    <DialogContent className={ourClassName} {...otherProps} />
+  );
+}
+
+ScrollIndicatedDialogContent.propTypes = {
+  classes: PropTypes.shape({
+    shadowScrollDialog: PropTypes.string,
+  }).isRequired,
+
+  className: PropTypes.string,
+};
+
+ScrollIndicatedDialogContent.defaultProps = {
+  className: '',
+};

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -2,11 +2,11 @@ import React, { Component } from 'react';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import ScrollIndicatedDialogContent from '../containers/ScrollIndicatedDialogContent';
 
 /**
  */
@@ -57,14 +57,14 @@ export class WorkspaceExport extends Component {
         <DialogTitle id="form-dialog-title" disableTypography>
           <Typography variant="h2">{t('downloadExport')}</Typography>
         </DialogTitle>
-        <DialogContent
+        <ScrollIndicatedDialogContent
           className={classes.dialogcontent}
         >
           {children}
           <pre>
             {exportableState}
           </pre>
-        </DialogContent>
+        </ScrollIndicatedDialogContent>
         <DialogActions>
           <Button className={classes.cancelBtn} onClick={() => handleClose()}>{t('cancel')}</Button>
           <CopyToClipboard

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -41,7 +41,7 @@ export class WorkspaceExport extends Component {
    */
   render() {
     const {
-      children, classes, container, handleClose, open, t,
+      children, container, handleClose, open, t,
     } = this.props;
     const exportableState = this.exportableState();
     return (
@@ -57,16 +57,14 @@ export class WorkspaceExport extends Component {
         <DialogTitle id="form-dialog-title" disableTypography>
           <Typography variant="h2">{t('downloadExport')}</Typography>
         </DialogTitle>
-        <ScrollIndicatedDialogContent
-          className={classes.dialogcontent}
-        >
+        <ScrollIndicatedDialogContent>
           {children}
           <pre>
             {exportableState}
           </pre>
         </ScrollIndicatedDialogContent>
         <DialogActions>
-          <Button className={classes.cancelBtn} onClick={() => handleClose()}>{t('cancel')}</Button>
+          <Button onClick={() => handleClose()}>{t('cancel')}</Button>
           <CopyToClipboard
             text={exportableState}
           >
@@ -80,7 +78,6 @@ export class WorkspaceExport extends Component {
 
 WorkspaceExport.propTypes = {
   children: PropTypes.node,
-  classes: PropTypes.objectOf(PropTypes.string),
   container: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
@@ -90,7 +87,6 @@ WorkspaceExport.propTypes = {
 
 WorkspaceExport.defaultProps = {
   children: null,
-  classes: {},
   container: null,
   open: false,
   t: key => key,

--- a/src/components/WorkspaceImport.js
+++ b/src/components/WorkspaceImport.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import PropTypes from 'prop-types';
 import {
@@ -9,6 +8,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
+import ScrollIndicatedDialogContent from '../containers/ScrollIndicatedDialogContent';
 
 /**
  */
@@ -77,7 +77,7 @@ export class WorkspaceImport extends Component {
         <DialogTitle id="workspace-import-title" disableTypography>
           <Typography variant="h2">{t('importWorkspace')}</Typography>
         </DialogTitle>
-        <DialogContent>
+        <ScrollIndicatedDialogContent>
           <TextField
             className={classes.textField}
             id="workspace-import-input"
@@ -88,7 +88,7 @@ export class WorkspaceImport extends Component {
             inputProps={{ autoFocus: 'autofocus', className: classes.textInput }}
             helperText={t('importWorkspaceHint')}
           />
-        </DialogContent>
+        </ScrollIndicatedDialogContent>
         <DialogActions>
           <Button className={classes.cancelBtn} onClick={handleClose}>
             {t('cancel')}

--- a/src/components/WorkspaceSelectionDialog.js
+++ b/src/components/WorkspaceSelectionDialog.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import {
   Card,
@@ -12,6 +11,7 @@ import {
 import PropTypes from 'prop-types';
 import WorkspaceTypeElasticIcon from './icons/WorkspaceTypeElasticIcon';
 import WorkspaceTypeMosaicIcon from './icons/WorkspaceTypeMosaicIcon';
+import ScrollIndicatedDialogContent from '../containers/ScrollIndicatedDialogContent';
 
 /**
  */
@@ -71,7 +71,7 @@ export class WorkspaceSelectionDialog extends Component {
         <DialogTitle id="workspace-selection-dialog-title" disableTypography>
           <Typography variant="h2">{t('workspaceSelectionTitle')}</Typography>
         </DialogTitle>
-        <DialogContent>
+        <ScrollIndicatedDialogContent>
           {children}
           <MenuList
             classes={{ root: classes.list }}
@@ -122,7 +122,7 @@ export class WorkspaceSelectionDialog extends Component {
               </Card>
             </MenuItem>
           </MenuList>
-        </DialogContent>
+        </ScrollIndicatedDialogContent>
       </Dialog>
     );
   }

--- a/src/containers/ScrollIndicatedDialogContent.js
+++ b/src/containers/ScrollIndicatedDialogContent.js
@@ -1,0 +1,29 @@
+import { withStyles } from '@material-ui/core/styles';
+import { ScrollIndicatedDialogContent } from '../components/ScrollIndicatedDialogContent';
+
+/**
+ * Styles for the withStyles HOC
+ */
+const styles = theme => ({
+  shadowScrollDialog: {
+    /* Shadow covers */
+    background: `linear-gradient(${theme.palette.background.paper} 30%, rgba(255, 255, 255, 0)), `
+                + `linear-gradient(rgba(255, 255, 255, 0), ${theme.palette.background.paper} 70%) 0 100%, `
+                // Shaddows
+                + 'radial-gradient(50% 0, farthest-side, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)), '
+                + 'radial-gradient(50% 100%, farthest-side, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)) 0 100%,',
+    /* Shadow covers */
+    background: `linear-gradient(${theme.palette.background.paper} 30%, rgba(255, 255, 255, 0)), ` // eslint-disable-line no-dupe-keys
+                + `linear-gradient(rgba(255, 255, 255, 0), ${theme.palette.background.paper} 70%) 0 100%, `
+                // Shaddows
+                + 'radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)), '
+                + 'radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)) 0 100%;',
+
+    backgroundAttachment: 'local, local, scroll, scroll',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: '100% 40px, 100% 40px, 100% 14px, 100% 14px',
+    overflowY: 'auto',
+  },
+});
+
+export default withStyles(styles)(ScrollIndicatedDialogContent);

--- a/src/containers/WorkspaceExport.js
+++ b/src/containers/WorkspaceExport.js
@@ -1,7 +1,6 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend/withPlugins';
 import { WorkspaceExport } from '../components/WorkspaceExport';
 
@@ -12,23 +11,8 @@ import { WorkspaceExport } from '../components/WorkspaceExport';
  */
 const mapStateToProps = state => ({ state });
 
-/**
- *
- * @param theme
- */
-const styles = theme => ({
-  cancelBtn: {
-    color: theme.palette.text.primary,
-  },
-  dialogcontent: {
-    backgroundColor: theme.palette.shades.light,
-    color: theme.palette.text.primary,
-  },
-});
-
 const enhance = compose(
   withTranslation(),
-  withStyles(styles),
   connect(mapStateToProps, {}),
   withPlugins('WorkspaceExport'),
 );


### PR DESCRIPTION
...content in dialogs

Closes #2774

![scrollShadows](https://user-images.githubusercontent.com/96776/60148092-9010ad00-9784-11e9-8aa4-e7d1bfc9dc62.gif)

Using the component in a plugin:

<img width="603" alt="Screen Shot 2019-06-25 at 8 20 59 PM" src="https://user-images.githubusercontent.com/96776/60148662-da932900-9786-11e9-9ca4-c589efa76ef8.png">
