### PR TITLE
Separate selected search state per search

### DIFF
--- a/__tests__/src/actions/search.test.js
+++ b/__tests__/src/actions/search.test.js
@@ -175,14 +175,18 @@ describe('search actions', () => {
         },
       });
       const windowId = 'foo';
+      const companionWindowId = 'cwid';
       const annotationId = ['abc123'];
       const expectedAction = {
         annotationId,
         canvasIndex: 1,
+        companionWindowId,
         type: ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION,
         windowId,
       };
-      store.dispatch(actions.selectContentSearchAnnotation(windowId, annotationId));
+      store.dispatch(
+        actions.selectContentSearchAnnotation(windowId, companionWindowId, annotationId),
+      );
       const actualActions = store.getActions();
       expect(actualActions).toEqual([expectedAction]);
     });

--- a/__tests__/src/components/SearchHit.test.js
+++ b/__tests__/src/components/SearchHit.test.js
@@ -11,6 +11,7 @@ function createWrapper(props) {
   return shallow(
     <SearchHit
       annotationId="foo"
+      classes={{ windowSelected: 'windowSelected' }}
       hit={{
         after: ', and start the chainsaw',
         annotations: ['foo'],
@@ -20,6 +21,7 @@ function createWrapper(props) {
       windowId="window"
       selected
       index={0}
+      windowSelected
       {...props}
     />,
   );
@@ -31,6 +33,7 @@ describe('SearchHit', () => {
     const wrapper = createWrapper({ selectContentSearchAnnotation });
     expect(wrapper.find('WithStyles(ForwardRef(ListItem))').length).toEqual(1);
     expect(wrapper.find('WithStyles(ForwardRef(ListItem))').prop('selected')).toEqual(true);
+    expect(wrapper.find('WithStyles(ForwardRef(ListItem))').prop('className')).toEqual('windowSelected');
     expect(wrapper.find('WithStyles(ForwardRef(ListItemText))').render().text()).toEqual('1Light up the moose , and start the chai ');
     expect(wrapper.find('strong').length).toEqual(1);
 

--- a/__tests__/src/components/SearchHit.test.js
+++ b/__tests__/src/components/SearchHit.test.js
@@ -35,7 +35,7 @@ describe('SearchHit', () => {
     expect(wrapper.find('strong').length).toEqual(1);
 
     wrapper.find('WithStyles(ForwardRef(ListItem))').simulate('click');
-    expect(selectContentSearchAnnotation).toHaveBeenCalledWith('window', ['foo']);
+    expect(selectContentSearchAnnotation).toHaveBeenCalledWith(['foo']);
   });
 
   it('renders the annotation char if the hit is not available', () => {

--- a/__tests__/src/components/SearchPanelNavigation.test.js
+++ b/__tests__/src/components/SearchPanelNavigation.test.js
@@ -28,9 +28,9 @@ describe('SearchPanelNavigation', () => {
       expect(wrapper.find('WithStyles(ForwardRef(Typography))').text()).toEqual('searchPageSeparator');
       expect(wrapper.find('Connect(WithPlugins(MiradorMenuButton))[disabled=false]').length).toEqual(2);
       wrapper.find('Connect(WithPlugins(MiradorMenuButton))[disabled=false]').first().props().onClick();
-      expect(selectContentSearchAnnotation).toHaveBeenCalledWith('window', ['1']);
+      expect(selectContentSearchAnnotation).toHaveBeenCalledWith(['1']);
       wrapper.find('Connect(WithPlugins(MiradorMenuButton))[disabled=false]').last().props().onClick();
-      expect(selectContentSearchAnnotation).toHaveBeenCalledWith('window', ['3']);
+      expect(selectContentSearchAnnotation).toHaveBeenCalledWith(['3']);
     });
     it('buttons disabled when no next/prev', () => {
       const wrapper = createWrapper({

--- a/__tests__/src/reducers/search.test.js
+++ b/__tests__/src/reducers/search.test.js
@@ -18,6 +18,7 @@ describe('search reducer', () => {
             },
           },
           query: 'search terms',
+          selectedContentSearchAnnotation: [],
         },
       },
     });
@@ -49,6 +50,7 @@ describe('search reducer', () => {
             },
           },
           query: 'search terms',
+          selectedContentSearchAnnotation: [],
         },
       },
     });
@@ -150,6 +152,32 @@ describe('search reducer', () => {
         xyz321: {
           isFetching: false,
           json: {},
+        },
+      },
+    });
+  });
+
+  it('handles SELECT_CONTENT_SEARCH_ANNOTATION', () => {
+    expect(searchesReducer(
+      {
+        foo: {
+          abc123: {
+            selectedContentSearchAnnotation: ['foo'],
+            whatever: true,
+          },
+        },
+      },
+      {
+        annotationId: ['bar'],
+        companionWindowId: 'abc123',
+        type: ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION,
+        windowId: 'foo',
+      },
+    )).toEqual({
+      foo: {
+        abc123: {
+          selectedContentSearchAnnotation: ['bar'],
+          whatever: true,
         },
       },
     });

--- a/__tests__/src/selectors/searches.test.js
+++ b/__tests__/src/selectors/searches.test.js
@@ -206,6 +206,31 @@ describe('getSelectedContentSearchAnnotationIds', () => {
       getSelectedContentSearchAnnotationIds(state, { windowId: 'baz' }),
     ).toEqual([]);
   });
+
+  it('returns the seleected content search annotation for the search', () => {
+    const state = {
+      searches: {
+        foo: {
+          bar: {
+            selectedContentSearchAnnotation: ['baz'],
+          },
+        },
+      },
+      windows: {
+        foo: {
+          selectedContentSearchAnnotation: ['unused'],
+        },
+      },
+    };
+
+    expect(
+      getSelectedContentSearchAnnotationIds(state, { companionWindowId: 'bar', windowId: 'foo' }),
+    ).toEqual(['baz']);
+
+    expect(
+      getSelectedContentSearchAnnotationIds(state, { windowId: 'baz' }),
+    ).toEqual([]);
+  });
 });
 
 

--- a/__tests__/src/selectors/searches.test.js
+++ b/__tests__/src/selectors/searches.test.js
@@ -207,7 +207,7 @@ describe('getSelectedContentSearchAnnotationIds', () => {
     ).toEqual([]);
   });
 
-  it('returns the seleected content search annotation for the search', () => {
+  it('returns the selected content search annotation for the search', () => {
     const state = {
       searches: {
         foo: {

--- a/src/components/SearchHit.js
+++ b/src/components/SearchHit.js
@@ -44,6 +44,7 @@ export class SearchHit extends Component {
       showDetails,
       selected,
       t,
+      windowSelected,
     } = this.props;
 
     if (focused && !selected) return null;
@@ -65,6 +66,7 @@ export class SearchHit extends Component {
               [classes.adjacent]: adjacent,
               [classes.selected]: selected,
               [classes.focused]: focused,
+              [classes.windowSelected]: windowSelected,
             },
           )}
           button={!selected}
@@ -133,6 +135,7 @@ SearchHit.propTypes = {
   showDetails: PropTypes.func,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
+  windowSelected: PropTypes.bool,
 };
 
 SearchHit.defaultProps = {
@@ -151,4 +154,5 @@ SearchHit.defaultProps = {
   selected: false,
   showDetails: () => {},
   t: k => k,
+  windowSelected: false,
 };

--- a/src/components/SearchHit.js
+++ b/src/components/SearchHit.js
@@ -22,10 +22,10 @@ export class SearchHit extends Component {
   /** */
   handleClick() {
     const {
-      annotationId, selectContentSearchAnnotation, windowId,
+      annotationId, selectContentSearchAnnotation,
     } = this.props;
 
-    selectContentSearchAnnotation(windowId, [annotationId]);
+    selectContentSearchAnnotation([annotationId]);
   }
 
   /** */

--- a/src/components/SearchPanelNavigation.js
+++ b/src/components/SearchPanelNavigation.js
@@ -11,14 +11,14 @@ import MiradorMenuButton from '../containers/MiradorMenuButton';
 export class SearchPanelNavigation extends Component {
   /** */
   nextSearchResult(currentHitIndex) {
-    const { searchHits, selectContentSearchAnnotation, windowId } = this.props;
-    selectContentSearchAnnotation(windowId, searchHits[currentHitIndex + 1].annotations);
+    const { searchHits, selectContentSearchAnnotation } = this.props;
+    selectContentSearchAnnotation(searchHits[currentHitIndex + 1].annotations);
   }
 
   /** */
   previousSearchResult(currentHitIndex) {
-    const { searchHits, selectContentSearchAnnotation, windowId } = this.props;
-    selectContentSearchAnnotation(windowId, searchHits[currentHitIndex - 1].annotations);
+    const { searchHits, selectContentSearchAnnotation } = this.props;
+    selectContentSearchAnnotation(searchHits[currentHitIndex - 1].annotations);
   }
 
   /** */
@@ -80,7 +80,7 @@ SearchPanelNavigation.propTypes = {
   selectContentSearchAnnotation: PropTypes.func.isRequired,
   selectedContentSearchAnnotation: PropTypes.arrayOf(PropTypes.string).isRequired,
   t: PropTypes.func,
-  windowId: PropTypes.string.isRequired,
+  windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
 };
 SearchPanelNavigation.defaultProps = {
   classes: {},

--- a/src/containers/SearchHit.js
+++ b/src/containers/SearchHit.js
@@ -30,6 +30,10 @@ const mapStateToProps = (state, {
   );
   const selectedCanvasIds = getSelectedCanvases(state, { windowId }).map(canvas => canvas.id);
 
+  const selectedAnnotation = getSelectedContentSearchAnnotationIds(state, {
+    companionWindowId, windowId,
+  });
+
   return {
     adjacent: selectedCanvasIds.includes(hitAnnotation.targetId),
     annotation: hitAnnotation,
@@ -39,7 +43,8 @@ const mapStateToProps = (state, {
       canvasId: hitAnnotation.targetId,
       windowId,
     }),
-    selected: getSelectedContentSearchAnnotationIds(state, { windowId })[0] === realAnnoId,
+    selected: selectedAnnotation[0] === realAnnoId,
+    windowSelected: getSelectedContentSearchAnnotationIds(state, { windowId })[0] === realAnnoId,
   };
 };
 
@@ -78,13 +83,13 @@ const styles = theme => ({
       '& $hitCounter': {
         backgroundColor: theme.palette.highlights.secondary,
       },
-      '&$selected': {
+      '&$windowSelected': {
         '& $hitCounter': {
           backgroundColor: theme.palette.highlights.primary,
         },
       },
     },
-    '&$selected': {
+    '&$windowSelected': {
       '& $hitCounter': {
         backgroundColor: theme.palette.highlights.primary,
       },
@@ -102,6 +107,7 @@ const styles = theme => ({
   subtitle: {
     marginBottom: theme.spacing(1.5),
   },
+  windowSelected: {},
 });
 
 const enhance = compose(

--- a/src/containers/SearchHit.js
+++ b/src/containers/SearchHit.js
@@ -43,9 +43,16 @@ const mapStateToProps = (state, {
   };
 };
 
-const mapDispatchToProps = {
-  selectContentSearchAnnotation: actions.selectContentSearchAnnotation,
-};
+/**
+ * mapDispatchToProps - to hook up connect
+ * @memberof SearchPanelNavigation
+ * @private
+ */
+const mapDispatchToProps = (dispatch, { companionWindowId, windowId }) => ({
+  selectContentSearchAnnotation: (...args) => dispatch(
+    actions.selectContentSearchAnnotation(windowId, companionWindowId, ...args),
+  ),
+});
 
 /** */
 const styles = theme => ({

--- a/src/containers/SearchPanelNavigation.js
+++ b/src/containers/SearchPanelNavigation.js
@@ -17,17 +17,21 @@ import {
  */
 const mapStateToProps = (state, { companionWindowId, windowId }) => ({
   searchHits: getSearchHitsForCompanionWindow(state, { companionWindowId, windowId }),
-  selectedContentSearchAnnotation: getSelectedContentSearchAnnotationIds(state, { windowId }),
+  selectedContentSearchAnnotation: getSelectedContentSearchAnnotationIds(state, {
+    companionWindowId, windowId,
+  }),
 });
 
 /**
  * mapDispatchToProps - to hook up connect
- * @memberof SearchPanelControls
+ * @memberof SearchPanelNavigation
  * @private
  */
-const mapDispatchToProps = {
-  selectContentSearchAnnotation: actions.selectContentSearchAnnotation,
-};
+const mapDispatchToProps = (dispatch, { companionWindowId, windowId }) => ({
+  selectContentSearchAnnotation: (...args) => dispatch(
+    actions.selectContentSearchAnnotation(windowId, companionWindowId, ...args),
+  ),
+});
 
 /** */
 const styles = theme => ({

--- a/src/containers/SearchResults.js
+++ b/src/containers/SearchResults.js
@@ -9,7 +9,6 @@ import {
   getNextSearchId,
   getSearchAnnotationsForCompanionWindow,
   getSearchHitsForCompanionWindow,
-  getSelectedContentSearchAnnotationIds,
   getSearchQuery,
   getSearchIsFetching,
 } from '../state/selectors';
@@ -26,12 +25,10 @@ const mapStateToProps = (state, { companionWindowId, windowId }) => ({
   searchAnnotations:
     getSearchAnnotationsForCompanionWindow(state, { companionWindowId, windowId }).resources,
   searchHits: getSearchHitsForCompanionWindow(state, { companionWindowId, windowId }),
-  selectedContentSearchAnnotation: getSelectedContentSearchAnnotationIds(state, { windowId }),
 });
 
 const mapDispatchToProps = {
   fetchSearch: actions.fetchSearch,
-  selectContentSearchAnnotation: actions.selectContentSearchAnnotation,
 };
 
 /** */

--- a/src/state/actions/search.js
+++ b/src/state/actions/search.js
@@ -99,7 +99,7 @@ export function fetchSearch(windowId, companionWindowId, searchId, query) {
  * @param  {String} annotationId
  * @memberof ActionCreators
  */
-export function selectContentSearchAnnotation(windowId, annotationIds) {
+export function selectContentSearchAnnotation(windowId, companionWindowId, annotationIds) {
   return (dispatch, getState) => {
     const state = getState();
     const annotations = getSearchAnnotationsForWindow(state, { windowId });
@@ -111,6 +111,7 @@ export function selectContentSearchAnnotation(windowId, annotationIds) {
     dispatch({
       annotationId: annotationIds,
       canvasIndex: canvas && canvas.index,
+      companionWindowId,
       type: ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION,
       windowId,
     });

--- a/src/state/reducers/search.js
+++ b/src/state/reducers/search.js
@@ -7,16 +7,17 @@ import ActionTypes from '../actions/action-types';
  * searchReducer
  */
 export const searchesReducer = (state = {}, action) => {
+  const searchStruct = (state[action.windowId] || {})[action.companionWindowId] || {};
   switch (action.type) {
     case ActionTypes.REQUEST_SEARCH:
-      if (((state[action.windowId] || {})[action.companionWindowId] || {}) !== action.query) {
+      if (searchStruct.query !== action.query) {
         // new query
         return {
           ...state,
           [action.windowId]: {
             ...state[action.windowId],
             [action.companionWindowId]: {
-              ...(state[action.windowId] || {})[action.companionWindowId],
+              ...searchStruct,
               data: {
                 [action.searchId]: {
                   isFetching: true,
@@ -35,9 +36,9 @@ export const searchesReducer = (state = {}, action) => {
         [action.windowId]: {
           ...state[action.windowId],
           [action.companionWindowId]: {
-            ...(state[action.windowId] || {})[action.companionWindowId],
+            ...searchStruct,
             data: {
-              ...((state[action.windowId] || {})[action.companionWindowId] || {}).data,
+              ...searchStruct.data,
               [action.searchId]: {
                 isFetching: true,
               },
@@ -51,9 +52,9 @@ export const searchesReducer = (state = {}, action) => {
         [action.windowId]: {
           ...state[action.windowId],
           [action.companionWindowId]: {
-            ...(state[action.windowId] || {})[action.companionWindowId],
+            ...searchStruct,
             data: {
-              ...((state[action.windowId] || {})[action.companionWindowId] || {}).data,
+              ...searchStruct.data,
               [action.searchId]: {
                 isFetching: false,
                 json: action.searchJson,
@@ -68,9 +69,9 @@ export const searchesReducer = (state = {}, action) => {
         [action.windowId]: {
           ...state[action.windowId],
           [action.companionWindowId]: {
-            ...(state[action.windowId] || {})[action.companionWindowId],
+            ...searchStruct,
             data: {
-              ...((state[action.windowId] || {})[action.companionWindowId] || {}).data,
+              ...searchStruct.data,
               [action.searchId]: {
                 error: action.error,
                 isFetching: false,
@@ -95,7 +96,7 @@ export const searchesReducer = (state = {}, action) => {
         [action.windowId]: {
           ...state[action.windowId],
           [action.companionWindowId]: {
-            ...(state[action.windowId] || {})[action.companionWindowId],
+            ...searchStruct,
             selectedContentSearchAnnotation: action.annotationId,
           },
         },

--- a/src/state/reducers/search.js
+++ b/src/state/reducers/search.js
@@ -9,6 +9,27 @@ import ActionTypes from '../actions/action-types';
 export const searchesReducer = (state = {}, action) => {
   switch (action.type) {
     case ActionTypes.REQUEST_SEARCH:
+      if (((state[action.windowId] || {})[action.companionWindowId] || {}) !== action.query) {
+        // new query
+        return {
+          ...state,
+          [action.windowId]: {
+            ...state[action.windowId],
+            [action.companionWindowId]: {
+              ...(state[action.windowId] || {})[action.companionWindowId],
+              data: {
+                [action.searchId]: {
+                  isFetching: true,
+                },
+              },
+              query: action.query,
+              selectedContentSearchAnnotation: [],
+            },
+          },
+        };
+      }
+
+      // paginating through a query
       return {
         ...state,
         [action.windowId]: {
@@ -16,18 +37,11 @@ export const searchesReducer = (state = {}, action) => {
           [action.companionWindowId]: {
             ...(state[action.windowId] || {})[action.companionWindowId],
             data: {
-              ...(() => {
-                const cw = ((state[action.windowId] || {})[action.companionWindowId] || {});
-
-                if (cw.query !== action.query) return undefined;
-
-                return cw.data;
-              })(),
+              ...((state[action.windowId] || {})[action.companionWindowId] || {}).data,
               [action.searchId]: {
                 isFetching: true,
               },
             },
-            query: action.query,
           },
         },
       };
@@ -74,6 +88,17 @@ export const searchesReducer = (state = {}, action) => {
           }
           return object;
         }, {}),
+      };
+    case ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION:
+      return {
+        ...state,
+        [action.windowId]: {
+          ...state[action.windowId],
+          [action.companionWindowId]: {
+            ...(state[action.windowId] || {})[action.companionWindowId],
+            selectedContentSearchAnnotation: action.annotationId,
+          },
+        },
       };
     case ActionTypes.IMPORT_MIRADOR_STATE:
       return {};

--- a/src/state/selectors/searches.js
+++ b/src/state/selectors/searches.js
@@ -122,10 +122,12 @@ export const getSearchAnnotationsForWindow = createSelector(
 export const getSelectedContentSearchAnnotationIds = createSelector(
   [
     getWindow,
+    getSearchForCompanionWindow,
   ],
-  window => (window && window.selectedContentSearchAnnotation) || [],
+  (window, search) => (search && search.selectedContentSearchAnnotation)
+    || (window && window.selectedContentSearchAnnotation)
+    || [],
 );
-
 
 export const getSelectedContentSearchAnnotations = createSelector(
   [


### PR DESCRIPTION
Fixes #2786 

![2019-06-25 07-11-51 2019-06-25 07_13_02](https://user-images.githubusercontent.com/111218/60105711-b4cf3b00-9718-11e9-8860-6cf79cb4f3d1.gif)

In talking with @jvine, we agreed there should only be one selected search annotation per window (highlighted in yellow in the companion window and on the canvas). To support consistent pagination with multiple searches open, we also need to track the annotation at the search level.