### PR TITLE
Refine the search experience

### DIFF
--- a/__tests__/src/actions/canvas.test.js
+++ b/__tests__/src/actions/canvas.test.js
@@ -9,11 +9,13 @@ const mockStore = configureMockStore(middlewares);
 
 jest.mock('../../../src/state/selectors', () => ({
   getCanvas: (state, { canvasIndex }) => ({ id: `canvasId-${canvasIndex}` }),
-  getSearchAnnotationsForWindow: () => ([{
+  getSearchAnnotationsForCompanionWindow: () => ({
     resources: [
       { id: 'annoId', targetId: 'canvasId-5' },
     ],
-  }]),
+  }),
+  getSearchForWindow: () => ({ cwid: { } }),
+  getSelectedCanvases: () => [{ id: 'canvasId-5' }],
 }));
 
 describe('canvas actions', () => {
@@ -27,22 +29,14 @@ describe('canvas actions', () => {
       const id = 'abc123';
       const expectedAction = {
         canvasIndex: 100,
-        type: ActionTypes.SET_CANVAS,
-        windowId: id,
-      };
-      store.dispatch(actions.setCanvas(id, 100));
-      expect(store.getActions()[0]).toEqual(expectedAction);
-    });
-
-    it('updates the currently selected search to something on that canvas', () => {
-      const id = 'abc123';
-      const expectedAction = {
-        canvasIndex: 5,
+        searches: {
+          cwid: ['annoId'],
+        },
         selectedContentSearchAnnotation: ['annoId'],
         type: ActionTypes.SET_CANVAS,
         windowId: id,
       };
-      store.dispatch(actions.setCanvas(id, 5));
+      store.dispatch(actions.setCanvas(id, 100));
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
   });

--- a/__tests__/src/actions/search.test.js
+++ b/__tests__/src/actions/search.test.js
@@ -28,6 +28,11 @@ describe('search actions', () => {
     });
   });
   describe('receiveSearch', () => {
+    let store = null;
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
     it('recieves an search', () => {
       const windowId = 'foo';
       const companionWindowId = 'abc123';
@@ -43,9 +48,50 @@ describe('search actions', () => {
         type: ActionTypes.RECEIVE_SEARCH,
         windowId,
       };
-      expect(
+      store.dispatch(
         actions.receiveSearch(windowId, companionWindowId, searchId, json),
-      ).toEqual(expectedAction);
+      );
+      expect(store.getActions()).toEqual([expectedAction]);
+    });
+
+    it('provides the first annotation id and its canvas', () => {
+      store = mockStore({
+        manifests: {
+          bar: {
+            json: manifestFixture015,
+          },
+        },
+        windows: {
+          foo: {
+            manifestId: 'bar',
+          },
+        },
+      });
+
+      const windowId = 'foo';
+      const companionWindowId = 'abc123';
+      const searchId = 'search?page=1';
+      const json = {
+        resources: [
+          {
+            '@id': 'abc123',
+            on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c2.json#0,2,4,5',
+          },
+        ],
+      };
+      const expectedAction = {
+        annotationId: 'abc123',
+        canvasIndex: 1,
+        companionWindowId,
+        searchId,
+        searchJson: json,
+        type: ActionTypes.RECEIVE_SEARCH,
+        windowId,
+      };
+      store.dispatch(
+        actions.receiveSearch(windowId, companionWindowId, searchId, json),
+      );
+      expect(store.getActions()).toEqual([expectedAction]);
     });
   });
 

--- a/__tests__/src/components/SearchResults.test.js
+++ b/__tests__/src/components/SearchResults.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Button from '@material-ui/core/Button';
 import { SearchResults } from '../../../src/components/SearchResults';
+import { ScrollTo } from '../../../src/components/ScrollTo';
 
 
 /**
@@ -44,6 +45,7 @@ describe('SearchResults', () => {
   it('can return to the full list view', () => {
     const wrapper = createWrapper({});
     wrapper.setState({ focused: true });
+    expect(wrapper.find(ScrollTo).prop('scrollTo')).toEqual(true);
     expect(wrapper.find(Button).text()).toEqual('backToResults');
     wrapper.find(Button).simulate('click');
     expect(wrapper.state().focused).toEqual(false);

--- a/__tests__/src/reducers/search.test.js
+++ b/__tests__/src/reducers/search.test.js
@@ -157,6 +157,33 @@ describe('search reducer', () => {
     });
   });
 
+  it('handles SET_CANVAS', () => {
+    expect(searchesReducer(
+      {
+        foo: {
+          abc123: {
+            selectedContentSearchAnnotation: ['foo'],
+            whatever: true,
+          },
+        },
+      },
+      {
+        searches: {
+          abc123: ['bar'],
+        },
+        type: ActionTypes.SET_CANVAS,
+        windowId: 'foo',
+      },
+    )).toEqual({
+      foo: {
+        abc123: {
+          selectedContentSearchAnnotation: ['bar'],
+          whatever: true,
+        },
+      },
+    });
+  });
+
   it('handles SELECT_CONTENT_SEARCH_ANNOTATION', () => {
     expect(searchesReducer(
       {

--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -450,4 +450,29 @@ describe('windows reducer', () => {
       type: ActionTypes.IMPORT_MIRADOR_STATE,
     })).toEqual({ new: 'stuff' });
   });
+
+  describe('RECEIVE_SEARCH', () => {
+    it('set the canvas index and annotation id if provided', () => {
+      const beforeState = { abc123: {} };
+      const action = {
+        annotationId: 'aaa123', canvasIndex: 5, type: ActionTypes.RECEIVE_SEARCH, windowId: 'abc123',
+      };
+      const expectedState = {
+        abc123: { canvasIndex: 5, selectedContentSearchAnnotation: ['aaa123'] },
+      };
+
+      expect(windowsReducer(beforeState, action)).toEqual(expectedState);
+    });
+    it('passes through existing data otherwise', () => {
+      const beforeState = { abc123: { canvasIndex: 5, selectedContentSearchAnnotation: ['aaa123'] } };
+      const action = {
+        type: ActionTypes.RECEIVE_SEARCH, windowId: 'abc123',
+      };
+      const expectedState = {
+        abc123: { canvasIndex: 5, selectedContentSearchAnnotation: ['aaa123'] },
+      };
+
+      expect(windowsReducer(beforeState, action)).toEqual(expectedState);
+    });
+  });
 });

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,3 +1,4 @@
+
 // Setup Jest to mock fetch
 
 import { JSDOM } from 'jsdom'; // eslint-disable-line import/no-extraneous-dependencies
@@ -7,6 +8,8 @@ import Adapter from 'enzyme-adapter-react-16'; // eslint-disable-line import/no-
 
 const jsdom = new JSDOM('<!doctype html><html><body><div id="main"></div></body></html>');
 const { window } = jsdom;
+
+jest.setTimeout(10000);
 
 window.HTMLCanvasElement.prototype.getContext = () => {};
 jest.setMock('node-fetch', fetch);

--- a/src/components/SearchHit.js
+++ b/src/components/SearchHit.js
@@ -57,7 +57,7 @@ export class SearchHit extends Component {
       <ScrollTo
         containerRef={containerRef}
         offsetTop={96} // offset for the height of the form above
-        scrollTo={selected}
+        scrollTo={selected && !focused}
       >
         <ListItem
           className={clsx(

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -5,6 +5,7 @@ import List from '@material-ui/core/List';
 import Typography from '@material-ui/core/Typography';
 import BackIcon from '@material-ui/icons/ArrowBackSharp';
 import SearchHit from '../containers/SearchHit';
+import { ScrollTo } from './ScrollTo';
 
 /** */
 export class SearchResults extends Component {
@@ -53,10 +54,12 @@ export class SearchResults extends Component {
     return (
       <>
         { focused && (
-          <Button onClick={this.toggleFocus} className={classes.navigation} size="small">
-            <BackIcon />
-            {t('backToResults')}
-          </Button>
+          <ScrollTo containerRef={containerRef} offsetTop={96} scrollTo>
+            <Button onClick={this.toggleFocus} className={classes.navigation} size="small">
+              <BackIcon />
+              {t('backToResults')}
+            </Button>
+          </ScrollTo>
         )}
         {noResultsState && (
           <Typography className={classes.noResults}>

--- a/src/state/reducers/search.js
+++ b/src/state/reducers/search.js
@@ -60,6 +60,10 @@ export const searchesReducer = (state = {}, action) => {
                 json: action.searchJson,
               },
             },
+            selectedContentSearchAnnotation: searchStruct.selectedContentSearchAnnotation
+              && searchStruct.selectedContentSearchAnnotation.length > 0
+              ? searchStruct.selectedContentSearchAnnotation
+              : (action.annotationId && [action.annotationId]),
           },
         },
       };

--- a/src/state/reducers/search.js
+++ b/src/state/reducers/search.js
@@ -101,6 +101,21 @@ export const searchesReducer = (state = {}, action) => {
           },
         },
       };
+    case ActionTypes.SET_CANVAS:
+      if (Object.keys(action.searches).length === 0) return state;
+
+      return {
+        ...state,
+        [action.windowId]: Object.keys(state[action.windowId]).reduce((object, key) => {
+          if (Object.keys(action.searches).includes(key)) {
+            object[key] = { // eslint-disable-line no-param-reassign
+              ...state[action.windowId][key],
+              selectedContentSearchAnnotation: action.searches[key],
+            };
+          }
+          return object;
+        }, {}),
+      };
     case ActionTypes.IMPORT_MIRADOR_STATE:
       return {};
     case ActionTypes.REMOVE_WINDOW:

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -191,6 +191,16 @@ export const windowsReducer = (state = {}, action) => {
           suggestedSearches: undefined,
         },
       };
+    case ActionTypes.RECEIVE_SEARCH:
+      return {
+        ...state,
+        [action.windowId]: {
+          ...state[action.windowId],
+          canvasIndex: action.canvasIndex || state[action.windowId].canvasIndex,
+          selectedContentSearchAnnotation: (action.annotationId && [action.annotationId])
+            || state[action.windowId].selectedContentSearchAnnotation,
+        },
+      };
     default:
       return state;
   }


### PR DESCRIPTION
- [x] when performing a search, jump to the first canvas with a hit
- [x] synchronize the search results with the current canvas, so the currently visible hits on the canvas are visible in the panel.
- [x] fixes #2813
- [x] tests (ugh.)