### PR TITLE
Add support for Prezi v3 for image resources

### DIFF
--- a/__tests__/integration/mirador/v3.html
+++ b/__tests__/integration/mirador/v3.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador - Prezi v3</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       windows: [{
+         manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json',
+       }],
+       resourceHeaders: {
+         Accept: 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"',
+       },
+       window: {
+         hideSearchPanel: false,
+       }
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/src/lib/ManifestoCanvas.test.js
+++ b/__tests__/src/lib/ManifestoCanvas.test.js
@@ -1,6 +1,7 @@
 import manifesto from 'manifesto.js';
 import ManifestoCanvas from '../../../src/lib/ManifestoCanvas';
 import fixture from '../../fixtures/version-2/019.json';
+import v3fixture from '../../fixtures/version-3/001.json';
 import imagev1Fixture from '../../fixtures/version-2/Osbornfa1.json';
 import emptyCanvasFixture from '../../fixtures/version-2/emptyCanvas.json';
 import serviceFixture from '../../fixtures/version-2/canvasService.json';
@@ -8,9 +9,13 @@ import otherContentFixture from '../../fixtures/version-2/299843.json';
 
 describe('ManifestoCanvas', () => {
   let instance;
+  let v3Instance;
   beforeAll(() => {
     instance = new ManifestoCanvas(
       manifesto.create(fixture).getSequences()[0].getCanvases()[0],
+    );
+    v3Instance = new ManifestoCanvas(
+      manifesto.create(v3fixture).getSequences()[0].getCanvases()[0],
     );
   });
   describe('annotationListUris', () => {
@@ -35,6 +40,11 @@ describe('ManifestoCanvas', () => {
     it('calculates a canonical imageUri', () => {
       expect(instance.canonicalImageUri()).toEqual(
         'https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/full/0/default.jpg',
+      );
+    });
+    it('calculates a canonical imageUri for prezi v3', () => {
+      expect(v3Instance.canonicalImageUri()).toEqual(
+        'https://iiif.bodleian.ox.ac.uk/iiif/image/9cca8fdd-4a61-4429-8ac1-f648764b4d6d/full/full/0/default.jpg',
       );
     });
   });

--- a/__tests__/src/lib/ManifestoCanvas.test.js
+++ b/__tests__/src/lib/ManifestoCanvas.test.js
@@ -32,9 +32,9 @@ describe('ManifestoCanvas', () => {
     });
   });
   describe('canonicalImageUri', () => {
-    it('calls manifestos method to return a canonical imageUri', () => {
-      expect(instance.canonicalImageUri).toEqual(
-        'https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/5426,/0/default.jpg',
+    it('calculates a canonical imageUri', () => {
+      expect(instance.canonicalImageUri()).toEqual(
+        'https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/full/full/0/default.jpg',
       );
     });
   });

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -43,8 +43,15 @@ export default class ManifestoCanvas {
       .map(otherContent => otherContent['@id']);
   }
 
-  /** */
+  /**
+   * Will negotiate a v2 or v3 type of resource
+   */
   get imageResource() {
+    return (this.presentation2ImageResource || this.presentation3ImageResource);
+  }
+
+  /** */
+  get presentation2ImageResource() {
     if (!(
       this.canvas.getImages()[0]
       && this.canvas.getImages()[0].getResource()
@@ -55,6 +62,21 @@ export default class ManifestoCanvas {
     }
 
     return this.canvas.getImages()[0].getResource();
+  }
+
+  /** */
+  get presentation3ImageResource() {
+    if (!(
+      this.canvas.getContent()[0]
+      && this.canvas.getContent()[0]
+      && this.canvas.getContent()[0].getBody()[0]
+      && this.canvas.getContent()[0].getBody()[0].getServices()[0]
+      && this.canvas.getContent()[0].getBody()[0].getServices()[0].id
+    )) {
+      return undefined;
+    }
+
+    return this.canvas.getContent()[0].getBody()[0];
   }
 
   /**

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -1,4 +1,5 @@
 import flatten from 'lodash/flatten';
+import { Utils } from 'manifesto.js';
 /**
  * ManifestoCanvas - adds additional, testable logic around Manifesto's Canvas
  * https://iiif-commons.github.io/manifesto/classes/_canvas_.manifesto.canvas.html
@@ -12,9 +13,19 @@ export default class ManifestoCanvas {
   }
 
   /**
+   * Implements Manifesto's canonicalImageUri algorithm to support
+   * IIIF Presentation v3
    */
-  get canonicalImageUri() {
-    return this.canvas.getCanonicalImageUri();
+  canonicalImageUri(w, format = 'jpg') {
+    const service = this.imageResource.getServices()[0];
+    if (!(service)) return undefined;
+    const region = 'full';
+    let size = w;
+    const imageWidth = this.imageResource.getWidth();
+    if ((!w) || w === imageWidth) size = 'full';
+    const quality = Utils.getImageQuality(service.getProfile());
+    const id = service.id.replace(/\/+$/, '');
+    return [id, region, size, 0, `${quality}.${format}`].join('/');
   }
 
   /**
@@ -140,7 +151,7 @@ export default class ManifestoCanvas {
     // note that, although the IIIF server may support sizeByConfinedWh (e.g. !w,h)
     // this is a IIIF level 2 feature, so we're instead providing w, or h,-style requests
     // which are only level 1.
-    return this.canonicalImageUri.replace(/\/full\/.*\/0\//, `/full/${width || ''},${height || ''}/0/`);
+    return this.canonicalImageUri().replace(/\/full\/.*\/0\//, `/full/${width || ''},${height || ''}/0/`);
   }
 
   /** @private */


### PR DESCRIPTION
This PR enables support for v3 of the presentation API for image based manifests.

How do you request a v3 manifest?

Setup this in your settings:

```
  resourceHeaders: {
    Accept: 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"',
  }, // Headers to send with IIIF Presentation API resource requests
```

And use this url: https://iiif.bodleian.ox.ac.uk/iiif/manifest/9cca8fdd-4a61-4429-8ac1-f648764b4d6d.json