### PR TITLE
Add some error reporting for search and info request failures

### DIFF
--- a/__tests__/src/reducers/errors.test.js
+++ b/__tests__/src/reducers/errors.test.js
@@ -21,6 +21,42 @@ describe('ADD_ERROR', () => {
     expect(ret[error.id]).toEqual(error);
   });
 
+  it('handles RECEIVE_INFO_RESPONSE_FAILURE', () => {
+    const error = {
+      error: errorMessage,
+      infoId: 'abc',
+    };
+    const ret = errorsReducer(undefined, {
+      type: ActionTypes.RECEIVE_INFO_RESPONSE_FAILURE,
+      ...error,
+
+    });
+    expect(ret.items).toEqual([error.infoId]);
+    expect(ret).toHaveProperty(error.infoId);
+    expect(ret[error.infoId]).toEqual({
+      id: 'abc',
+      message: errorMessage,
+    });
+  });
+
+  it('handles RECEIVE_SEARCH_FAILURE', () => {
+    const error = {
+      error: errorMessage,
+      searchId: 'def',
+    };
+    const ret = errorsReducer(undefined, {
+      type: ActionTypes.RECEIVE_SEARCH_FAILURE,
+      ...error,
+
+    });
+    expect(ret.items).toEqual([error.searchId]);
+    expect(ret).toHaveProperty(error.searchId);
+    expect(ret[error.searchId]).toEqual({
+      id: 'def',
+      message: errorMessage,
+    });
+  });
+
   it('should handle REMOVE_ERROR', () => {
     const stateBefore = {
       errorId: {

--- a/src/components/ErrorDialog.js
+++ b/src/components/ErrorDialog.js
@@ -33,7 +33,7 @@ export class ErrorDialog extends Component {
         </DialogTitle>
         <DialogContent disableTypography>
           <DialogContentText variant="body2" noWrap color="inherit">
-            {error.message}
+            {`${error.message}`}
           </DialogContentText>
           <DialogActions>
             <Button onClick={() => removeError(error.id)} variant="contained">

--- a/src/containers/ErrorDialog.js
+++ b/src/containers/ErrorDialog.js
@@ -17,7 +17,7 @@ import * as actions from '../state/actions';
  */
 const mapStateToProps = state => ({
   /* extract 'items' value and get first key-value-pair (an error) */
-  errors: first(values(omit(state.errors, 'items'))),
+  error: first(values(omit(state.errors, 'items'))),
 });
 
 /**

--- a/src/state/reducers/errors.js
+++ b/src/state/reducers/errors.js
@@ -11,6 +11,24 @@ export const errorsReducer = (state = defaultState, action) => {
   switch (action.type) {
     case ActionTypes.ADD_ERROR:
       return { ...state, [action.id]: { id: action.id, message: action.message }, items: [...state.items, action.id] }; // eslint-disable-line max-len
+    case ActionTypes.RECEIVE_INFO_RESPONSE_FAILURE:
+      return {
+        ...state,
+        [action.infoId]: {
+          id: action.infoId,
+          message: action.error,
+        },
+        items: [...state.items, action.infoId],
+      };
+    case ActionTypes.RECEIVE_SEARCH_FAILURE:
+      return {
+        ...state,
+        [action.searchId]: {
+          id: action.searchId,
+          message: action.error,
+        },
+        items: [...state.items, action.searchId],
+      };
     case ActionTypes.REMOVE_ERROR:
       ret = Object.keys(state).reduce((object, key) => {
         if (key !== action.id) {


### PR DESCRIPTION
search and info request failures aren't reported in the UI at all and can lead to some bizarre, hard-to-debug behaviors (particularly in browsers without react/redux dev tools available). The `ErrorDialog` might be heavy-handed, but it's the tool we have, so 🤷‍♂ 

<img width="854" alt="Screen Shot 2019-06-27 at 15 27 27" src="https://user-images.githubusercontent.com/111218/60305076-4b098980-98f0-11e9-851c-e6a31bdd799e.png">
