### PR TITLE
add a right border to left-anchored companion windows

### DIFF
--- a/src/containers/CompanionWindow.js
+++ b/src/containers/CompanionWindow.js
@@ -50,7 +50,7 @@ const styles = theme => ({
     borderTop: `0.5px solid ${theme.palette.divider}`,
   },
   'companionWindow-left': {
-
+    borderRight: `0.5px solid ${theme.palette.divider}`,
   },
   'companionWindow-right': {
     borderLeft: `0.5px solid ${theme.palette.divider}`,


### PR DESCRIPTION
No border was specified in #2214, but it looks funny without a border when you're in gallery view.


Before:
<img width="418" alt="Screen Shot 2019-07-01 at 11 29 50" src="https://user-images.githubusercontent.com/111218/60458484-90c99900-9bf3-11e9-9930-00115079c33f.png">

After:
<img width="420" alt="Screen Shot 2019-07-01 at 11 30 40" src="https://user-images.githubusercontent.com/111218/60458526-afc82b00-9bf3-11e9-97a9-a0f5679d8ac5.png">
