### PR TITLE
Replace canvasIndex window state with canvasId

### DIFF
--- a/__tests__/integration/mirador/index.html
+++ b/__tests__/integration/mirador/index.html
@@ -15,7 +15,7 @@
        id: 'mirador',
        windows: [{
          manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
-         canvasIndex: 2,
+         canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
          thumbnailNavigationPosition: 'far-bottom',
        },
        {

--- a/__tests__/integration/mirador/thumbnail-navigation.test.js
+++ b/__tests__/integration/mirador/thumbnail-navigation.test.js
@@ -10,14 +10,14 @@ describe('Thumbnail navigation', () => {
     let windows = await page.evaluate(() => (
       miradorInstance.store.getState().windows
     ));
-    expect(Object.values(windows)[0].canvasIndex).toBe(2); // test harness in index.html starts at 2
+    expect(Object.values(windows)[0].canvasId).toBe('https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892'); // test harness in index.html starts at 2
     await page.waitFor(1000);
     await expect(page).toClick('.mirador-thumbnail-nav-canvas-1 img');
     await expect(page).toMatchElement('.mirador-thumbnail-nav-canvas-1.mirador-current-canvas-grouping', { timeout: 1500 });
     windows = await page.evaluate(() => (
       miradorInstance.store.getState().windows
     ));
-    expect(Object.values(windows)[0].canvasIndex).toBe(1);
+    expect(Object.values(windows)[0].canvasId).toBe('https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-18737483'); // canvas @ index 1
   });
   it('displays on right side', async () => {
     await expect(page).toMatchElement('.mirador-thumb-navigation');

--- a/__tests__/src/actions/canvas.test.js
+++ b/__tests__/src/actions/canvas.test.js
@@ -8,7 +8,8 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 jest.mock('../../../src/state/selectors', () => ({
-  getCanvas: (state, { canvasIndex }) => ({ id: `canvasId-${canvasIndex}` }),
+  getCanvas: (state, { canvasId, canvasIndex }) => ({ id: canvasId || `canvasIndex-${canvasIndex}` }),
+  getCanvasGrouping: (state, { canvasId }) => [{ id: canvasId }],
   getSearchAnnotationsForCompanionWindow: () => ({
     resources: [
       { id: 'annoId', targetId: 'canvasId-5' },
@@ -37,6 +38,24 @@ describe('canvas actions', () => {
         windowId: id,
       };
       store.dispatch(actions.setCanvas(id, 100));
+      expect(store.getActions()[0]).toEqual(expectedAction);
+    });
+  });
+  describe('setCanvasByIndex', () => {
+    let store = null;
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    it('sets to a defined canvas', () => {
+      const id = 'abc123';
+      const expectedAction = {
+        canvasId: 'canvasIndex-1',
+        searches: {},
+        type: ActionTypes.SET_CANVAS,
+        windowId: id,
+      };
+      store.dispatch(actions.setCanvasByIndex(id, 1));
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
   });

--- a/__tests__/src/actions/canvas.test.js
+++ b/__tests__/src/actions/canvas.test.js
@@ -12,11 +12,11 @@ jest.mock('../../../src/state/selectors', () => ({
   getCanvasGrouping: (state, { canvasId }) => [{ id: canvasId }],
   getSearchAnnotationsForCompanionWindow: () => ({
     resources: [
-      { id: 'annoId', targetId: 'canvasId-5' },
+      { id: 'annoId', targetId: 'a' },
     ],
   }),
   getSearchForWindow: () => ({ cwid: { } }),
-  getSelectedCanvases: () => [{ id: 'canvasId-5' }],
+  getSelectedCanvases: () => [{ id: 'a' }],
 }));
 
 describe('canvas actions', () => {
@@ -29,7 +29,7 @@ describe('canvas actions', () => {
     it('sets to a defined canvas', () => {
       const id = 'abc123';
       const expectedAction = {
-        canvasIndex: 100,
+        canvasId: 'a',
         searches: {
           cwid: ['annoId'],
         },
@@ -37,7 +37,7 @@ describe('canvas actions', () => {
         type: ActionTypes.SET_CANVAS,
         windowId: id,
       };
-      store.dispatch(actions.setCanvas(id, 100));
+      store.dispatch(actions.setCanvas(id, 'a'));
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
   });

--- a/__tests__/src/actions/search.test.js
+++ b/__tests__/src/actions/search.test.js
@@ -81,7 +81,7 @@ describe('search actions', () => {
       };
       const expectedAction = {
         annotationId: 'abc123',
-        canvasIndex: 1,
+        canvasId: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c2.json',
         companionWindowId,
         searchId,
         searchJson: json,
@@ -225,7 +225,7 @@ describe('search actions', () => {
       const annotationId = ['abc123'];
       const expectedAction = {
         annotationId,
-        canvasIndex: 1,
+        canvasId: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c2.json',
         companionWindowId,
         type: ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION,
         windowId,

--- a/__tests__/src/components/GalleryView.test.js
+++ b/__tests__/src/components/GalleryView.test.js
@@ -31,6 +31,5 @@ describe('GalleryView', () => {
   });
   it('renders gallery items for all canvases', () => {
     expect(wrapper.find(GalleryViewThumbnail).length).toBe(3);
-    expect(wrapper.find(GalleryViewThumbnail).at(0).prop('selected')).toBe(true);
   });
 });

--- a/__tests__/src/components/GalleryViewThumbnail.test.js
+++ b/__tests__/src/components/GalleryViewThumbnail.test.js
@@ -42,7 +42,7 @@ describe('GalleryView', () => {
     const setCanvas = jest.fn();
     wrapper = createWrapper({ setCanvas });
     wrapper.find('div[role="button"]').first().simulate('click');
-    expect(setCanvas).toHaveBeenCalledWith(0);
+    expect(setCanvas).toHaveBeenCalledWith('http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json');
     expect(wrapper.find(Typography).length).toBe(1);
   });
 

--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -47,8 +47,8 @@ describe('ThumbnailCanvasGrouping', () => {
   });
   it('when clicked, updates the current canvas', () => {
     wrapper = createWrapper({ data, index: 0, setCanvas });
-    wrapper.find('.mirador-thumbnail-nav-canvas-0').simulate('click', { currentTarget: { dataset: { canvasIndex: '0' } } });
-    expect(setCanvas).toHaveBeenCalledWith(0);
+    wrapper.find('.mirador-thumbnail-nav-canvas-0').simulate('click', { currentTarget: { dataset: { canvasId: 'info:0' } } });
+    expect(setCanvas).toHaveBeenCalledWith('info:0');
   });
   describe('attributes based off far-bottom position', () => {
     it('in button div', () => {

--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -11,7 +11,7 @@ function createWrapper(props) {
   return shallow(
     <ThumbnailCanvasGrouping
       index={1}
-      canvasIndex={1}
+      currentCanvasId="https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1"
       classes={{}}
       style={{
         height: 90,

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -28,10 +28,10 @@ function createWrapper(props, fixture = manifestJson) {
 describe('ThumbnailNavigation', () => {
   let wrapper;
   let rightWrapper;
-  let setCanvas;
+  let setCanvasByIndex;
   beforeEach(() => {
-    setCanvas = jest.fn();
-    wrapper = createWrapper({ setCanvas });
+    setCanvasByIndex = jest.fn();
+    wrapper = createWrapper({ setCanvasByIndex });
   });
   it('renders the component', () => {
     expect(wrapper.find('.mirador-thumb-navigation').length).toBe(1);
@@ -65,7 +65,7 @@ describe('ThumbnailNavigation', () => {
     beforeEach(() => {
       rightWrapper = createWrapper({
         position: 'far-right',
-        setCanvas,
+        setCanvasByIndex,
       });
     });
     it('style', () => {
@@ -101,26 +101,26 @@ describe('ThumbnailNavigation', () => {
     });
   });
   describe('keyboard navigation', () => {
-    const rightSetCanvas = jest.fn();
+    const rightSetCanvasByIndex = jest.fn();
     beforeEach(() => {
       rightWrapper = createWrapper({
         canvasIndex: 1,
         position: 'far-right',
-        setCanvas: rightSetCanvas,
+        setCanvasByIndex: rightSetCanvasByIndex,
       });
     });
     describe('handleKeyUp', () => {
       it('next', () => {
         wrapper.instance().handleKeyUp({ key: 'ArrowRight' });
-        expect(setCanvas).toHaveBeenCalledWith(2);
+        expect(setCanvasByIndex).toHaveBeenCalledWith(2);
         rightWrapper.instance().handleKeyUp({ key: 'ArrowDown' });
-        expect(rightSetCanvas).toHaveBeenCalledWith(2);
+        expect(rightSetCanvasByIndex).toHaveBeenCalledWith(2);
       });
       it('previous', () => {
         wrapper.instance().handleKeyUp({ key: 'ArrowLeft' });
-        expect(setCanvas).toHaveBeenCalledWith(0);
+        expect(setCanvasByIndex).toHaveBeenCalledWith(0);
         rightWrapper.instance().handleKeyUp({ key: 'ArrowUp' });
-        expect(rightSetCanvas).toHaveBeenCalledWith(0);
+        expect(rightSetCanvasByIndex).toHaveBeenCalledWith(0);
       });
     });
   });

--- a/__tests__/src/components/ViewerNavigation.test.js
+++ b/__tests__/src/components/ViewerNavigation.test.js
@@ -7,7 +7,7 @@ function createWrapper(props) {
   return shallow(
     <ViewerNavigation
       canvases={[1, 2]}
-      setCanvas={() => {}}
+      setCanvasByIndex={() => {}}
       t={k => (k)}
       {...props}
     />,
@@ -16,12 +16,12 @@ function createWrapper(props) {
 
 describe('ViewerNavigation', () => {
   let wrapper;
-  let setCanvas;
+  let setCanvasByIndex;
   beforeEach(() => {
-    setCanvas = jest.fn();
+    setCanvasByIndex = jest.fn();
     wrapper = createWrapper({
       canvasIndex: 0,
-      setCanvas,
+      setCanvasByIndex,
     });
   });
   it('renders the component', () => {
@@ -34,17 +34,17 @@ describe('ViewerNavigation', () => {
     });
     it('setCanvas function is called after click', () => {
       wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvas).toHaveBeenCalledWith(1);
+      expect(setCanvasByIndex).toHaveBeenCalledWith(1);
     });
     it('nextCanvas button is not disabled in bookview', () => {
       wrapper = createWrapper({
         canvases: [1, 2],
         canvasIndex: 0,
-        setCanvas,
+        setCanvasByIndex,
         view: 'book',
       });
       wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvas).toHaveBeenCalledWith(1);
+      expect(setCanvasByIndex).toHaveBeenCalledWith(1);
     });
   });
   describe('when next canvases are not present', () => {
@@ -61,7 +61,7 @@ describe('ViewerNavigation', () => {
     });
     it('setCanvas function is not called after click, as its disabled', () => {
       wrapper.find('.mirador-previous-canvas-button').simulate('click');
-      expect(setCanvas).not.toHaveBeenCalled();
+      expect(setCanvasByIndex).not.toHaveBeenCalled();
     });
   });
   describe('bookView', () => {
@@ -69,21 +69,21 @@ describe('ViewerNavigation', () => {
       wrapper = createWrapper({
         canvases: [1, 2, 3],
         canvasIndex: 0,
-        setCanvas,
+        setCanvasByIndex,
         view: 'book',
       });
       wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvas).toHaveBeenCalledWith(2);
+      expect(setCanvasByIndex).toHaveBeenCalledWith(2);
     });
     it('setCanvas function is called after click for previous', () => {
       wrapper = createWrapper({
         canvasIndex: 5,
-        setCanvas,
+        setCanvasByIndex,
         view: 'book',
       });
       wrapper.find('.mirador-previous-canvas-button').simulate('click');
       expect(wrapper.find('.mirador-previous-canvas-button').prop('aria-label')).toBe('previousCanvas');
-      expect(setCanvas).toHaveBeenCalledWith(3);
+      expect(setCanvasByIndex).toHaveBeenCalledWith(3);
     });
   });
 });

--- a/__tests__/src/components/WindowViewer.test.js
+++ b/__tests__/src/components/WindowViewer.test.js
@@ -42,7 +42,7 @@ describe('WindowViewer', () => {
       it('isFetching is false', () => {
         wrapper = createWrapper(
           {
-            canvasIndex: 1,
+            currentCanvasId: 1,
             infoResponses: {
               'https://stacks.stanford.edu/image/iiif/fr426cg9537%2FSC1094_s3_b14_f17_Cats_1976_0005': {
                 isFetching: false,
@@ -59,7 +59,7 @@ describe('WindowViewer', () => {
       it('infoResponse is undefined', () => {
         wrapper = createWrapper(
           {
-            canvasIndex: 1,
+            currentCanvasId: 1,
             infoResponses: {
               foo: {
                 isFetching: false,
@@ -76,7 +76,7 @@ describe('WindowViewer', () => {
       it('error is not present', () => {
         wrapper = createWrapper(
           {
-            canvasIndex: 1,
+            currentCanvasId: 1,
             infoResponses: {
               'https://stacks.stanford.edu/image/iiif/fr426cg9537%2FSC1094_s3_b14_f17_Cats_1976_0005': {
                 isFetching: false,
@@ -104,8 +104,8 @@ describe('WindowViewer', () => {
 
       wrapper = createWrapper(
         {
-          canvasIndex: 0,
           currentCanvases,
+          currentCanvasId: 0,
           fetchInfoResponse: mockFnCanvas0,
           view: 'single',
         },
@@ -115,8 +115,8 @@ describe('WindowViewer', () => {
       currentCanvases = [canvases[2]];
       wrapper = createWrapper(
         {
-          canvasIndex: 2,
           currentCanvases,
+          currentCanvasId: 2,
           fetchInfoResponse: mockFnCanvas2,
           view: 'single',
         },
@@ -142,14 +142,14 @@ describe('WindowViewer', () => {
       currentCanvases = [canvases[2]];
       wrapper = createWrapper(
         {
-          canvasIndex: 2,
           currentCanvases,
+          currentCanvasId: 2,
           fetchInfoResponse: mockFn,
           view: 'single',
         },
       );
 
-      wrapper.setProps({ canvasIndex: 3, currentCanvases: [canvases[3]], view: 'single' });
+      wrapper.setProps({ currentCanvases: [canvases[3]], currentCanvasId: 3, view: 'single' });
 
       expect(mockFn).toHaveBeenCalledTimes(0);
     });

--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -36,7 +36,7 @@ describe('MiradorViewer', () => {
         },
         windows: [
           {
-            canvasIndex: 2,
+            canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
             loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
             thumbnailNavigationPosition: 'far-bottom',
           },
@@ -50,8 +50,8 @@ describe('MiradorViewer', () => {
       const { windows, manifests } = instance.store.getState();
       const windowIds = Object.keys(windows);
       expect(Object.keys(windowIds).length).toBe(2);
-      expect(windows[windowIds[0]].canvasIndex).toBe(2);
-      expect(windows[windowIds[1]].canvasIndex).toBe(0);
+      expect(windows[windowIds[0]].canvasId).toBe('https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892');
+      expect(windows[windowIds[1]].canvasId).toBe(undefined);
       expect(windows[windowIds[0]].layoutOrder).toBe(0);
       expect(windows[windowIds[1]].layoutOrder).toBe(1);
       expect(windows[windowIds[0]].thumbnailNavigationPosition).toBe('far-bottom');

--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -119,26 +119,26 @@ describe('windows reducer', () => {
   it('should handle SET_CANVAS', () => {
     expect(windowsReducer({
       abc123: {
-        canvasIndex: 1,
+        canvasId: 'http://example.com/canvas/1',
         id: 'abc123',
       },
       def456: {
-        canvasIndex: 1,
+        canvasId: 'http://example.com/canvas/1',
         id: 'def456',
       },
     }, {
-      canvasIndex: 5,
+      canvasId: 'http://example.com/canvas/5',
       selectedContentSearchAnnotation: 'xyz',
       type: ActionTypes.SET_CANVAS,
       windowId: 'abc123',
     })).toEqual({
       abc123: {
-        canvasIndex: 5,
+        canvasId: 'http://example.com/canvas/5',
         id: 'abc123',
         selectedContentSearchAnnotation: 'xyz',
       },
       def456: {
-        canvasIndex: 1,
+        canvasId: 'http://example.com/canvas/1',
         id: 'def456',
       },
     });
@@ -434,10 +434,10 @@ describe('windows reducer', () => {
     it('sets the highlightedAnnotation attribute on the given window', () => {
       const beforeState = { abc123: {} };
       const action = {
-        annotationId: ['aaa123'], canvasIndex: 5, type: ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION, windowId: 'abc123',
+        annotationId: ['aaa123'], canvasId: 'info:canvas/5', type: ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION, windowId: 'abc123',
       };
       const expectedState = {
-        abc123: { canvasIndex: 5, selectedContentSearchAnnotation: ['aaa123'] },
+        abc123: { canvasId: 'info:canvas/5', selectedContentSearchAnnotation: ['aaa123'] },
       };
 
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);
@@ -455,21 +455,21 @@ describe('windows reducer', () => {
     it('set the canvas index and annotation id if provided', () => {
       const beforeState = { abc123: {} };
       const action = {
-        annotationId: 'aaa123', canvasIndex: 5, type: ActionTypes.RECEIVE_SEARCH, windowId: 'abc123',
+        annotationId: 'aaa123', canvasId: 'info:canvas/5', type: ActionTypes.RECEIVE_SEARCH, windowId: 'abc123',
       };
       const expectedState = {
-        abc123: { canvasIndex: 5, selectedContentSearchAnnotation: ['aaa123'] },
+        abc123: { canvasId: 'info:canvas/5', selectedContentSearchAnnotation: ['aaa123'] },
       };
 
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);
     });
     it('passes through existing data otherwise', () => {
-      const beforeState = { abc123: { canvasIndex: 5, selectedContentSearchAnnotation: ['aaa123'] } };
+      const beforeState = { abc123: { canvasId: 'info:canvas/5', selectedContentSearchAnnotation: ['aaa123'] } };
       const action = {
         type: ActionTypes.RECEIVE_SEARCH, windowId: 'abc123',
       };
       const expectedState = {
-        abc123: { canvasIndex: 5, selectedContentSearchAnnotation: ['aaa123'] },
+        abc123: { canvasId: 'info:canvas/5', selectedContentSearchAnnotation: ['aaa123'] },
       };
 
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);

--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -1,5 +1,6 @@
 import { windowsReducer } from '../../../src/state/reducers/windows';
 import ActionTypes from '../../../src/state/actions/action-types';
+import manifestJson from '../../fixtures/version-2/019.json';
 
 describe('windows reducer', () => {
   it('should handle ADD_WINDOW', () => {
@@ -27,6 +28,28 @@ describe('windows reducer', () => {
       def456: {
         id: 'def456',
       },
+    });
+  });
+  it('should handle RECEIVE_MANIFEST', () => {
+    const state = {
+      window: {
+        canvasIndex: 1,
+        manifestId: 'a',
+      },
+      window2: {
+      },
+    };
+    expect(windowsReducer(state, {
+      manifestId: 'a',
+      manifestJson,
+      type: ActionTypes.RECEIVE_MANIFEST,
+    })).toEqual({
+      window: {
+        canvasId: 'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
+        canvasIndex: undefined,
+        manifestId: 'a',
+      },
+      window2: {},
     });
   });
   it('should handle MAXIMIZE_WINDOW', () => {

--- a/__tests__/src/selectors/annotations.test.js
+++ b/__tests__/src/selectors/annotations.test.js
@@ -54,14 +54,13 @@ describe('getAnnotationResourcesByMotivationForCanvas', () => {
       },
       windows: {
         abc123: {
-          canvasIndex: 1,
           manifestId: 'mid',
         },
       },
     };
 
     expect(
-      getAnnotationResourcesByMotivationForCanvas(state, { motivations: ['something', 'oa:commenting'], windowId: 'abc123' }).map(r => r.motivations),
+      getAnnotationResourcesByMotivationForCanvas(state, { canvasId: 'cid2', motivations: ['something', 'oa:commenting'], windowId: 'abc123' }).map(r => r.motivations),
     ).toEqual(expected);
   });
 });

--- a/__tests__/src/selectors/canvases.test.js
+++ b/__tests__/src/selectors/canvases.test.js
@@ -77,14 +77,6 @@ describe('getCanvas', () => {
     });
     expect(received.id).toBe('https://iiif.bodleian.ox.ac.uk/iiif/canvas/9cca8fdd-4a61-4429-8ac1-f648764b4d6d.json');
   });
-
-  it('returns the default canvas if an id or index is not provided', () => {
-    const state = { manifests: { a: { json: manifestFixture001 } } };
-    const received = getCanvas(state, {
-      manifestId: 'a',
-    });
-    expect(received.index).toBe(0);
-  });
 });
 
 describe('getCanvasLabel', () => {

--- a/__tests__/src/selectors/canvases.test.js
+++ b/__tests__/src/selectors/canvases.test.js
@@ -19,7 +19,7 @@ describe('getSelectedCanvases', () => {
     },
     windows: {
       a: {
-        canvasIndex: 1,
+        canvasId: 'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
         id: 'a',
         manifestId: 'x',
         view: 'book',

--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -8,6 +8,7 @@ import manifestFixturev3001 from '../../fixtures/version-3/001.json';
 import manifestFixtureWithAProvider from '../../fixtures/version-3/with_a_provider.json';
 import manifestFixtureFg165hz3589 from '../../fixtures/version-2/fg165hz3589.json';
 import {
+  getManifestoInstance,
   getManifestLocale,
   getDestructuredMetadata,
   getManifest,
@@ -16,7 +17,7 @@ import {
   getManifestDescription,
   getManifestHomepage,
   getManifestProvider,
-  getManifestStartCanvasIndex,
+  getManifestStartCanvas,
   getManifestTitle,
   getManifestThumbnail,
   getManifestMetadata,
@@ -70,6 +71,14 @@ describe('getManifest()', () => {
   it('should return undefined if manifest does not exist', () => {
     const received = getManifest(state, { windowId: 'b' });
     expect(received).toBeUndefined();
+  });
+});
+
+describe('getManifestoInstance', () => {
+  it('creates a manifesto instance', () => {
+    const state = { manifests: { x: { json: manifestFixture019 } } };
+    const received = getManifestoInstance(state, { manifestId: 'x' });
+    expect(received.id).toEqual('http://iiif.io/api/presentation/2.1/example/fixtures/19/manifest.json');
   });
 });
 
@@ -396,7 +405,7 @@ describe('getRights', () => {
   });
 });
 
-describe('getManifestStartCanvasIndex', () => {
+describe('getManifestStartCanvas', () => {
   it('gets the startCanvas index for a IIIF v2 manifest', () => {
     const manifest = {
       '@context': 'http://iiif.io/api/presentation/2/context.json',
@@ -415,8 +424,7 @@ describe('getManifestStartCanvasIndex', () => {
         startCanvas: 'http://example.com/2',
       }],
     };
-    const state = { manifests: { x: { json: manifest } } };
-    expect(getManifestStartCanvasIndex(state, { manifestId: 'x' })).toEqual(1);
+    expect(getManifestStartCanvas(manifest).id).toEqual('http://example.com/2');
   });
 
   it('gets the start data for a IIIF v3 manifest', () => {
@@ -437,13 +445,32 @@ describe('getManifestStartCanvasIndex', () => {
       }],
       start: { source: 'http://example.com/2' },
     };
-    const state = { manifests: { x: { json: manifest } } };
-    expect(getManifestStartCanvasIndex(state, { manifestId: 'x' })).toEqual(1);
+    expect(getManifestStartCanvas(manifest).id).toEqual('http://example.com/2');
+  });
+
+  it('gets a canvas by index', () => {
+    const manifest = {
+      '@context': 'http://iiif.io/api/presentation/2/context.json',
+      '@id':
+       'http://iiif.io/api/presentation/2.1/example/fixtures/19/manifest.json',
+      '@type': 'sc:Manifest',
+      sequences: [{
+        canvases: [
+          {
+            '@id': 'http://example.com/1',
+          },
+          {
+            '@id': 'http://example.com/2',
+          },
+        ],
+        startCanvas: 'http://example.com/2',
+      }],
+    };
+    expect(getManifestStartCanvas(manifest, 0).id).toEqual('http://example.com/1');
   });
 
   it('is undefined if no start canvas is specified', () => {
-    const state = { manifests: { x: { json: manifestFixture001 } } };
-    expect(getManifestStartCanvasIndex(state, { manifestId: 'x' })).toEqual(undefined);
+    expect(getManifestStartCanvas(manifestFixture001).id).toEqual(undefined);
   });
 });
 

--- a/__tests__/src/selectors/windows.test.js
+++ b/__tests__/src/selectors/windows.test.js
@@ -82,34 +82,13 @@ describe('getWindowManifests', () => {
 });
 
 describe('getCanvasIndex', () => {
-  it('returns the index if provided', () => {
-    expect(getCanvasIndex({}, { canvasIndex: 25 })).toEqual(25);
-  });
-  it('returns the index, if provided, even if it is 0', () => {
-    const state = {
-      windows: {
-        a: { canvasIndex: 13 },
-      },
-    };
-
-    expect(getCanvasIndex(state, { canvasIndex: 0 })).toEqual(0);
-  });
-  it('returns the current canvasIndex for the window if provided', () => {
-    const state = {
-      windows: {
-        a: { canvasIndex: 13 },
-      },
-    };
-
-    expect(getCanvasIndex(state, { windowId: 'a' })).toEqual(13);
-  });
-  it('returns the default canvasIndex for the manifest', () => {
+  it('returns the current canvasIndex for the window', () => {
     const state = {
       manifests: {
-        x: { json: { ...manifestFixture019, start: { id: 'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1' } } },
+        y: { json: { ...manifestFixture015 } },
       },
       windows: {
-        a: { manifestId: 'x' },
+        a: { canvasId: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/15/c2.json', manifestId: 'y' },
       },
     };
 

--- a/src/components/GalleryView.js
+++ b/src/components/GalleryView.js
@@ -12,7 +12,7 @@ export class GalleryView extends Component {
    */
   render() {
     const {
-      canvases, classes, selectedCanvasIndex, windowId,
+      canvases, classes, windowId,
     } = this.props;
     return (
       <Paper
@@ -26,7 +26,6 @@ export class GalleryView extends Component {
           canvases.map(canvas => (
             <GalleryViewThumbnail
               key={canvas.id}
-              selected={selectedCanvasIndex === canvas.index}
               windowId={windowId}
               canvas={canvas}
             />
@@ -40,7 +39,6 @@ export class GalleryView extends Component {
 GalleryView.propTypes = {
   canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.objectOf(PropTypes.string),
-  selectedCanvasIndex: PropTypes.number.isRequired,
   windowId: PropTypes.string.isRequired,
 };
 

--- a/src/components/GalleryViewThumbnail.js
+++ b/src/components/GalleryViewThumbnail.js
@@ -29,7 +29,7 @@ export class GalleryViewThumbnail extends Component {
     if (selected) {
       focusOnCanvas();
     } else {
-      setCanvas(canvas.index);
+      setCanvas(canvas.id);
     }
   }
 
@@ -59,7 +59,7 @@ export class GalleryViewThumbnail extends Component {
     if (enterOrSpace) {
       focusOnCanvas();
     } else {
-      setCanvas(canvas.index);
+      setCanvas(canvas.index, canvas.id);
     }
   }
 

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -16,7 +16,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
   /** */
   setCanvas(e) {
     const { setCanvas } = this.props;
-    setCanvas(parseInt(e.currentTarget.dataset.canvasIndex, 10));
+    setCanvas(e.currentTarget.dataset.canvasId);
   }
 
   /**
@@ -53,6 +53,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
       >
         <div
           role="button"
+          data-canvas-id={currentGroupings[0].id}
           data-canvas-index={currentGroupings[0].index}
           onKeyUp={this.setCanvas}
           onClick={this.setCanvas}

--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -32,7 +32,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
   /** */
   render() {
     const {
-      index, style, data, classes, canvasIndex,
+      index, style, data, classes, currentCanvasId,
     } = this.props;
     const {
       canvasGroupings, position, height,
@@ -66,7 +66,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
             classes.canvas,
             {
               [classes.currentCanvas]: currentGroupings
-                .map(canvas => canvas.index).includes(canvasIndex),
+                .map(canvas => canvas.id).includes(currentCanvasId),
             },
           )}
         >
@@ -84,8 +84,8 @@ export class ThumbnailCanvasGrouping extends PureComponent {
 }
 
 ThumbnailCanvasGrouping.propTypes = {
-  canvasIndex: PropTypes.number.isRequired,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  currentCanvasId: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   index: PropTypes.number.isRequired,
   setCanvas: PropTypes.func.isRequired,

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -151,9 +151,9 @@ export class ThumbnailNavigation extends Component {
   /**
    */
   nextCanvas() {
-    const { canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvasByIndex } = this.props;
     if (this.hasNextCanvas()) {
-      setCanvas(canvasIndex + this.canvasIncrementor());
+      setCanvasByIndex(canvasIndex + this.canvasIncrementor());
     }
   }
 
@@ -167,9 +167,9 @@ export class ThumbnailNavigation extends Component {
   /**
    */
   previousCanvas() {
-    const { canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvasByIndex } = this.props;
     if (this.hasPreviousCanvas()) {
-      setCanvas(Math.max(0, canvasIndex - this.canvasIncrementor()));
+      setCanvasByIndex(Math.max(0, canvasIndex - this.canvasIncrementor()));
     }
   }
 
@@ -256,7 +256,7 @@ ThumbnailNavigation.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   position: PropTypes.string.isRequired,
-  setCanvas: PropTypes.func.isRequired,
+  setCanvasByIndex: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   view: PropTypes.string,
   windowId: PropTypes.string.isRequired,

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -19,9 +19,9 @@ export class ViewerNavigation extends Component {
   /**
    */
   nextCanvas() {
-    const { canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvasByIndex } = this.props;
     if (this.hasNextCanvas()) {
-      setCanvas(canvasIndex + this.canvasIncrementor());
+      setCanvasByIndex(canvasIndex + this.canvasIncrementor());
     }
   }
 
@@ -35,9 +35,9 @@ export class ViewerNavigation extends Component {
   /**
    */
   previousCanvas() {
-    const { canvasIndex, setCanvas } = this.props;
+    const { canvasIndex, setCanvasByIndex } = this.props;
     if (this.hasPreviousCanvas()) {
-      setCanvas(Math.max(0, canvasIndex - this.canvasIncrementor()));
+      setCanvasByIndex(Math.max(0, canvasIndex - this.canvasIncrementor()));
     }
   }
 
@@ -94,7 +94,7 @@ export class ViewerNavigation extends Component {
 ViewerNavigation.propTypes = {
   canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   canvasIndex: PropTypes.number.isRequired,
-  setCanvas: PropTypes.func.isRequired,
+  setCanvasByIndex: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   view: PropTypes.string,
 };

--- a/src/components/WindowSideBarAnnotationsPanel.js
+++ b/src/components/WindowSideBarAnnotationsPanel.js
@@ -31,7 +31,7 @@ export class WindowSideBarAnnotationsPanel extends Component {
 
         {selectedCanvases.map((canvas, index) => (
           <CanvasAnnotations
-            canvasIndex={canvas.index}
+            canvasId={canvas.id}
             key={canvas.id}
             index={index}
             totalSize={selectedCanvases.length}

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -154,7 +154,7 @@ export class WindowSideBarCanvasPanel extends Component {
           <List>
             {
               canvasesIdAndLabel.map((canvas, canvasIndex) => {
-                const onClick = () => { setCanvas(windowId, canvasIndex); }; // eslint-disable-line require-jsdoc, max-len
+                const onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
 
                 return (
                   <ScrollTo

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -48,11 +48,11 @@ export class WindowViewer extends Component {
    */
   componentDidUpdate(prevProps) {
     const {
-      canvasIndex, currentCanvases, view, fetchInfoResponse, fetchAnnotation,
+      currentCanvasId, currentCanvases, view, fetchInfoResponse, fetchAnnotation,
     } = this.props;
 
     if (prevProps.view !== view
-      || (prevProps.canvasIndex !== canvasIndex && !this.infoResponseIsInStore())
+      || (prevProps.currentCanvasId !== currentCanvasId && !this.infoResponseIsInStore())
     ) {
       currentCanvases.forEach((canvas) => {
         const manifestoCanvas = new ManifestoCanvas(canvas);
@@ -135,8 +135,8 @@ export class WindowViewer extends Component {
 }
 
 WindowViewer.propTypes = {
-  canvasIndex: PropTypes.number.isRequired,
   currentCanvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  currentCanvasId: PropTypes.string.isRequired,
   fetchAnnotation: PropTypes.func.isRequired,
   fetchInfoResponse: PropTypes.func.isRequired,
   infoResponses: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -233,13 +233,13 @@ export default {
     Example Window:
     {
       manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
-      canvasIndex: 2,
+      canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/page_2',
       thumbnailNavigationPosition: 'far-bottom',
     }
     // ../state/actions/window.js `defaultOptions`
     // ../lib/MiradorViewer.js `windowAction`
     */
-  ], 
+  ],
   thumbnailNavigation: {
     defaultPosition: 'off', // Which position for the thumbnail navigation to be be displayed. Other possible values are "far-bottom" or "far-right"
     height: 130, // height of entire ThumbnailNavigation area when position is "far-bottom"

--- a/src/containers/CanvasAnnotations.js
+++ b/src/containers/CanvasAnnotations.js
@@ -24,15 +24,15 @@ function getIdAndContentOfResources(resources) {
 }
 
 /** For connect */
-const mapStateToProps = (state, { canvasIndex, windowId }) => ({
+const mapStateToProps = (state, { canvasId, windowId }) => ({
   allAnnotationsAreHighlighted: getWindow(state, { windowId }).displayAllAnnotations,
   annotations: getIdAndContentOfResources(
     getAnnotationResourcesByMotivationForCanvas(
-      state, { canvasIndex, motivations: ['oa:commenting', 'sc:painting'], windowId },
+      state, { canvasId, motivations: ['oa:commenting', 'sc:painting'], windowId },
     ),
   ),
   label: getCanvasLabel(state, {
-    canvasIndex,
+    canvasId,
     windowId,
   }),
   selectedAnnotationIds: getSelectedAnnotationIds(state, { windowId }),

--- a/src/containers/GalleryView.js
+++ b/src/containers/GalleryView.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { GalleryView } from '../components/GalleryView';
-import { getManifestCanvases, getCanvasIndex } from '../state/selectors';
+import { getManifestCanvases } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -13,7 +13,6 @@ import { getManifestCanvases, getCanvasIndex } from '../state/selectors';
 const mapStateToProps = (state, { windowId }) => (
   {
     canvases: getManifestCanvases(state, { windowId }),
-    selectedCanvasIndex: getCanvasIndex(state, { windowId }),
   }
 );
 

--- a/src/containers/GalleryViewThumbnail.js
+++ b/src/containers/GalleryViewThumbnail.js
@@ -7,6 +7,7 @@ import { GalleryViewThumbnail } from '../components/GalleryViewThumbnail';
 import {
   getSearchAnnotationsForWindow,
   getSelectedContentSearchAnnotations,
+  getCurrentCanvas,
 } from '../state/selectors';
 
 /**
@@ -66,6 +67,7 @@ const styles = theme => ({
 
 /** */
 const mapStateToProps = (state, { canvas, windowId }) => {
+  const currentCanvas = getCurrentCanvas(state, { windowId });
   const selectedAnnotations = getSelectedContentSearchAnnotations(state, { windowId });
   const annotationResources = flatten(selectedAnnotations.map(a => a.resources));
   const selectedAnnotationCanvases = annotationResources.map(a => a.targetId);
@@ -79,6 +81,7 @@ const mapStateToProps = (state, { canvas, windowId }) => {
       .filter(a => a.targetId === canvas.id).length,
     annotationSelected: selectedAnnotationCanvases.includes(canvas.id),
     config: state.config.galleryView,
+    selected: currentCanvas && currentCanvas.id === canvas.id,
   };
 };
 

--- a/src/containers/ThumbnailCanvasGrouping.js
+++ b/src/containers/ThumbnailCanvasGrouping.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getWindow, getCanvasIndex } from '../state/selectors';
+import { getWindow, getCurrentCanvas } from '../state/selectors';
 import { ThumbnailCanvasGrouping } from '../components/ThumbnailCanvasGrouping';
 
 /**
@@ -22,7 +22,7 @@ const mapDispatchToProps = (dispatch, { data }) => ({
  * @private
  */
 const mapStateToProps = (state, { data }) => ({
-  canvasIndex: getCanvasIndex(state, { windowId: data.windowId }),
+  currentCanvasId: (getCurrentCanvas(state, { windowId: data.windowId }) || {}).id,
   window: getWindow(state, { windowId: data.windowId }),
 });
 

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -33,7 +33,7 @@ const mapStateToProps = (state, { windowId }) => {
  * @private
  */
 const mapDispatchToProps = (dispatch, { windowId }) => ({
-  setCanvas: (...args) => dispatch(actions.setCanvas(windowId, ...args)),
+  setCanvasByIndex: (...args) => dispatch(actions.setCanvasByIndex(windowId, ...args)),
 });
 
 /**

--- a/src/containers/ViewerNavigation.js
+++ b/src/containers/ViewerNavigation.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state, { windowId }) => ({
  * @private
  */
 const mapDispatchToProps = (dispatch, { windowId }) => ({
-  setCanvas: (...args) => dispatch(actions.setCanvas(windowId, ...args)),
+  setCanvasByIndex: (...args) => dispatch(actions.setCanvasByIndex(windowId, ...args)),
 });
 
 const enhance = compose(

--- a/src/containers/WindowViewSettings.js
+++ b/src/containers/WindowViewSettings.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getWindowViewType, getCanvasIndex } from '../state/selectors';
+import { getWindowViewType } from '../state/selectors';
 import { WindowViewSettings } from '../components/WindowViewSettings';
 
 /**
@@ -21,7 +21,6 @@ const mapDispatchToProps = { setWindowViewType: actions.setWindowViewType };
  */
 const mapStateToProps = (state, { windowId }) => (
   {
-    canvasIndex: getCanvasIndex(state, { windowId }),
     windowViewType: getWindowViewType(state, { windowId }),
   }
 );

--- a/src/containers/WindowViewer.js
+++ b/src/containers/WindowViewer.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
 import { WindowViewer } from '../components/WindowViewer';
-import { getSelectedCanvases, getCanvasIndex, getWindowViewType } from '../state/selectors';
+import { getSelectedCanvases, getCurrentCanvas, getWindowViewType } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -12,8 +12,8 @@ import { getSelectedCanvases, getCanvasIndex, getWindowViewType } from '../state
  */
 const mapStateToProps = (state, { windowId }) => (
   {
-    canvasIndex: getCanvasIndex(state, { windowId }),
-    currentCanvases: getSelectedCanvases(state, { windowId }),
+    currentCanvases: getSelectedCanvases(state, { windowId }) || [],
+    currentCanvasId: (getCurrentCanvas(state, { windowId }) || {}).id,
     infoResponses: state.infoResponses,
     view: getWindowViewType(state, { windowId }),
   }

--- a/src/lib/CanvasGroupings.js
+++ b/src/lib/CanvasGroupings.js
@@ -10,6 +10,11 @@ export default class CanvasGroupings {
     this._groupings = null; // eslint-disable-line no-underscore-dangle
   }
 
+  /** */
+  getCanvasesById(canvasId) {
+    return this.groupings().find(group => group.some(c => c.id === canvasId));
+  }
+
   /**
    */
   getCanvases(index) {

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -52,7 +52,6 @@ class MiradorViewer {
       const manifestAction = this.store.dispatch(actions.fetchManifest(manifestId));
       const windowAction = this.store.dispatch(actions.addWindow({
         // these are default values ...
-        canvasIndex: 0,
         id: windowId,
         layoutOrder,
         manifestId,

--- a/src/state/actions/canvas.js
+++ b/src/state/actions/canvas.js
@@ -9,7 +9,7 @@ import {
  * setCanvas - action creator
  *
  * @param  {String} windowId
- * @param  {Number} canvasIndex
+ * @param  {String} canvasId
  * @memberof ActionCreators
  */
 export function setCanvas(windowId, canvasIndex) {
@@ -46,6 +46,23 @@ export function setCanvas(windowId, canvasIndex) {
     }
 
     dispatch(action);
+  });
+}
+
+/**
+ * setCanvasByIndex - action creator
+ *
+ * @param  {String} windowId
+ * @param  {Number} canvasIndex
+ * @memberof ActionCreators
+ */
+export function setCanvasByIndex(windowId, canvasIndex) {
+  return ((dispatch, getState) => {
+    const state = getState();
+
+    const canvas = getCanvas(state, { canvasIndex, windowId });
+
+    dispatch(setCanvas(windowId, canvas && canvas.id));
   });
 }
 

--- a/src/state/actions/canvas.js
+++ b/src/state/actions/canvas.js
@@ -1,6 +1,7 @@
 import ActionTypes from './action-types';
 import {
-  getSelectedCanvases,
+  getCanvasGrouping,
+  getCanvas,
   getSearchAnnotationsForCompanionWindow,
   getSearchForWindow,
 } from '../selectors';
@@ -12,11 +13,11 @@ import {
  * @param  {String} canvasId
  * @memberof ActionCreators
  */
-export function setCanvas(windowId, canvasIndex) {
+export function setCanvas(windowId, canvasId) {
   return ((dispatch, getState) => {
     const state = getState();
 
-    const canvasIds = getSelectedCanvases(state, { canvasIndex, windowId }).map(c => c.id);
+    const canvasIds = getCanvasGrouping(state, { canvasId, windowId }).map(c => c.id);
     const searches = getSearchForWindow(state, { windowId }) || {};
     const annotationBySearch = Object.keys(searches).reduce((accumulator, companionWindowId) => {
       const annotations = getSearchAnnotationsForCompanionWindow(state, {
@@ -33,7 +34,7 @@ export function setCanvas(windowId, canvasIndex) {
     const annotationIds = Object.values(annotationBySearch);
 
     const action = {
-      canvasIndex,
+      canvasId: canvasIds && canvasIds[0],
       searches: annotationBySearch,
       type: ActionTypes.SET_CANVAS,
       windowId,

--- a/src/state/actions/search.js
+++ b/src/state/actions/search.js
@@ -56,7 +56,7 @@ export function receiveSearch(windowId, companionWindowId, searchId, searchJson)
 
     dispatch({
       annotationId: annotation && annotation.id,
-      canvasIndex: canvas && canvas.index,
+      canvasId: canvas && canvas.id,
       companionWindowId,
       searchId,
       searchJson,
@@ -132,7 +132,7 @@ export function selectContentSearchAnnotation(windowId, companionWindowId, annot
 
     dispatch({
       annotationId: annotationIds,
-      canvasIndex: canvas && canvas.index,
+      canvasId: canvas && canvas.id,
       companionWindowId,
       type: ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION,
       windowId,

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -46,7 +46,7 @@ export function addWindow({ companionWindows, ...options }) {
     const cwThumbs = `cw-${uuid()}`;
     const additionalCompanionWindowIds = (companionWindows || []).map(e => `cw-${uuid()}`);
     const defaultOptions = {
-      canvasIndex: undefined,
+      canvasId: undefined,
       collectionIndex: 0,
       companionAreaOpen: true,
       companionWindowIds: [cwDefault, cwThumbs, ...additionalCompanionWindowIds],

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -84,7 +84,7 @@ export const windowsReducer = (state = {}, action) => {
       };
     case ActionTypes.SET_CANVAS:
       return updateIn(state, [action.windowId], orig => merge(orig, {
-        canvasIndex: action.canvasIndex,
+        canvasId: action.canvasId,
         selectedContentSearchAnnotation: action.selectedContentSearchAnnotation,
       }));
     case ActionTypes.ADD_COMPANION_WINDOW:
@@ -136,7 +136,7 @@ export const windowsReducer = (state = {}, action) => {
         ...state,
         [action.windowId]: {
           ...state[action.windowId],
-          canvasIndex: action.canvasIndex,
+          canvasId: action.canvasId,
           selectedContentSearchAnnotation: action.annotationId,
         },
       };
@@ -196,7 +196,7 @@ export const windowsReducer = (state = {}, action) => {
         ...state,
         [action.windowId]: {
           ...state[action.windowId],
-          canvasIndex: action.canvasIndex || state[action.windowId].canvasIndex,
+          canvasId: action.canvasId || state[action.windowId].canvasId,
           selectedContentSearchAnnotation: (action.annotationId && [action.annotationId])
             || state[action.windowId].selectedContentSearchAnnotation,
         },

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -1,5 +1,6 @@
 import { remove, updateIn, merge } from 'immutable';
 import ActionTypes from '../actions/action-types';
+import { getManifestStartCanvas } from '../selectors';
 
 /**
  * windowsReducer
@@ -9,6 +10,21 @@ export const windowsReducer = (state = {}, action) => {
     case ActionTypes.ADD_WINDOW:
       return { ...state, [action.window.id]: action.window };
 
+    case ActionTypes.RECEIVE_MANIFEST:
+      return Object.keys(state).reduce((object, key) => {
+        if (state[key].manifestId === action.manifestId) {
+          object[key] = { // eslint-disable-line no-param-reassign
+            ...state[key],
+            canvasId: state[key].canvasId
+              || getManifestStartCanvas(action.manifestJson, state[key].canvasIndex).id,
+            canvasIndex: undefined,
+          };
+        } else {
+          object[key] = state[key]; // eslint-disable-line no-param-reassign
+        }
+
+        return object;
+      }, {});
     case ActionTypes.MAXIMIZE_WINDOW:
       return {
         ...state,

--- a/src/state/selectors/annotations.js
+++ b/src/state/selectors/annotations.js
@@ -104,9 +104,9 @@ export const getSelectedAnnotationIds = createSelector(
     getSelectedCanvases,
   ],
   (selectedAnnotations, canvases) => (
-    flatten(
+    (canvases && flatten(
       canvases.map(c => c.id).map(targetId => selectedAnnotations && selectedAnnotations[targetId]),
-    )
+    )) || []
   ),
 );
 

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import { Utils } from 'manifesto.js';
 import CanvasGroupings from '../../lib/CanvasGroupings';
 import { getManifestoInstance } from './manifests';
-import { getCanvasIndex, getWindowViewType } from './windows';
+import { getWindow, getWindowViewType } from './windows';
 
 export const getCanvases = createSelector(
   [getManifestoInstance],

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -27,10 +27,31 @@ export const getCanvas = createSelector(
     if (!manifest) return undefined;
 
     if (canvasId !== undefined) return manifest.getSequences()[0].getCanvasById(canvasId);
-
     return manifest.getSequences()[0].getCanvasByIndex(canvasIndex);
   },
 );
+
+export const getCurrentCanvas = createSelector(
+  [
+    getManifestoInstance,
+    getWindow,
+  ],
+  (manifest, window) => {
+    if (!manifest || !window) return undefined;
+
+    if (!window.canvasId) return manifest.getSequences()[0].getCanvasByIndex(0);
+
+    return manifest.getSequences()[0].getCanvasById(window.canvasId);
+  },
+);
+
+/** */
+export function getSelectedCanvases(state, args) {
+  const canvas = getCurrentCanvas(state, { ...args });
+  if (!canvas) return undefined;
+
+  return getCanvasGrouping(state, { ...args, canvasId: canvas.id });
+}
 
 /**
 * Return the current canvases selected in a window
@@ -41,17 +62,17 @@ export const getCanvas = createSelector(
 * @param {string} props.windowId
 * @return {Array}
 */
-export const getSelectedCanvases = createSelector(
+export const getCanvasGrouping = createSelector(
   [
     getCanvases,
-    getCanvasIndex,
+    (state, { canvasId }) => canvasId,
     getWindowViewType,
   ],
-  (canvases, canvasIndex, view) => canvases
+  (canvases, canvasId, view) => (canvases
       && new CanvasGroupings(
         canvases,
         view,
-      ).getCanvases(canvasIndex),
+      ).getCanvasesById(canvasId)) || [],
 );
 
 /**

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -20,7 +20,7 @@ export const getCanvases = createSelector(
 export const getCanvas = createSelector(
   [
     getManifestoInstance,
-    getCanvasIndex,
+    (state, { canvasIndex }) => canvasIndex,
     (state, { canvasId }) => canvasId,
   ],
   (manifest, canvasIndex, canvasId) => {

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -58,16 +58,12 @@ export function getWindow(state, { windowId }) {
 export const getCanvasIndex = createSelector(
   [
     getWindow,
-    (state, { canvasIndex }) => canvasIndex,
-    getManifestStartCanvasIndex,
+    getManifestoInstance,
   ],
-  (window, providedCanvasIndex, defaultIndex) => {
-    if (providedCanvasIndex !== undefined) return providedCanvasIndex;
-
-    if (window && (window.canvasIndex !== undefined)) return window.canvasIndex;
-
-    return defaultIndex || 0;
-  },
+  (window, manifest) => (
+    (manifest && window && window.canvasId
+      && manifest.getSequences()[0].getCanvasById(window.canvasId))
+    || {}).index || 0,
 );
 
 /** Return type of view in a certain window.

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { getManifestTitle, getManifestStartCanvasIndex, getManifestViewingHint } from './manifests';
+import { getManifestTitle, getManifestViewingHint, getManifestoInstance } from './manifests';
 import { getWorkspaceType, getDefaultView } from './config';
 
 /**


### PR DESCRIPTION
This refactors our window state to avoid using the `canvasIndex` parameter, and instead uses an explicit `canvasId`. This should be slightly easier for consumers to provide (and easier for our internal annotation + search actions to provide), be more future proof and create a more predictable user experience in some complex scenarios (particularly dealing with multiple sequences). 

Fixes https://github.com/ProjectMirador/mirador/issues/2664

Follow-on work, hopefully outside the scope of this PR, includes:

- renaming `getSelectedCanvases` to `getVisibleCanvases` (or similar) to reflect its actual use
- moving functions around to more logical locations (they've been left as-is here to preserve a good diff-viewing experience)
- extracting 'setPreviousCanvas` and `setNextCanvas` selectors to replace `setCanvasByIndex`, simplifying the paginating components significantly. 