### PR TITLE
Set a maxWidth for GalleryViewThumbnail to keep a somewhat consistent…

### DIFF
--- a/src/components/GalleryViewThumbnail.js
+++ b/src/components/GalleryViewThumbnail.js
@@ -93,7 +93,10 @@ export class GalleryViewThumbnail extends Component {
           isValid={manifestoCanvas.hasValidDimensions}
           maxHeight={config.height}
           aspectRatio={manifestoCanvas.aspectRatio}
-          style={{ margin: '0 auto' }}
+          style={{
+            margin: '0 auto',
+            maxWidth: `${Math.ceil(config.height * manifestoCanvas.aspectRatio)}px`,
+          }}
         />
         <Typography variant="caption" className={classes.galleryViewCaption}>
           {manifestoCanvas.getLabel()}


### PR DESCRIPTION
… thumbnail size between the placeholder and the actual image.

This is what we're currently doing in the thumbnail panel, so 🤷‍♂ 

Fixes https://github.com/ProjectMirador/mirador/issues/2833