### PR TITLE
Use `flex-basis: auto` so IE11 displays right-anchored companion windows

### DIFF
--- a/src/containers/Window.js
+++ b/src/containers/Window.js
@@ -51,7 +51,7 @@ const styles = theme => ({
   },
   companionAreaRight: {
     display: 'flex',
-    flex: '0',
+    flex: '0 1 auto',
     minHeight: 0,
   },
   maximized: {},


### PR DESCRIPTION
Fixes #2830 (~assuming it doesn't break other browsers...~ seems fine in IE11, Safari, Chrome, + FF)