### PR TITLE
Extract actions for selecting the next + previous canvases

### DIFF
--- a/__tests__/src/actions/canvas.test.js
+++ b/__tests__/src/actions/canvas.test.js
@@ -8,8 +8,9 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 jest.mock('../../../src/state/selectors', () => ({
-  getCanvas: (state, { canvasId, canvasIndex }) => ({ id: canvasId || `canvasIndex-${canvasIndex}` }),
   getCanvasGrouping: (state, { canvasId }) => [{ id: canvasId }],
+  getNextCanvasGrouping: () => [{ id: 'canvasIndex-2' }],
+  getPreviousCanvasGrouping: () => [{ id: 'canvasIndex-0' }],
   getSearchAnnotationsForCompanionWindow: () => ({
     resources: [
       { id: 'annoId', targetId: 'a' },
@@ -41,7 +42,7 @@ describe('canvas actions', () => {
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
   });
-  describe('setCanvasByIndex', () => {
+  describe('setPreviousCanvas', () => {
     let store = null;
     beforeEach(() => {
       store = mockStore({});
@@ -50,12 +51,30 @@ describe('canvas actions', () => {
     it('sets to a defined canvas', () => {
       const id = 'abc123';
       const expectedAction = {
-        canvasId: 'canvasIndex-1',
+        canvasId: 'canvasIndex-0',
         searches: {},
         type: ActionTypes.SET_CANVAS,
         windowId: id,
       };
-      store.dispatch(actions.setCanvasByIndex(id, 1));
+      store.dispatch(actions.setPreviousCanvas(id));
+      expect(store.getActions()[0]).toEqual(expectedAction);
+    });
+  });
+  describe('setNextCanvas', () => {
+    let store = null;
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    it('sets to a defined canvas', () => {
+      const id = 'abc123';
+      const expectedAction = {
+        canvasId: 'canvasIndex-2',
+        searches: {},
+        type: ActionTypes.SET_CANVAS,
+        windowId: id,
+      };
+      store.dispatch(actions.setNextCanvas(id));
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
   });

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -28,10 +28,8 @@ function createWrapper(props, fixture = manifestJson) {
 describe('ThumbnailNavigation', () => {
   let wrapper;
   let rightWrapper;
-  let setCanvasByIndex;
   beforeEach(() => {
-    setCanvasByIndex = jest.fn();
-    wrapper = createWrapper({ setCanvasByIndex });
+    wrapper = createWrapper();
   });
   it('renders the component', () => {
     expect(wrapper.find('.mirador-thumb-navigation').length).toBe(1);
@@ -65,7 +63,6 @@ describe('ThumbnailNavigation', () => {
     beforeEach(() => {
       rightWrapper = createWrapper({
         position: 'far-right',
-        setCanvasByIndex,
       });
     });
     it('style', () => {
@@ -101,26 +98,35 @@ describe('ThumbnailNavigation', () => {
     });
   });
   describe('keyboard navigation', () => {
-    const rightSetCanvasByIndex = jest.fn();
+    const setNextCanvas = jest.fn();
+    const setPreviousCanvas = jest.fn();
     beforeEach(() => {
-      rightWrapper = createWrapper({
+      wrapper = createWrapper({
         canvasIndex: 1,
-        position: 'far-right',
-        setCanvasByIndex: rightSetCanvasByIndex,
+        hasNextCanvas: true,
+        hasPreviousCanvas: true,
+        setNextCanvas,
+        setPreviousCanvas,
       });
     });
     describe('handleKeyUp', () => {
-      it('next', () => {
+      it('handles right arrow by advancing the current canvas', () => {
         wrapper.instance().handleKeyUp({ key: 'ArrowRight' });
-        expect(setCanvasByIndex).toHaveBeenCalledWith(2);
-        rightWrapper.instance().handleKeyUp({ key: 'ArrowDown' });
-        expect(rightSetCanvasByIndex).toHaveBeenCalledWith(2);
+        expect(setNextCanvas).toHaveBeenCalled();
       });
-      it('previous', () => {
+      it('handles down arrow by advancing the current canvas when the canvas is on the right', () => {
+        wrapper.setProps({ position: 'far-right' });
+        wrapper.instance().handleKeyUp({ key: 'ArrowDown' });
+        expect(setNextCanvas).toHaveBeenCalled();
+      });
+      it('handles left arrow by selecting the previous canvas', () => {
         wrapper.instance().handleKeyUp({ key: 'ArrowLeft' });
-        expect(setCanvasByIndex).toHaveBeenCalledWith(0);
-        rightWrapper.instance().handleKeyUp({ key: 'ArrowUp' });
-        expect(rightSetCanvasByIndex).toHaveBeenCalledWith(0);
+        expect(setPreviousCanvas).toHaveBeenCalled();
+      });
+      it('handles up arrow by selecting the previous canvas when the canvas is on the right', () => {
+        wrapper.setProps({ position: 'far-right' });
+        wrapper.instance().handleKeyUp({ key: 'ArrowUp' });
+        expect(setPreviousCanvas).toHaveBeenCalled();
       });
     });
   });

--- a/__tests__/src/components/ViewerNavigation.test.js
+++ b/__tests__/src/components/ViewerNavigation.test.js
@@ -7,7 +7,6 @@ function createWrapper(props) {
   return shallow(
     <ViewerNavigation
       canvases={[1, 2]}
-      setCanvasByIndex={() => {}}
       t={k => (k)}
       {...props}
     />,
@@ -16,12 +15,16 @@ function createWrapper(props) {
 
 describe('ViewerNavigation', () => {
   let wrapper;
-  let setCanvasByIndex;
+  let setNextCanvas;
+  let setPreviousCanvas;
   beforeEach(() => {
-    setCanvasByIndex = jest.fn();
+    setNextCanvas = jest.fn();
+    setPreviousCanvas = jest.fn();
     wrapper = createWrapper({
-      canvasIndex: 0,
-      setCanvasByIndex,
+      hasNextCanvas: true,
+      hasPreviousCanvas: false,
+      setNextCanvas,
+      setPreviousCanvas,
     });
   });
   it('renders the component', () => {
@@ -32,27 +35,35 @@ describe('ViewerNavigation', () => {
       expect(wrapper.find('.mirador-next-canvas-button').prop('aria-label')).toBe('nextCanvas');
       expect(wrapper.find('.mirador-next-canvas-button').prop('disabled')).toBe(false);
     });
-    it('setCanvas function is called after click', () => {
+    it('setNextCanvas function is called after click', () => {
       wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvasByIndex).toHaveBeenCalledWith(1);
-    });
-    it('nextCanvas button is not disabled in bookview', () => {
-      wrapper = createWrapper({
-        canvases: [1, 2],
-        canvasIndex: 0,
-        setCanvasByIndex,
-        view: 'book',
-      });
-      wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvasByIndex).toHaveBeenCalledWith(1);
+      expect(setNextCanvas).toHaveBeenCalled();
     });
   });
   describe('when next canvases are not present', () => {
     it('nextCanvas button is disabled', () => {
-      const endWrapper = createWrapper({
-        canvasIndex: 1,
-      });
+      const endWrapper = createWrapper();
       expect(endWrapper.find('.mirador-next-canvas-button').prop('disabled')).toBe(true);
+      endWrapper.find('.mirador-next-canvas-button').simulate('click');
+      expect(setNextCanvas).not.toHaveBeenCalled();
+    });
+  });
+  describe('when previous canvases are present', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({
+        hasNextCanvas: false,
+        hasPreviousCanvas: true,
+        setNextCanvas,
+        setPreviousCanvas,
+      });
+    });
+    it('previousCanvas button is not disabled', () => {
+      expect(wrapper.find('.mirador-previous-canvas-button').prop('aria-label')).toBe('previousCanvas');
+      expect(wrapper.find('.mirador-previous-canvas-button').prop('disabled')).toBe(false);
+    });
+    it('setPreviousCanvas function is called after click', () => {
+      wrapper.find('.mirador-previous-canvas-button').simulate('click');
+      expect(setPreviousCanvas).toHaveBeenCalled();
     });
   });
   describe('when previous canvases are not present', () => {
@@ -61,29 +72,7 @@ describe('ViewerNavigation', () => {
     });
     it('setCanvas function is not called after click, as its disabled', () => {
       wrapper.find('.mirador-previous-canvas-button').simulate('click');
-      expect(setCanvasByIndex).not.toHaveBeenCalled();
-    });
-  });
-  describe('bookView', () => {
-    it('setCanvas function is called after click for next', () => {
-      wrapper = createWrapper({
-        canvases: [1, 2, 3],
-        canvasIndex: 0,
-        setCanvasByIndex,
-        view: 'book',
-      });
-      wrapper.find('.mirador-next-canvas-button').simulate('click');
-      expect(setCanvasByIndex).toHaveBeenCalledWith(2);
-    });
-    it('setCanvas function is called after click for previous', () => {
-      wrapper = createWrapper({
-        canvasIndex: 5,
-        setCanvasByIndex,
-        view: 'book',
-      });
-      wrapper.find('.mirador-previous-canvas-button').simulate('click');
-      expect(wrapper.find('.mirador-previous-canvas-button').prop('aria-label')).toBe('previousCanvas');
-      expect(setCanvasByIndex).toHaveBeenCalledWith(3);
+      expect(setPreviousCanvas).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/src/selectors/canvases.test.js
+++ b/__tests__/src/selectors/canvases.test.js
@@ -2,6 +2,8 @@ import manifestFixture001 from '../../fixtures/version-2/001.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import {
   getVisibleCanvases,
+  getNextCanvasGrouping,
+  getPreviousCanvasGrouping,
   getCanvas,
   getCanvasLabel,
   selectCanvasAuthService,
@@ -56,6 +58,61 @@ describe('getVisibleCanvases', () => {
     const selectedCanvas = getVisibleCanvases(noManifestationState, { windowId: 'a' });
 
     expect(selectedCanvas).toBeUndefined();
+  });
+});
+
+describe('getNextCanvasGrouping', () => {
+  const state = {
+    manifests: {
+      x: {
+        id: 'x',
+        json: manifestFixture019,
+      },
+    },
+    windows: {
+      a: {
+        canvasId: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json',
+        id: 'a',
+        manifestId: 'x',
+        view: 'book',
+      },
+    },
+  };
+
+  it('should return the next canvas groupings', () => {
+    const selectedCanvases = getNextCanvasGrouping(state, { windowId: 'a' });
+
+    expect(selectedCanvases.map(canvas => canvas.id)).toEqual([
+      'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
+      'https://purl.stanford.edu/rz176rt6531/iiif/canvas/rz176rt6531_1',
+    ]);
+  });
+});
+
+describe('getPreviousCanvasGrouping', () => {
+  const state = {
+    manifests: {
+      x: {
+        id: 'x',
+        json: manifestFixture019,
+      },
+    },
+    windows: {
+      a: {
+        canvasId: 'https://purl.stanford.edu/rz176rt6531/iiif/canvas/rz176rt6531_1',
+        id: 'a',
+        manifestId: 'x',
+        view: 'book',
+      },
+    },
+  };
+
+  it('should return the next canvas groupings', () => {
+    const selectedCanvases = getPreviousCanvasGrouping(state, { windowId: 'a' });
+
+    expect(selectedCanvases.map(canvas => canvas.id)).toEqual([
+      'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json',
+    ]);
   });
 });
 

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -151,44 +151,18 @@ export class ThumbnailNavigation extends Component {
   /**
    */
   nextCanvas() {
-    const { canvasIndex, setCanvasByIndex } = this.props;
-    if (this.hasNextCanvas()) {
-      setCanvasByIndex(canvasIndex + this.canvasIncrementor());
+    const { hasNextCanvas, setNextCanvas } = this.props;
+    if (hasNextCanvas) {
+      setNextCanvas();
     }
-  }
-
-  /**
-   */
-  hasNextCanvas() {
-    const { canvasIndex, canvasGroupings } = this.props;
-    return canvasIndex < canvasGroupings.canvases.length - this.canvasIncrementor();
   }
 
   /**
    */
   previousCanvas() {
-    const { canvasIndex, setCanvasByIndex } = this.props;
-    if (this.hasPreviousCanvas()) {
-      setCanvasByIndex(Math.max(0, canvasIndex - this.canvasIncrementor()));
-    }
-  }
-
-  /**
-   */
-  hasPreviousCanvas() {
-    const { canvasIndex } = this.props;
-    return canvasIndex > 0;
-  }
-
-  /**
-   */
-  canvasIncrementor() {
-    const { view } = this.props;
-    switch (view) {
-      case 'book':
-        return 2;
-      default:
-        return 1;
+    const { hasPreviousCanvas, setPreviousCanvas } = this.props;
+    if (hasPreviousCanvas) {
+      setPreviousCanvas();
     }
   }
 
@@ -255,13 +229,20 @@ ThumbnailNavigation.propTypes = {
   canvasIndex: PropTypes.number.isRequired,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  hasNextCanvas: PropTypes.bool,
+  hasPreviousCanvas: PropTypes.bool,
   position: PropTypes.string.isRequired,
-  setCanvasByIndex: PropTypes.func.isRequired,
+  setNextCanvas: PropTypes.func,
+  setPreviousCanvas: PropTypes.func,
   t: PropTypes.func.isRequired,
   view: PropTypes.string,
   windowId: PropTypes.string.isRequired,
 };
 
 ThumbnailNavigation.defaultProps = {
+  hasNextCanvas: false,
+  hasPreviousCanvas: false,
+  setNextCanvas: () => {},
+  setPreviousCanvas: () => {},
   view: undefined,
 };

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -8,81 +8,28 @@ import ns from '../config/css-ns';
  */
 export class ViewerNavigation extends Component {
   /**
-   */
-  constructor(props) {
-    super(props);
-
-    this.nextCanvas = this.nextCanvas.bind(this);
-    this.previousCanvas = this.previousCanvas.bind(this);
-  }
-
-  /**
-   */
-  nextCanvas() {
-    const { canvasIndex, setCanvasByIndex } = this.props;
-    if (this.hasNextCanvas()) {
-      setCanvasByIndex(canvasIndex + this.canvasIncrementor());
-    }
-  }
-
-  /**
-   */
-  hasNextCanvas() {
-    const { canvasIndex, canvases } = this.props;
-    return canvasIndex < canvases.length - this.canvasIncrementor();
-  }
-
-  /**
-   */
-  previousCanvas() {
-    const { canvasIndex, setCanvasByIndex } = this.props;
-    if (this.hasPreviousCanvas()) {
-      setCanvasByIndex(Math.max(0, canvasIndex - this.canvasIncrementor()));
-    }
-  }
-
-  /**
-   */
-  hasPreviousCanvas() {
-    const { canvasIndex } = this.props;
-    return canvasIndex > 0;
-  }
-
-  /**
-   */
-  canvasIncrementor() {
-    const { canvasIndex, canvases, view } = this.props;
-    switch (view) {
-      case 'book':
-        // the case where the index is n - 1
-        if (canvasIndex === canvases.length - 2) return 1;
-        return 2;
-      default:
-        return 1;
-    }
-  }
-
-  /**
    * Renders things
    */
   render() {
-    const { t } = this.props;
+    const {
+      hasNextCanvas, hasPreviousCanvas, setNextCanvas, setPreviousCanvas, t,
+    } = this.props;
 
     return (
       <div className={ns('osd-navigation')}>
         <MiradorMenuButton
           aria-label={t('previousCanvas')}
           className={ns('previous-canvas-button')}
-          disabled={!this.hasPreviousCanvas()}
-          onClick={this.previousCanvas}
+          disabled={!hasPreviousCanvas}
+          onClick={() => { hasPreviousCanvas && setPreviousCanvas(); }}
         >
           <NavigationIcon style={{ transform: 'rotate(180deg)' }} />
         </MiradorMenuButton>
         <MiradorMenuButton
           aria-label={t('nextCanvas')}
           className={ns('next-canvas-button')}
-          disabled={!this.hasNextCanvas()}
-          onClick={this.nextCanvas}
+          disabled={!hasNextCanvas}
+          onClick={() => { hasNextCanvas && setNextCanvas(); }}
         >
           <NavigationIcon />
         </MiradorMenuButton>
@@ -92,13 +39,16 @@ export class ViewerNavigation extends Component {
 }
 
 ViewerNavigation.propTypes = {
-  canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  canvasIndex: PropTypes.number.isRequired,
-  setCanvasByIndex: PropTypes.func.isRequired,
+  hasNextCanvas: PropTypes.bool,
+  hasPreviousCanvas: PropTypes.bool,
+  setNextCanvas: PropTypes.func,
+  setPreviousCanvas: PropTypes.func,
   t: PropTypes.func.isRequired,
-  view: PropTypes.string,
 };
 
 ViewerNavigation.defaultProps = {
-  view: undefined,
+  hasNextCanvas: false,
+  hasPreviousCanvas: false,
+  setNextCanvas: () => {},
+  setPreviousCanvas: () => {},
 };

--- a/src/containers/ThumbnailNavigation.js
+++ b/src/containers/ThumbnailNavigation.js
@@ -6,7 +6,10 @@ import { withPlugins } from '../extend/withPlugins';
 import CanvasGroupings from '../lib/CanvasGroupings';
 import * as actions from '../state/actions';
 import { ThumbnailNavigation } from '../components/ThumbnailNavigation';
-import { getManifestCanvases, getCanvasIndex, getWindowViewType } from '../state/selectors';
+import {
+  getNextCanvasGrouping, getPreviousCanvasGrouping,
+  getManifestCanvases, getCanvasIndex, getWindowViewType,
+} from '../state/selectors';
 
 /**
  * mapStateToProps - used to hook up state to props
@@ -22,6 +25,8 @@ const mapStateToProps = (state, { windowId }) => {
     ),
     canvasIndex: getCanvasIndex(state, { windowId }),
     config: state.config,
+    hasNextCanvas: !!getNextCanvasGrouping(state, { windowId }),
+    hasPreviousCanvas: !!getPreviousCanvasGrouping(state, { windowId }),
     position: state.companionWindows[state.windows[windowId].thumbnailNavigationId].position,
     view: viewType,
   };
@@ -33,7 +38,8 @@ const mapStateToProps = (state, { windowId }) => {
  * @private
  */
 const mapDispatchToProps = (dispatch, { windowId }) => ({
-  setCanvasByIndex: (...args) => dispatch(actions.setCanvasByIndex(windowId, ...args)),
+  setNextCanvas: (...args) => dispatch(actions.setNextCanvas(windowId)),
+  setPreviousCanvas: (...args) => dispatch(actions.setPreviousCanvas(windowId)),
 });
 
 /**

--- a/src/containers/ViewerNavigation.js
+++ b/src/containers/ViewerNavigation.js
@@ -3,15 +3,13 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getManifestCanvases, getCanvasIndex, getWindowViewType } from '../state/selectors';
+import { getNextCanvasGrouping, getPreviousCanvasGrouping } from '../state/selectors';
 import { ViewerNavigation } from '../components/ViewerNavigation';
 
 /** */
 const mapStateToProps = (state, { windowId }) => ({
-  canvases: getManifestCanvases(state, { windowId }),
-  canvasIndex: getCanvasIndex(state, { windowId }),
-  view: getWindowViewType(state, { windowId }),
-  windowId: window.id,
+  hasNextCanvas: !!getNextCanvasGrouping(state, { windowId }),
+  hasPreviousCanvas: !!getPreviousCanvasGrouping(state, { windowId }),
 });
 
 /**
@@ -20,7 +18,8 @@ const mapStateToProps = (state, { windowId }) => ({
  * @private
  */
 const mapDispatchToProps = (dispatch, { windowId }) => ({
-  setCanvasByIndex: (...args) => dispatch(actions.setCanvasByIndex(windowId, ...args)),
+  setNextCanvas: (...args) => dispatch(actions.setNextCanvas(windowId)),
+  setPreviousCanvas: (...args) => dispatch(actions.setPreviousCanvas(windowId)),
 });
 
 const enhance = compose(

--- a/src/lib/CanvasGroupings.js
+++ b/src/lib/CanvasGroupings.js
@@ -10,11 +10,6 @@ export default class CanvasGroupings {
     this._groupings = null; // eslint-disable-line no-underscore-dangle
   }
 
-  /** */
-  getCanvasesById(canvasId) {
-    return this.groupings().find(group => group.some(c => c.id === canvasId));
-  }
-
   /**
    */
   getCanvases(index) {

--- a/src/state/actions/canvas.js
+++ b/src/state/actions/canvas.js
@@ -1,7 +1,8 @@
 import ActionTypes from './action-types';
 import {
   getCanvasGrouping,
-  getCanvas,
+  getNextCanvasGrouping,
+  getPreviousCanvasGrouping,
   getSearchAnnotationsForCompanionWindow,
   getSearchForWindow,
 } from '../selectors';
@@ -50,20 +51,22 @@ export function setCanvas(windowId, canvasId) {
   });
 }
 
-/**
- * setCanvasByIndex - action creator
- *
- * @param  {String} windowId
- * @param  {Number} canvasIndex
- * @memberof ActionCreators
- */
-export function setCanvasByIndex(windowId, canvasIndex) {
+/** Set the window's canvas to the next canvas grouping */
+export function setNextCanvas(windowId) {
+  return ((dispatch, getState) => {
+    const state = getState();
+    const newGroup = getNextCanvasGrouping(state, { windowId });
+    newGroup && dispatch(setCanvas(windowId, newGroup[0] && newGroup[0].id));
+  });
+}
+
+/** Set the window's canvas to the previous canvas grouping */
+export function setPreviousCanvas(windowId) {
   return ((dispatch, getState) => {
     const state = getState();
 
-    const canvas = getCanvas(state, { canvasIndex, windowId });
-
-    dispatch(setCanvas(windowId, canvas && canvas.id));
+    const newGroup = getPreviousCanvasGrouping(state, { windowId });
+    newGroup && dispatch(setCanvas(windowId, newGroup[0] && newGroup[0].id));
   });
 }
 

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -54,6 +54,27 @@ export function getVisibleCanvases(state, args) {
 }
 
 /**
+* Return the current canvases grouped by how they'll appear in the viewer
+* For book view returns groups of 2, for single returns 1
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
+* @return {Array}
+*/
+const getCanvasGroupings = createSelector(
+  [
+    getCanvases,
+    getWindowViewType,
+  ],
+  (canvases, view) => (canvases
+      && new CanvasGroupings(
+        canvases,
+        view,
+      ).groupings()),
+);
+
+/**
 * Return the current canvases selected in a window
 * For book view returns 2, for single returns 1
 * @param {object} state
@@ -64,15 +85,62 @@ export function getVisibleCanvases(state, args) {
 */
 export const getCanvasGrouping = createSelector(
   [
-    getCanvases,
+    getCanvasGroupings,
     (state, { canvasId }) => canvasId,
-    getWindowViewType,
   ],
-  (canvases, canvasId, view) => (canvases
-      && new CanvasGroupings(
-        canvases,
-        view,
-      ).getCanvasesById(canvasId)) || [],
+  (groupings, canvasId, view) => (groupings
+      && groupings.find(group => group.some(c => c.id === canvasId))) || [],
+);
+
+/**
+* Return the next canvas(es) for a window
+* For book view returns 2, for single returns 1
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
+* @return {Array}
+*/
+export const getNextCanvasGrouping = createSelector(
+  [
+    getCanvasGroupings,
+    getCurrentCanvas,
+  ],
+  (groupings, canvas, view) => {
+    if (!groupings) return undefined;
+    const currentGroupIndex = groupings.findIndex(group => group.some(c => c.id === canvas.id));
+
+    if (currentGroupIndex < 0 || currentGroupIndex + 1 >= groupings.length) return undefined;
+    const newGroup = groupings[currentGroupIndex + 1];
+
+    return newGroup;
+  },
+);
+
+/**
+* Return the previous canvas(es) for a window
+* For book view returns 2, for single returns 1
+* @param {object} state
+* @param {object} props
+* @param {string} props.manifestId
+* @param {string} props.windowId
+* @return {Array}
+*/
+export const getPreviousCanvasGrouping = createSelector(
+  [
+    getCanvasGroupings,
+    getCurrentCanvas,
+  ],
+  (groupings, canvas, view) => {
+    if (!groupings) return undefined;
+
+    const currentGroupIndex = groupings.findIndex(group => group.some(c => c.id === canvas.id));
+
+    if (currentGroupIndex < 1) return undefined;
+    const newGroup = groupings[currentGroupIndex - 1];
+
+    return newGroup;
+  },
 );
 
 /**


### PR DESCRIPTION
This eliminates our use of `setCanvasByIndex`, and instead provides actions for selecting the next/previous canvas(es). This consolidates some logic spread across multiple components into reusable selectors, and paves the way to support canvas-level viewing hints.