### PR TITLE
Refactor canvas nav

### DIFF
--- a/__tests__/src/components/SidebarIndexCompact.test.js
+++ b/__tests__/src/components/SidebarIndexCompact.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Typography from '@material-ui/core/Typography';
+import { SidebarIndexCompact } from '../../../src/components/SidebarIndexCompact';
+
+/** */
+function createWrapper(props) {
+  return shallow(
+    <SidebarIndexCompact
+      canvas={{ label: 'yolo' }}
+      classes={{}}
+      {...props}
+    />,
+  );
+}
+
+describe('SidebarIndexCompact', () => {
+  it('creates Typography with a canvas label', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(Typography).length).toBe(1);
+    expect(wrapper.text()).toBe('yolo');
+  });
+});

--- a/__tests__/src/components/SidebarIndexList.test.js
+++ b/__tests__/src/components/SidebarIndexList.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import manifesto from 'manifesto.js';
+import { SidebarIndexList } from '../../../src/components/SidebarIndexList';
+import SidebarIndexThumbnail from '../../../src/containers/SidebarIndexThumbnail';
+import SidebarIndexCompact from '../../../src/containers/SidebarIndexCompact';
+import manifestJson from '../../fixtures/version-2/019.json';
+
+/**
+ * Helper function to create a shallow wrapper around SidebarIndexList
+ */
+function createWrapper(props) {
+  const canvases = manifesto.create(manifestJson).getSequences()[0].getCanvases();
+
+  return shallow(
+    <SidebarIndexList
+      id="asdf"
+      canvases={canvases}
+      classes={{}}
+      t={key => key}
+      windowId="xyz"
+      setCanvas={() => {}}
+      config={{ canvasNavigation: { height: 100 } }}
+      updateVariant={() => {}}
+      selectedCanvases={[canvases[1]]}
+      {...props}
+    />,
+  );
+}
+
+describe('SidebarIndexList', () => {
+  let setCanvas;
+
+  beforeEach(() => {
+    setCanvas = jest.fn();
+  });
+
+  it('renders all needed elements for the thumbnail view', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(List).length).toBe(1);
+    expect(wrapper.find(ListItem).length).toBe(3);
+    expect(wrapper.find(ListItem).first().props().component).toEqual('li');
+    expect(wrapper.find(ListItem).at(1).props().selected).toBe(true);
+    expect(wrapper.find(List).find(SidebarIndexThumbnail).length).toBe(3);
+  });
+
+  it('renders all needed elements for the compact view', () => {
+    const wrapper = createWrapper({ variant: 'compact' });
+    expect(wrapper.find(List).length).toBe(1);
+    expect(wrapper.find(ListItem).length).toBe(3);
+    expect(wrapper.find(ListItem).first().props().component).toEqual('li');
+    expect(wrapper.find(List).find(SidebarIndexCompact).length).toBe(3);
+  });
+
+  it('should call the onClick handler of a list item', () => {
+    const wrapper = createWrapper({ setCanvas });
+    wrapper.find(ListItem).at(1).simulate('click');
+    expect(setCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  describe('getIdAndLabelOfCanvases', () => {
+    it('should return id and label of each canvas in manifest', () => {
+      const canvases = manifesto
+        .create(manifestJson)
+        .getSequences()[0]
+        .getCanvases();
+      const wrapper = createWrapper({ canvases });
+      const received = wrapper.instance().getIdAndLabelOfCanvases(canvases);
+      const expected = [
+        {
+          id: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json',
+          label: 'Test 19 Canvas: 1',
+        },
+        {
+          id: 'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
+          label: 'Image 1',
+        },
+        {
+          id: 'https://purl.stanford.edu/rz176rt6531/iiif/canvas/rz176rt6531_1',
+          label: 'Image 2',
+        },
+      ];
+      expect(received).toEqual(expected);
+    });
+
+    it('should return empty array if canvas if empty', () => {
+      const wrapper = createWrapper({ canvases: [] });
+      const received = wrapper.instance().getIdAndLabelOfCanvases([]);
+      expect(received).toEqual([]);
+    });
+  });
+});

--- a/__tests__/src/components/SidebarIndexThumbnail.test.js
+++ b/__tests__/src/components/SidebarIndexThumbnail.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Typography from '@material-ui/core/Typography';
+import manifesto from 'manifesto.js';
+import fixture from '../../fixtures/version-2/019.json';
+import { SidebarIndexThumbnail } from '../../../src/components/SidebarIndexThumbnail';
+import { CanvasThumbnail } from '../../../src/components/CanvasThumbnail';
+
+/** */
+function createWrapper(props) {
+  return shallow(
+    <SidebarIndexThumbnail
+      canvas={{ label: 'yolo' }}
+      otherCanvas={manifesto.create(fixture).getSequences()[0].getCanvases()[1]}
+      classes={{}}
+      config={{ canvasNavigation: { height: 200, width: 100 } }}
+      {...props}
+    />,
+  );
+}
+
+describe('SidebarIndexThumbnail', () => {
+  it('creates Typography with a canvas label', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(Typography).length).toBe(1);
+    expect(wrapper.text()).toEqual(expect.stringContaining('yolo'));
+  });
+  it('contains a CanvasThumbnail', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(CanvasThumbnail).length).toBe(1);
+  });
+});

--- a/__tests__/src/components/WindowSideBarCanvasPanel.test.js
+++ b/__tests__/src/components/WindowSideBarCanvasPanel.test.js
@@ -4,8 +4,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import manifesto from 'manifesto.js';
 import { WindowSideBarCanvasPanel } from '../../../src/components/WindowSideBarCanvasPanel';
-import SidebarIndexThumbnail from '../../../src/containers/SidebarIndexThumbnail';
-import SidebarIndexCompact from '../../../src/containers/SidebarIndexCompact';
+import SidebarIndexList from '../../../src/containers/SidebarIndexList';
 import CompanionWindow from '../../../src/containers/CompanionWindow';
 import manifestJson from '../../fixtures/version-2/019.json';
 
@@ -32,20 +31,10 @@ function createWrapper(props) {
 }
 
 describe('WindowSideBarCanvasPanel', () => {
-  let setCanvas;
-
-  beforeEach(() => {
-    setCanvas = jest.fn();
-  });
-
-  it('renders all needed elements for the thumbnail view', () => {
+  it('renders SidebarIndexList', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(CompanionWindow).props().title).toBe('canvasIndex');
-    expect(wrapper.find(List).length).toBe(1);
-    expect(wrapper.find(ListItem).length).toBe(3);
-    expect(wrapper.find(ListItem).first().props().component).toEqual('li');
-    expect(wrapper.find(ListItem).at(1).props().selected).toBe(true);
-    expect(wrapper.find(List).find(SidebarIndexThumbnail).length).toBe(3);
+    expect(wrapper.find(SidebarIndexList).length).toBe(1);
   });
 
   describe('handleVariantChange', () => {
@@ -54,53 +43,6 @@ describe('WindowSideBarCanvasPanel', () => {
       const wrapper = createWrapper({ updateVariant });
       wrapper.instance().handleVariantChange({ target: { value: 'compact' } });
       expect(updateVariant).toHaveBeenCalledWith('compact');
-    });
-  });
-
-  it('renders all needed elements for the compact view', () => {
-    const wrapper = createWrapper({ variant: 'compact' });
-    expect(wrapper.find(CompanionWindow).props().title).toBe('canvasIndex');
-    expect(wrapper.find(List).length).toBe(1);
-    expect(wrapper.find(ListItem).length).toBe(3);
-    expect(wrapper.find(ListItem).first().props().component).toEqual('li');
-    expect(wrapper.find(List).find(SidebarIndexCompact).length).toBe(3);
-  });
-
-  it('should call the onClick handler of a list item', () => {
-    const wrapper = createWrapper({ setCanvas });
-    wrapper.find(ListItem).at(1).simulate('click');
-    expect(setCanvas).toHaveBeenCalledTimes(1);
-  });
-
-  describe('getIdAndLabelOfCanvases', () => {
-    it('should return id and label of each canvas in manifest', () => {
-      const canvases = manifesto
-        .create(manifestJson)
-        .getSequences()[0]
-        .getCanvases();
-      const wrapper = createWrapper({ canvases });
-      const received = wrapper.instance().getIdAndLabelOfCanvases(canvases);
-      const expected = [
-        {
-          id: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json',
-          label: 'Test 19 Canvas: 1',
-        },
-        {
-          id: 'https://purl.stanford.edu/fr426cg9537/iiif/canvas/fr426cg9537_1',
-          label: 'Image 1',
-        },
-        {
-          id: 'https://purl.stanford.edu/rz176rt6531/iiif/canvas/rz176rt6531_1',
-          label: 'Image 2',
-        },
-      ];
-      expect(received).toEqual(expected);
-    });
-
-    it('should return empty array if canvas if empty', () => {
-      const wrapper = createWrapper({ canvases: [] });
-      const received = wrapper.instance().getIdAndLabelOfCanvases([]);
-      expect(received).toEqual([]);
     });
   });
 });

--- a/__tests__/src/components/WindowSideBarCanvasPanel.test.js
+++ b/__tests__/src/components/WindowSideBarCanvasPanel.test.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
-import Typography from '@material-ui/core/Typography';
 import manifesto from 'manifesto.js';
 import { WindowSideBarCanvasPanel } from '../../../src/components/WindowSideBarCanvasPanel';
-import { CanvasThumbnail } from '../../../src/components/CanvasThumbnail';
+import SidebarIndexThumbnail from '../../../src/containers/SidebarIndexThumbnail';
+import SidebarIndexCompact from '../../../src/containers/SidebarIndexCompact';
 import CompanionWindow from '../../../src/containers/CompanionWindow';
 import manifestJson from '../../fixtures/version-2/019.json';
 
@@ -45,8 +45,7 @@ describe('WindowSideBarCanvasPanel', () => {
     expect(wrapper.find(ListItem).length).toBe(3);
     expect(wrapper.find(ListItem).first().props().component).toEqual('li');
     expect(wrapper.find(ListItem).at(1).props().selected).toBe(true);
-    expect(wrapper.find(List).find(Typography).length).toBe(3);
-    expect(wrapper.find(CanvasThumbnail).length).toBe(3);
+    expect(wrapper.find(List).find(SidebarIndexThumbnail).length).toBe(3);
   });
 
   describe('handleVariantChange', () => {
@@ -64,27 +63,7 @@ describe('WindowSideBarCanvasPanel', () => {
     expect(wrapper.find(List).length).toBe(1);
     expect(wrapper.find(ListItem).length).toBe(3);
     expect(wrapper.find(ListItem).first().props().component).toEqual('li');
-    expect(wrapper.find(List).find(Typography).length).toBe(3);
-    expect(wrapper.find(CanvasThumbnail).length).toBe(0);
-  });
-
-
-  it('should set the correct labels', () => {
-    const wrapper = createWrapper();
-
-    expect(wrapper
-      .find(List)
-      .find(Typography)
-      .at(0)
-      .render()
-      .text()).toBe('Test 19 Canvas: 1');
-
-    expect(wrapper
-      .find(List)
-      .find(Typography)
-      .at(1)
-      .render()
-      .text()).toBe('Image 1');
+    expect(wrapper.find(List).find(SidebarIndexCompact).length).toBe(3);
   });
 
   it('should call the onClick handler of a list item', () => {

--- a/src/components/SidebarIndexCompact.js
+++ b/src/components/SidebarIndexCompact.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import classNames from 'classnames';
+
+/** */
+export class SidebarIndexCompact extends Component {
+  /** */
+  render() {
+    const {
+      classes, canvas,
+    } = this.props;
+
+    return (
+      <>
+        <Typography
+          className={classNames(classes.label)}
+          variant="body1"
+        >
+          {canvas.label}
+        </Typography>
+      </>
+    );
+  }
+}
+
+SidebarIndexCompact.propTypes = {
+  canvas: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+};

--- a/src/components/SidebarIndexList.js
+++ b/src/components/SidebarIndexList.js
@@ -1,0 +1,83 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import { ScrollTo } from './ScrollTo';
+import ManifestoCanvas from '../lib/ManifestoCanvas';
+import SidebarIndexCompact from '../containers/SidebarIndexCompact';
+import SidebarIndexThumbnail from '../containers/SidebarIndexThumbnail';
+
+/** */
+export class SidebarIndexList extends Component {
+  /** @private */
+  getIdAndLabelOfCanvases() {
+    const { canvases } = this.props;
+
+    return canvases.map((canvas, index) => ({
+      id: canvas.id,
+      label: new ManifestoCanvas(canvas).getLabel(),
+    }));
+  }
+
+  /** */
+  render() {
+    const {
+      canvases,
+      classes,
+      containerRef,
+      selectedCanvases,
+      setCanvas,
+      variant,
+      windowId,
+    } = this.props;
+
+    const canvasesIdAndLabel = this.getIdAndLabelOfCanvases(canvases);
+
+    return (
+      <List>
+        {
+          canvasesIdAndLabel.map((canvas, canvasIndex) => {
+            const onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
+
+            return (
+              <ScrollTo
+                containerRef={containerRef}
+                key={`${canvas.id}-${variant}`}
+                offsetTop={96} // offset for the height of the form above
+                scrollTo={!!selectedCanvases.find(c => c.id === canvas.id)}
+              >
+                <ListItem
+                  key={canvas.id}
+                  className={classes.listItem}
+                  alignItems="flex-start"
+                  onClick={onClick}
+                  button
+                  component="li"
+                  selected={!!selectedCanvases.find(c => c.id === canvas.id)}
+                >
+                  {variant === 'compact' && <SidebarIndexCompact canvas={canvas} />}
+                  {variant === 'thumbnail' && <SidebarIndexThumbnail canvas={canvas} otherCanvas={canvases[canvasIndex]} />}
+                </ListItem>
+              </ScrollTo>
+            );
+          })
+        }
+      </List>
+    );
+  }
+}
+
+SidebarIndexList.propTypes = {
+  canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  containerRef: PropTypes.oneOf([PropTypes.func, PropTypes.object]).isRequired,
+  selectedCanvases: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string })),
+  setCanvas: PropTypes.func.isRequired,
+  variant: PropTypes.oneOf(['compact', 'thumbnail']),
+  windowId: PropTypes.string.isRequired,
+};
+
+SidebarIndexList.defaultProps = {
+  selectedCanvases: [],
+  variant: 'thumbnail',
+};

--- a/src/components/SidebarIndexThumbnail.js
+++ b/src/components/SidebarIndexThumbnail.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import classNames from 'classnames';
+import ManifestoCanvas from '../lib/ManifestoCanvas';
+import { CanvasThumbnail } from './CanvasThumbnail';
+
+/** */
+export class SidebarIndexThumbnail extends Component {
+  /** */
+  render() {
+    const {
+      classes, config, otherCanvas, canvas,
+    } = this.props;
+
+    const { width, height } = config.canvasNavigation;
+    const manifestoCanvas = new ManifestoCanvas(otherCanvas);
+
+    return (
+      <>
+        <div style={{ minWidth: 50 }}>
+          <CanvasThumbnail
+            className={classNames(classes.clickable)}
+            isValid={manifestoCanvas.hasValidDimensions}
+            imageUrl={manifestoCanvas.thumbnail(width, height)}
+            maxHeight={config.canvasNavigation.height}
+            maxWidth={config.canvasNavigation.width}
+            aspectRatio={manifestoCanvas.aspectRatio}
+          />
+        </div>
+        <Typography
+          className={classNames(classes.label)}
+          variant="body1"
+        >
+          {canvas.label}
+        </Typography>
+      </>
+    );
+  }
+}
+
+SidebarIndexThumbnail.propTypes = {
+  canvas: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  otherCanvas: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -1,17 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
 import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import RootRef from '@material-ui/core/RootRef';
 import Select from '@material-ui/core/Select';
-import { ScrollTo } from './ScrollTo';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
 import CompanionWindow from '../containers/CompanionWindow';
-import SidebarIndexCompact from '../containers/SidebarIndexCompact';
-import SidebarIndexThumbnail from '../containers/SidebarIndexThumbnail';
+import SidebarIndexList from '../containers/SidebarIndexList';
 
 /**
  * a panel showing the canvases for a given manifest
@@ -30,16 +25,6 @@ export class WindowSideBarCanvasPanel extends Component {
   }
 
   /** @private */
-  getIdAndLabelOfCanvases() {
-    const { canvases } = this.props;
-
-    return canvases.map((canvas, index) => ({
-      id: canvas.id,
-      label: new ManifestoCanvas(canvas).getLabel(),
-    }));
-  }
-
-  /** @private */
   handleVariantChange(event) {
     const { updateVariant } = this.props;
 
@@ -52,11 +37,8 @@ export class WindowSideBarCanvasPanel extends Component {
    */
   render() {
     const {
-      canvases,
       classes,
       id,
-      selectedCanvases,
-      setCanvas,
       t,
       toggleDraggingEnabled,
       variant,
@@ -64,7 +46,6 @@ export class WindowSideBarCanvasPanel extends Component {
     } = this.props;
 
     const { variantSelectionOpened } = this.state;
-    const canvasesIdAndLabel = this.getIdAndLabelOfCanvases(canvases);
     return (
       <RootRef rootRef={this.containerRef}>
         <CompanionWindow
@@ -103,35 +84,7 @@ export class WindowSideBarCanvasPanel extends Component {
             </FormControl>
           )}
         >
-          <List>
-            {
-              canvasesIdAndLabel.map((canvas, canvasIndex) => {
-                const onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
-
-                return (
-                  <ScrollTo
-                    containerRef={this.containerRef}
-                    key={`${canvas.id}-${variant}`}
-                    offsetTop={96} // offset for the height of the form above
-                    scrollTo={!!selectedCanvases.find(c => c.id === canvas.id)}
-                  >
-                    <ListItem
-                      key={canvas.id}
-                      className={classes.listItem}
-                      alignItems="flex-start"
-                      onClick={onClick}
-                      button
-                      component="li"
-                      selected={!!selectedCanvases.find(c => c.id === canvas.id)}
-                    >
-                      {variant === 'compact' && <SidebarIndexCompact canvas={canvas} />}
-                      {variant === 'thumbnail' && <SidebarIndexThumbnail canvas={canvas} otherCanvas={canvases[canvasIndex]} />}
-                    </ListItem>
-                  </ScrollTo>
-                );
-              })
-            }
-          </List>
+          <SidebarIndexList id={id} containerRef={this.containerRef} windowId={windowId} />
         </CompanionWindow>
       </RootRef>
     );
@@ -139,11 +92,8 @@ export class WindowSideBarCanvasPanel extends Component {
 }
 
 WindowSideBarCanvasPanel.propTypes = {
-  canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   id: PropTypes.string.isRequired,
-  selectedCanvases: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string })),
-  setCanvas: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   toggleDraggingEnabled: PropTypes.func.isRequired,
   updateVariant: PropTypes.func.isRequired,
@@ -152,6 +102,5 @@ WindowSideBarCanvasPanel.propTypes = {
 };
 
 WindowSideBarCanvasPanel.defaultProps = {
-  selectedCanvases: [],
   variant: 'thumbnail',
 };

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -8,10 +7,11 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import RootRef from '@material-ui/core/RootRef';
 import Select from '@material-ui/core/Select';
-import { CanvasThumbnail } from './CanvasThumbnail';
 import { ScrollTo } from './ScrollTo';
 import ManifestoCanvas from '../lib/ManifestoCanvas';
 import CompanionWindow from '../containers/CompanionWindow';
+import SidebarIndexCompact from '../containers/SidebarIndexCompact';
+import SidebarIndexThumbnail from '../containers/SidebarIndexThumbnail';
 
 /**
  * a panel showing the canvases for a given manifest
@@ -45,54 +45,6 @@ export class WindowSideBarCanvasPanel extends Component {
 
     updateVariant(event.target.value);
     this.setState({ variantSelectionOpened: false });
-  }
-
-  /** */
-  renderCompact(canvas, otherCanvas) {
-    const {
-      classes,
-    } = this.props;
-
-    return (
-      <>
-        <Typography
-          className={classNames(classes.label)}
-          variant="body1"
-        >
-          {canvas.label}
-        </Typography>
-      </>
-    );
-  }
-
-  /** */
-  renderThumbnail(canvas, otherCanvas) {
-    const {
-      classes, config,
-    } = this.props;
-    const { width, height } = config.canvasNavigation;
-    const manifestoCanvas = new ManifestoCanvas(otherCanvas);
-
-    return (
-      <>
-        <div style={{ minWidth: 50 }}>
-          <CanvasThumbnail
-            className={classNames(classes.clickable)}
-            isValid={manifestoCanvas.hasValidDimensions}
-            imageUrl={manifestoCanvas.thumbnail(width, height)}
-            maxHeight={config.canvasNavigation.height}
-            maxWidth={config.canvasNavigation.width}
-            aspectRatio={manifestoCanvas.aspectRatio}
-          />
-        </div>
-        <Typography
-          className={classNames(classes.label)}
-          variant="body1"
-        >
-          {canvas.label}
-        </Typography>
-      </>
-    );
   }
 
   /**
@@ -172,8 +124,8 @@ export class WindowSideBarCanvasPanel extends Component {
                       component="li"
                       selected={!!selectedCanvases.find(c => c.id === canvas.id)}
                     >
-                      {variant === 'compact' && this.renderCompact(canvas, canvases[canvasIndex])}
-                      {variant === 'thumbnail' && this.renderThumbnail(canvas, canvases[canvasIndex])}
+                      {variant === 'compact' && <SidebarIndexCompact canvas={canvas} />}
+                      {variant === 'thumbnail' && <SidebarIndexThumbnail canvas={canvas} otherCanvas={canvases[canvasIndex]} />}
                     </ListItem>
                   </ScrollTo>
                 );
@@ -189,7 +141,6 @@ export class WindowSideBarCanvasPanel extends Component {
 WindowSideBarCanvasPanel.propTypes = {
   canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
-  config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   id: PropTypes.string.isRequired,
   selectedCanvases: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string })),
   setCanvas: PropTypes.func.isRequired,

--- a/src/containers/SidebarIndexCompact.js
+++ b/src/containers/SidebarIndexCompact.js
@@ -1,0 +1,24 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
+import { withPlugins } from '../extend/withPlugins';
+import { SidebarIndexCompact } from '../components/SidebarIndexCompact';
+
+/**
+ * Styles for withStyles HOC
+ */
+const styles = theme => ({
+  label: {
+    paddingLeft: theme.spacing(1),
+  },
+});
+
+const enhance = compose(
+  withStyles(styles),
+  withTranslation(),
+  connect(null, null),
+  withPlugins('SidebarIndexCompact'),
+);
+
+export default enhance(SidebarIndexCompact);

--- a/src/containers/SidebarIndexList.js
+++ b/src/containers/SidebarIndexList.js
@@ -4,22 +4,20 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { WindowSideBarCanvasPanel } from '../components/WindowSideBarCanvasPanel';
 import {
   getCompanionWindow,
   getManifestCanvases,
   getVisibleCanvases,
 } from '../state/selectors';
+import { SidebarIndexList } from '../components/SidebarIndexList';
 
 /**
  * mapStateToProps - to hook up connect
  */
 const mapStateToProps = (state, { id, windowId }) => {
   const canvases = getManifestCanvases(state, { windowId });
-  const { config } = state;
   return {
     canvases,
-    config,
     selectedCanvases: getVisibleCanvases(state, { windowId }),
     variant: getCompanionWindow(state, { companionWindowId: id, windowId }).variant,
   };
@@ -27,40 +25,31 @@ const mapStateToProps = (state, { id, windowId }) => {
 
 /**
  * mapStateToProps - used to hook up connect to state
- * @memberof WindowSideBarCanvasPanel
+ * @memberof SidebarIndexList
  * @private
  */
 const mapDispatchToProps = (dispatch, { id, windowId }) => ({
   setCanvas: (...args) => dispatch(actions.setCanvas(...args)),
-  toggleDraggingEnabled: () => dispatch(actions.toggleDraggingEnabled()),
-  updateVariant: variant => dispatch(
-    actions.updateCompanionWindow(windowId, id, { variant }),
-  ),
 });
 
 /**
- *
- * @param theme
+ * Styles for withStyles HOC
  */
 const styles = theme => ({
   label: {
     paddingLeft: theme.spacing(1),
   },
-  select: {
-    '&:focus': {
-      backgroundColor: theme.palette.background.paper,
-    },
-  },
-  selectEmpty: {
-    backgroundColor: theme.palette.background.paper,
+  listItem: {
+    borderBottom: `0.5px solid ${theme.palette.divider}`,
+    paddingRight: theme.spacing(1),
   },
 });
 
 const enhance = compose(
-  withTranslation(),
   withStyles(styles),
+  withTranslation(),
   connect(mapStateToProps, mapDispatchToProps),
-  withPlugins('WindowSideBarCanvasPanel'),
+  withPlugins('SidebarIndexList'),
 );
 
-export default enhance(WindowSideBarCanvasPanel);
+export default enhance(SidebarIndexList);

--- a/src/containers/SidebarIndexThumbnail.js
+++ b/src/containers/SidebarIndexThumbnail.js
@@ -1,0 +1,33 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import { withStyles } from '@material-ui/core/styles';
+import { withPlugins } from '../extend/withPlugins';
+import { SidebarIndexThumbnail } from '../components/SidebarIndexThumbnail';
+
+/**
+ * mapStateToProps - used to hook up state to props
+ * @memberof SidebarIndexThumbnail
+ * @private
+ */
+const mapStateToProps = (state, { data }) => ({
+  config: state.config,
+});
+
+/**
+ * Styles for withStyles HOC
+ */
+const styles = theme => ({
+  label: {
+    paddingLeft: theme.spacing(1),
+  },
+});
+
+const enhance = compose(
+  withStyles(styles),
+  withTranslation(),
+  connect(mapStateToProps, null),
+  withPlugins('SidebarIndexThumbnail'),
+);
+
+export default enhance(SidebarIndexThumbnail);


### PR DESCRIPTION
In looking at how to integrate #2392 , it became clear that there needed to be some work on the existing components to open them up to be more receptive to the TOC work. 

This PR extracts components out of the existing `WindowSideBarCanvasPanel` in anticipation of a Table of COntents component.

Also worth noting while working on this, I looked at addressing performance issues with manifests with a large number of canvases but had issues with that. Spun out to #2856