### PR TITLE
Update material-ui and remove react-placeholder dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
     "@babel/plugin-transform-runtime",
     "transform-react-remove-prop-types",
     ["lodash", { "id": [
-      "lodash", "react-placeholder",
+      "lodash",
       ]}
     ]],
 }

--- a/__tests__/src/components/ManifestListItem.test.js
+++ b/__tests__/src/components/ManifestListItem.test.js
@@ -36,7 +36,7 @@ describe('ManifestListItem', () => {
     const wrapper = createWrapper({ ready: false });
 
     expect(wrapper.find('.mirador-manifest-list-item').length).toBe(1);
-    expect(wrapper.find('ReactPlaceholder').length > 0).toBe(true);
+    expect(wrapper.find('WithStyles(ForwardRef(Skeleton))').length > 0).toBe(true);
   });
   it('renders an error message if fetching the manifest failed', () => {
     const wrapper = createWrapper({ error: 'This is an error message' });

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   ],
   "repository": "https://github.com/ProjectMirador/mirador",
   "dependencies": {
-    "@material-ui/core": "^4.2.0",
+    "@material-ui/core": "^4.2.2",
     "@material-ui/icons": "^4.2.1",
+    "@material-ui/lab": "^4.0.0-alpha.23",
     "@researchgate/react-intersection-observer": "^1.0.0",
     "classnames": "^2.2.6",
     "clsx": "^1.0.4",
@@ -55,7 +56,6 @@
     "react-iframe-comm": "^1.2.2",
     "react-image": "^2.1.3",
     "react-mosaic-component": "^3.2.0",
-    "react-placeholder": "^3.0.1",
     "react-redux": "^7.1.0",
     "react-resize-observer": "^1.1.1",
     "react-rnd": "^9.2.0",

--- a/src/components/AttributionPanel.js
+++ b/src/components/AttributionPanel.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import { RectShape } from 'react-placeholder/lib/placeholders';
+import Skeleton from '@material-ui/lab/Skeleton';
 import Img from 'react-image';
 import CompanionWindow from '../containers/CompanionWindow';
 import { LabelValueMetadata } from './LabelValueMetadata';
@@ -60,7 +60,7 @@ export class AttributionPanel extends Component {
               role="presentation"
               className={classes.logo}
               unloader={
-                <RectShape className={classes.placeholder} style={{ height: 60, width: 60 }} />
+                <Skeleton className={classes.placeholder} variant="rect" height={60} width={60} />
               }
             />
           </div>

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -4,12 +4,10 @@ import ListItem from '@material-ui/core/ListItem';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { ReactPlaceholder } from 'react-placeholder/lib';
-import { TextBlock, TextRow, RectShape } from 'react-placeholder/lib/placeholders';
+import Skeleton from '@material-ui/lab/Skeleton';
 import Img from 'react-image';
 import ManifestListItemError from '../containers/ManifestListItemError';
 import ns from '../config/css-ns';
-import 'react-placeholder/lib/reactPlaceholder.css';
 
 /**
  * Handling open button click
@@ -55,16 +53,17 @@ export class ManifestListItem extends React.Component {
     const placeholder = (
       <Grid container className={ns('manifest-list-item')} spacing={2}>
         <Grid item xs={3} sm={2}>
-          <RectShape color="gray" style={{ height: 80, width: 120 }} />
+          <Skeleton className={classes.placeholder} variant="rect" height={80} width={120} />
         </Grid>
         <Grid item xs={9} sm={6}>
-          <TextRow color="gray" />
+          <Skeleton className={classes.placeholder} variant="text" />
         </Grid>
         <Grid item xs={8} sm={2}>
-          <TextBlock rows={2} color="gray" />
+          <Skeleton className={classes.placeholder} variant="text" />
+          <Skeleton className={classes.placeholder} variant="text" />
         </Grid>
         <Grid item xs={4} sm={2}>
-          <RectShape color="gray" style={{ height: 60, width: 60 }} />
+          <Skeleton className={classes.placeholder} variant="rect" height={60} width={60} />
         </Grid>
       </Grid>
     );
@@ -79,12 +78,7 @@ export class ManifestListItem extends React.Component {
 
     return (
       <ListItem divider elevation={1} className={[classes.root, active ? classes.active : ''].join(' ')} data-manifestid={manifestId}>
-        <ReactPlaceholder
-          showLoadingAnimation
-          delay={500}
-          ready={ready}
-          customPlaceholder={placeholder}
-        >
+        {ready ? (
           <Grid container className={ns('manifest-list-item')} spacing={2}>
             <Grid item xs={12} sm={6} className={classes.buttonGrid}>
               <ButtonBase
@@ -102,9 +96,12 @@ export class ManifestListItem extends React.Component {
                       alt=""
                       height="80"
                       unloader={(
-                        <RectShape
+                        <Skeleton
+                          variant="rect"
+                          disableAnimate
                           className={classes.placeholder}
-                          style={{ height: 80, width: 120 }}
+                          height={80}
+                          width={120}
                         />
                       )}
                     />
@@ -128,13 +125,21 @@ export class ManifestListItem extends React.Component {
                 alt=""
                 role="presentation"
                 className={classes.logo}
-                unloader={
-                  <RectShape className={classes.placeholder} style={{ height: 60, width: 60 }} />
-                }
+                unloader={(
+                  <Skeleton
+                    variant="rect"
+                    disableAnimate
+                    className={classes.placeholder}
+                    height={60}
+                    width={60}
+                  />
+                )}
               />
             </Grid>
           </Grid>
-        </ReactPlaceholder>
+        ) : (
+          placeholder
+        )}
       </ListItem>
     );
   }


### PR DESCRIPTION
This PR updates Material-UI and adds Material-Labs. Also removes react-placeholder.

Reduces the minified gzipped bundle by another 2KB. 

The color might be a little bit different than the implementation from react-placeholder, so just want to get a reaction from @jvine or @ggeisler about that. Currently they use the hover color it seems to do the animation.

![skeleton](https://user-images.githubusercontent.com/1656824/62826622-dd51ae00-bb7b-11e9-9630-28646c5c3a79.gif)

