### PR TITLE
Extend our existing modeling of Annotations to handle OpenAnnot…

### DIFF
--- a/__tests__/fixtures/version-3/001.json
+++ b/__tests__/fixtures/version-3/001.json
@@ -269,6 +269,33 @@
           ]
         }
       ],
+      "annotations": [
+        {
+          "id": "https://example.org/iiif/foo/bar/annopage/",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/iiif/book1/page/manifest/a1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "TextualBody",
+                "language": "en",
+                "value": "I love this!"
+              },
+              "target": "https://iiif.bodleian.ox.ac.uk/iiif/canvas/9cca8fdd-4a61-4429-8ac1-f648764b4d6d.json#xywh=2000,500,2000,2000"
+            }
+          ]
+        },
+        {
+          "id": "https://example.org/iiif/foo/bar/annopage/remote/1",
+          "type": "AnnotationPage"
+        },
+        {
+          "id": "https://example.org/iiif/foo/bar/annopage/remote/2",
+          "type": "AnnotationPage"
+        }
+      ],
       "metadata": [
         {
           "label": {

--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -4,7 +4,7 @@ import OpenSeadragon from 'openseadragon';
 import manifesto from 'manifesto.js';
 import { OpenSeadragonViewer } from '../../../src/components/OpenSeadragonViewer';
 import OpenSeadragonCanvasOverlay from '../../../src/lib/OpenSeadragonCanvasOverlay';
-import Annotation from '../../../src/lib/Annotation';
+import AnnotationList from '../../../src/lib/AnnotationList';
 import CanvasWorld from '../../../src/lib/CanvasWorld';
 import fixture from '../../fixtures/version-2/019.json';
 
@@ -273,7 +273,7 @@ describe('OpenSeadragonViewer', () => {
       wrapper.setProps(
         {
           selectedAnnotations: [
-            new Annotation(
+            new AnnotationList(
               { '@id': 'foo', resources: [{ foo: 'bar' }] },
             ),
           ],
@@ -282,7 +282,7 @@ describe('OpenSeadragonViewer', () => {
       wrapper.setProps(
         {
           selectedAnnotations: [
-            new Annotation(
+            new AnnotationList(
               { '@id': 'foo', resources: [{ foo: 'bar' }] },
             ),
           ],
@@ -291,7 +291,7 @@ describe('OpenSeadragonViewer', () => {
       wrapper.setProps(
         {
           selectedAnnotations: [
-            new Annotation(
+            new AnnotationList(
               { '@id': 'bar', resources: [{ foo: 'bar' }] },
             ),
           ],
@@ -348,7 +348,7 @@ describe('OpenSeadragonViewer', () => {
       };
 
       const annotations = [
-        new Annotation(
+        new AnnotationList(
           { '@id': 'foo', resources: [{ on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=10,10,100,200' }] },
         ),
       ];

--- a/__tests__/src/lib/AnnotationFactory.test.js
+++ b/__tests__/src/lib/AnnotationFactory.test.js
@@ -1,0 +1,27 @@
+import AnnotationFactory from '../../../src/lib/AnnotationFactory';
+import AnnotationList from '../../../src/lib/AnnotationList';
+import AnnotationPage from '../../../src/lib/AnnotationPage';
+
+describe('AnnotationFactory', () => {
+  describe('determineAnnotation', () => {
+    describe('when falsey', () => {
+      it('returns null', () => {
+        expect(AnnotationFactory.determineAnnotation(undefined)).toBeNull();
+      });
+    });
+    describe('when Presentation v3', () => {
+      it('returns an AnnotationPage', () => {
+        expect(AnnotationFactory.determineAnnotation({
+          type: 'AnnotationPage',
+        })).toBeInstanceOf(AnnotationPage);
+      });
+    });
+    describe('when Presentation v2', () => {
+      it('returns an AnnotationPage', () => {
+        expect(AnnotationFactory.determineAnnotation({
+          '@type': 'AnnotationList',
+        })).toBeInstanceOf(AnnotationList);
+      });
+    });
+  });
+});

--- a/__tests__/src/lib/AnnotationItem.test.js
+++ b/__tests__/src/lib/AnnotationItem.test.js
@@ -1,0 +1,95 @@
+import AnnotationItem from '../../../src/lib/AnnotationItem';
+
+describe('AnnotationItem', () => {
+  describe('id', () => {
+    it('returns the id', () => {
+      expect(new AnnotationItem({ id: 'foo' }).id).toEqual('foo');
+    });
+    it('creates a memoized uuid', () => {
+      const annoResource = new AnnotationItem();
+      const expected = annoResource.id;
+      expect(annoResource.id).toEqual(expected);
+    });
+  });
+
+  describe('targetId', () => {
+    it('removes fragmentSelector coords from string targets', () => {
+      expect(
+        new AnnotationItem({ target: 'www.example.com/#xywh=10,10,100,200' }).targetId,
+      ).toEqual('www.example.com/');
+    });
+
+    it('returns null when there is no target', () => {
+      expect(new AnnotationItem().targetId).toBeNull();
+    });
+  });
+
+  describe('motivations', () => {
+    it('with no motivation', () => {
+      expect(new AnnotationItem().motivations).toEqual([]);
+    });
+    it('with a single motivation', () => {
+      expect(new AnnotationItem({ motivation: 'commenting' })
+        .motivations).toEqual(['commenting']);
+    });
+    it('with multiple motivations', () => {
+      expect(new AnnotationItem({ motivation: ['commenting', 'funstuff'] })
+        .motivations).toEqual(['commenting', 'funstuff']);
+    });
+  });
+  describe('resources/body', () => {
+    it('with no body', () => {
+      expect(new AnnotationItem().resources).toEqual([]);
+      expect(new AnnotationItem().body).toEqual([]);
+    });
+    it('with a single body', () => {
+      expect(new AnnotationItem({ body: 'foo' })
+        .resources).toEqual(['foo']);
+      expect(new AnnotationItem({ body: 'foo' })
+        .body).toEqual(['foo']);
+    });
+    it('with multiple bodies', () => {
+      expect(new AnnotationItem({ body: ['foo', 'bar'] })
+        .resources).toEqual(['foo', 'bar']);
+      expect(new AnnotationItem({ body: ['foo', 'bar'] })
+        .body).toEqual(['foo', 'bar']);
+    });
+  });
+  describe('target', () => {
+    it('with no target', () => {
+      expect(new AnnotationItem().target).toEqual([]);
+    });
+    it('with a single target', () => {
+      expect(new AnnotationItem({ target: 'foo' })
+        .target).toEqual(['foo']);
+    });
+    it('with multiple target', () => {
+      expect(new AnnotationItem({ target: ['foo', 'bar'] })
+        .target).toEqual(['foo', 'bar']);
+    });
+  });
+  describe('selector', () => {
+    it('returns the on string (for simple fragment selector)', () => {
+      expect(new AnnotationItem({ target: 'yolo' }).selector).toEqual('yolo');
+    });
+  });
+  describe('chars', () => {
+    it('with no resource', () => {
+      expect(new AnnotationItem().chars).toEqual('');
+    });
+    it('with a single body', () => {
+      expect(new AnnotationItem({ body: { value: 'foo' } })
+        .chars).toEqual('foo');
+    });
+    it('with multiple bodies', () => {
+      expect(new AnnotationItem({ body: [{ value: 'foo' }, { value: 'bar' }] })
+        .chars).toEqual('foo bar');
+    });
+  });
+  describe('fragmentSelector', () => {
+    it('simple string', () => {
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=10,10,100,200' })
+        .fragmentSelector).toEqual([10, 10, 100, 200]);
+    });
+  });
+});

--- a/__tests__/src/lib/AnnotationList.test.js
+++ b/__tests__/src/lib/AnnotationList.test.js
@@ -1,30 +1,30 @@
-import Annotation from '../../../src/lib/Annotation';
+import AnnotationList from '../../../src/lib/AnnotationList';
 import AnnotationResource from '../../../src/lib/AnnotationResource';
 
-describe('Annotation', () => {
+describe('AnnotationList', () => {
   describe('id', () => {
     it('returns the @id', () => {
-      expect(new Annotation({ '@id': 'foo' }).id).toEqual('foo');
+      expect(new AnnotationList({ '@id': 'foo' }).id).toEqual('foo');
     });
   });
   describe('present', () => {
     it('checks for json', () => {
-      expect(new Annotation().present()).toEqual(false);
+      expect(new AnnotationList().present()).toEqual(false);
     });
     it('checks for resources', () => {
-      expect(new Annotation({ '@id': 'foo' }).present()).toEqual(false);
-      expect(new Annotation({ resources: [] }).present()).toEqual(false);
+      expect(new AnnotationList({ '@id': 'foo' }).present()).toEqual(false);
+      expect(new AnnotationList({ resources: [] }).present()).toEqual(false);
     });
   });
   describe('resources', () => {
     it('maps resources to AnnotationResource', () => {
-      new Annotation(
+      new AnnotationList(
         { resources: [{ foo: 'bar' }] },
       ).resources.forEach(resource => expect(resource).toBeInstanceOf(AnnotationResource));
     });
 
     it('handles resources that are just a single object instead of an array of objects', () => {
-      new Annotation(
+      new AnnotationList(
         { resources: { foo: 'bar' } },
       ).resources.forEach(resource => expect(resource).toBeInstanceOf(AnnotationResource));
     });

--- a/__tests__/src/lib/AnnotationPage.test.js
+++ b/__tests__/src/lib/AnnotationPage.test.js
@@ -1,0 +1,32 @@
+import AnnotationPage from '../../../src/lib/AnnotationPage';
+
+describe('AnnotationPage', () => {
+  describe('id', () => {
+    it('returns the id', () => {
+      expect(new AnnotationPage({ id: 'foo' }).id).toEqual('foo');
+    });
+  });
+  describe('present', () => {
+    it('checks for json', () => {
+      expect(new AnnotationPage().present()).toEqual(false);
+    });
+    it('checks for items', () => {
+      expect(new AnnotationPage({ id: 'foo' }).present()).toEqual(false);
+      expect(new AnnotationPage({ items: [] }).present()).toEqual(false);
+    });
+  });
+  describe('items', () => {
+    it('returns items', () => {
+      expect(new AnnotationPage(
+        { items: [{ foo: 'bar' }] },
+      ).items).toEqual([{ foo: 'bar' }]);
+    });
+  });
+  describe('resources', () => {
+    it('returns items', () => {
+      expect(new AnnotationPage(
+        { items: [{ foo: 'bar' }] },
+      ).resources).toEqual([{ foo: 'bar' }]);
+    });
+  });
+});

--- a/__tests__/src/lib/AnnotationPage.test.js
+++ b/__tests__/src/lib/AnnotationPage.test.js
@@ -1,4 +1,5 @@
 import AnnotationPage from '../../../src/lib/AnnotationPage';
+import AnnotationItem from '../../../src/lib/AnnotationItem';
 
 describe('AnnotationPage', () => {
   describe('id', () => {
@@ -17,16 +18,16 @@ describe('AnnotationPage', () => {
   });
   describe('items', () => {
     it('returns items', () => {
-      expect(new AnnotationPage(
+      new AnnotationPage(
         { items: [{ foo: 'bar' }] },
-      ).items).toEqual([{ foo: 'bar' }]);
+      ).items.forEach(resource => expect(resource).toBeInstanceOf(AnnotationItem));
     });
   });
   describe('resources', () => {
     it('returns items', () => {
-      expect(new AnnotationPage(
+      new AnnotationPage(
         { items: [{ foo: 'bar' }] },
-      ).resources).toEqual([{ foo: 'bar' }]);
+      ).items.forEach(resource => expect(resource).toBeInstanceOf(AnnotationItem));
     });
   });
 });

--- a/__tests__/src/lib/ManifestoCanvas.test.js
+++ b/__tests__/src/lib/ManifestoCanvas.test.js
@@ -48,6 +48,27 @@ describe('ManifestoCanvas', () => {
       );
     });
   });
+  describe('processAnnotations', () => {
+    describe('v2', () => {
+      it('fetches annotations for each annotationList', () => {
+        const otherContentInstance = new ManifestoCanvas(
+          manifesto.create(otherContentFixture).getSequences()[0].getCanvases()[0],
+        );
+        const fetchMock = jest.fn();
+        otherContentInstance.processAnnotations(fetchMock);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('v3', () => {
+      it('fetches annotations for external items and receives annotations for items that are embedded', () => {
+        const receiveMock = jest.fn();
+        const fetchMock = jest.fn();
+        v3Instance.processAnnotations(fetchMock, receiveMock);
+        expect(receiveMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
   describe('imageInformationUri', () => {
     it('correctly returns an image information url for a v2 Image API', () => {
       expect(instance.imageInformationUri).toEqual('https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/info.json');

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -26,7 +26,9 @@ export class WindowViewer extends Component {
    * Request the initial canvas on mount
    */
   componentDidMount() {
-    const { currentCanvases, fetchInfoResponse, fetchAnnotation } = this.props;
+    const {
+      currentCanvases, fetchInfoResponse, fetchAnnotation, receiveAnnotation,
+    } = this.props;
 
     if (!this.infoResponseIsInStore()) {
       currentCanvases.forEach((canvas) => {
@@ -35,9 +37,7 @@ export class WindowViewer extends Component {
         if (imageResource) {
           fetchInfoResponse({ imageResource });
         }
-        manifestoCanvas.annotationListUris.forEach((uri) => {
-          fetchAnnotation(manifestoCanvas.canvas.id, uri);
-        });
+        manifestoCanvas.processAnnotations(fetchAnnotation, receiveAnnotation);
       });
     }
   }
@@ -48,7 +48,7 @@ export class WindowViewer extends Component {
    */
   componentDidUpdate(prevProps) {
     const {
-      currentCanvasId, currentCanvases, view, fetchInfoResponse, fetchAnnotation,
+      currentCanvasId, currentCanvases, view, fetchInfoResponse, fetchAnnotation, receiveAnnotation,
     } = this.props;
 
     if (prevProps.view !== view
@@ -60,9 +60,7 @@ export class WindowViewer extends Component {
         if (imageResource) {
           fetchInfoResponse({ imageResource });
         }
-        manifestoCanvas.annotationListUris.forEach((uri) => {
-          fetchAnnotation(manifestoCanvas.canvas.id, uri);
-        });
+        manifestoCanvas.processAnnotations(fetchAnnotation, receiveAnnotation);
       });
     }
   }
@@ -140,6 +138,7 @@ WindowViewer.propTypes = {
   fetchAnnotation: PropTypes.func.isRequired,
   fetchInfoResponse: PropTypes.func.isRequired,
   infoResponses: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  receiveAnnotation: PropTypes.func.isRequired,
   view: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
 };

--- a/src/containers/AnnotationSettings.js
+++ b/src/containers/AnnotationSettings.js
@@ -14,7 +14,7 @@ import { AnnotationSettings } from '../components/AnnotationSettings';
  */
 const mapStateToProps = (state, { windowId }) => ({
   displayAll: getWindow(state, { windowId }).displayAllAnnotations,
-  displayAllDisabled: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting'], windowId }).length < 2,
+  displayAllDisabled: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting', 'commenting'], windowId }).length < 2,
 });
 
 /**

--- a/src/containers/CanvasAnnotations.js
+++ b/src/containers/CanvasAnnotations.js
@@ -28,7 +28,7 @@ const mapStateToProps = (state, { canvasId, windowId }) => ({
   allAnnotationsAreHighlighted: getWindow(state, { windowId }).displayAllAnnotations,
   annotations: getIdAndContentOfResources(
     getAnnotationResourcesByMotivationForCanvas(
-      state, { canvasId, motivations: ['oa:commenting', 'sc:painting'], windowId },
+      state, { canvasId, motivations: ['oa:commenting', 'sc:painting', 'commenting'], windowId },
     ),
   ),
   label: getCanvasLabel(state, {

--- a/src/containers/WindowSideBarAnnotationsPanel.js
+++ b/src/containers/WindowSideBarAnnotationsPanel.js
@@ -15,7 +15,7 @@ import { WindowSideBarAnnotationsPanel } from '../components/WindowSideBarAnnota
  * @private
  */
 const mapStateToProps = (state, { windowId }) => ({
-  annotationCount: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting'], windowId }).length,
+  annotationCount: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting', 'commenting'], windowId }).length,
   selectedCanvases: getVisibleCanvases(state, { windowId }),
 });
 

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -32,7 +32,7 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
  * @private
  */
 const mapStateToProps = (state, { windowId }) => ({
-  hasAnnotations: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting'], windowId }).length > 0,
+  hasAnnotations: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting', 'commenting'], windowId }).length > 0,
   hasSearchResults: getWindow(state, { windowId }).suggestedSearches || getSearchQuery(state, {
     companionWindowId: (getCompanionWindowsForPosition(state, { position: 'left', windowId })[0] || {}).id,
     windowId,

--- a/src/containers/WindowViewer.js
+++ b/src/containers/WindowViewer.js
@@ -27,6 +27,7 @@ const mapStateToProps = (state, { windowId }) => (
 const mapDispatchToProps = {
   fetchAnnotation: actions.fetchAnnotation,
   fetchInfoResponse: actions.fetchInfoResponse,
+  receiveAnnotation: actions.receiveAnnotation,
 };
 
 

--- a/src/lib/AnnotationFactory.js
+++ b/src/lib/AnnotationFactory.js
@@ -1,0 +1,23 @@
+import AnnotationList from './AnnotationList';
+import AnnotationPage from './AnnotationPage';
+
+/**
+ * Used to determine the type of Annotation supported by a version of the IIIF
+ * Presentation API.
+ */
+export default class AnnotationFactory {
+  /** */
+  static determineAnnotation(json, target) {
+    if (!json) {
+      return null;
+    }
+
+    // IIIF Presentation API v3. AnnotationPage
+    if (json.type === 'AnnotationPage') {
+      return new AnnotationPage(json, target);
+    }
+
+    // IIIF Presentation API v2. OpenAnnotation and SharedCanvas models
+    return new AnnotationList(json, target);
+  }
+}

--- a/src/lib/AnnotationItem.js
+++ b/src/lib/AnnotationItem.js
@@ -1,0 +1,80 @@
+import compact from 'lodash/compact';
+import flatten from 'lodash/flatten';
+import uuid from 'uuid/v4';
+
+/**
+ * A modeled WebAnnotation item
+ */
+export default class AnnotationItem {
+  /** */
+  constructor(resource = {}) {
+    this.resource = resource;
+  }
+
+  /** */
+  get id() {
+    this._id = this._id || this.resource.id || uuid(); // eslint-disable-line no-underscore-dangle
+    return this._id; // eslint-disable-line no-underscore-dangle
+  }
+
+  /** */
+  get targetId() {
+    const target = this.target[0];
+    switch (typeof target) {
+      case 'string':
+        return target.replace(/#?xywh=(.*)$/, '');
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * @return {[Array]}
+   */
+  get motivations() {
+    return flatten(compact(new Array(this.resource.motivation)));
+  }
+
+  /** */
+  get body() {
+    return flatten(compact(new Array(this.resource.body)));
+  }
+
+  /** */
+  get resources() {
+    return this.body;
+  }
+
+  /** */
+  get target() {
+    return flatten(compact(new Array(this.resource.target)));
+  }
+
+  /** */
+  get chars() {
+    return this.body.map(r => r.value).join(' ');
+  }
+
+  /** */
+  get selector() {
+    const target = this.target[0];
+    switch (typeof target) {
+      case 'string':
+        return target;
+      default:
+        return null;
+    }
+  }
+
+  /** */
+  get fragmentSelector() {
+    const { selector } = this;
+
+    switch (typeof selector) {
+      case 'string':
+        return selector.match(/xywh=(.*)$/)[1].split(',').map(str => parseInt(str, 10));
+      default:
+        return null;
+    }
+  }
+}

--- a/src/lib/AnnotationList.js
+++ b/src/lib/AnnotationList.js
@@ -1,7 +1,7 @@
 import flatten from 'lodash/flatten';
 import AnnotationResource from './AnnotationResource';
 /** */
-export default class Annotation {
+export default class AnnotationList {
   /** */
   constructor(json, target) {
     this.json = json;

--- a/src/lib/AnnotationPage.js
+++ b/src/lib/AnnotationPage.js
@@ -1,0 +1,36 @@
+/**
+ * Annotation representation for IIIF Presentation v3
+ * https://iiif.io/api/presentation/3.0/#55-annotation-page
+ */
+export default class AnnotationPage {
+  /** */
+  constructor(json, target) {
+    this.json = json;
+    this.target = target;
+  }
+
+  /** */
+  get id() {
+    return this.json.id;
+  }
+
+  /** */
+  present() {
+    return (this.items
+      && this.items.length > 0);
+  }
+
+  /** */
+  get items() {
+    if (!this.json || !this.json.items) return [];
+
+    return this.json.items;
+  }
+
+  /**
+   * Alias to items for compatibility for right now.
+   */
+  get resources() {
+    return this.items;
+  }
+}

--- a/src/lib/AnnotationPage.js
+++ b/src/lib/AnnotationPage.js
@@ -1,3 +1,5 @@
+import flatten from 'lodash/flatten';
+import AnnotationItem from './AnnotationItem';
 /**
  * Annotation representation for IIIF Presentation v3
  * https://iiif.io/api/presentation/3.0/#55-annotation-page
@@ -24,7 +26,7 @@ export default class AnnotationPage {
   get items() {
     if (!this.json || !this.json.items) return [];
 
-    return this.json.items;
+    return flatten([this.json.items]).map(resource => new AnnotationItem(resource));
   }
 
   /**

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -43,6 +43,32 @@ export default class ManifestoCanvas {
       .map(otherContent => otherContent['@id']);
   }
 
+  /** */
+  get canvasAnnotationPages() {
+    return flatten(
+      new Array(this.canvas.__jsonld.annotations), // eslint-disable-line no-underscore-dangle
+    )
+      .filter(annotations => annotations && annotations.type === 'AnnotationPage');
+  }
+
+  /** */
+  processAnnotations(fetchAnnotation, receiveAnnotation) {
+    // IIIF v2
+    this.annotationListUris.forEach((uri) => {
+      fetchAnnotation(this.canvas.id, uri);
+    });
+    // IIIF v3
+    this.canvasAnnotationPages.forEach((annotation) => {
+      // If there are no items, try to retrieve the referenced resource.
+      // otherwise the resource should be embedded and just add to the store.
+      if (!annotation.items) {
+        fetchAnnotation(this.canvas.id, annotation.id);
+      } else {
+        receiveAnnotation(this.canvas.id, annotation.id, annotation);
+      }
+    });
+  }
+
   /**
    * Will negotiate a v2 or v3 type of resource
    */

--- a/src/state/actions/search.js
+++ b/src/state/actions/search.js
@@ -7,7 +7,7 @@ import {
   getSelectedContentSearchAnnotationIds,
 } from '../selectors';
 import ActionTypes from './action-types';
-import Annotation from '../../lib/Annotation';
+import AnnotationList from '../../lib/AnnotationList';
 
 /**
  * requestSearch - action creator
@@ -47,7 +47,7 @@ export function receiveSearch(windowId, companionWindowId, searchId, searchJson)
     if (selectedIds.length === 0) {
       const canvases = getCanvases(state, { windowId });
       annotation = sortSearchAnnotationsByCanvasOrder( // eslint-disable-line prefer-destructuring
-        new Annotation(searchJson), canvases,
+        new AnnotationList(searchJson), canvases,
       )[0];
       canvas = annotation && getCanvas(state, {
         canvasId: annotation.targetId, windowId,

--- a/src/state/selectors/annotations.js
+++ b/src/state/selectors/annotations.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import filter from 'lodash/filter';
 import flatten from 'lodash/flatten';
-import AnnotationList from '../../lib/AnnotationList';
+import AnnotationFactory from '../../lib/AnnotationFactory';
 import { getCanvas, getVisibleCanvases } from './canvases';
 
 const getAnnotationsOnCanvas = createSelector(
@@ -22,7 +22,8 @@ const getPresentAnnotationsCanvas = createSelector(
     getAnnotationsOnCanvas,
   ],
   annotations => filter(
-    Object.values(annotations).map(annotation => annotation && new AnnotationList(annotation.json)),
+    Object.values(annotations)
+      .map(annotation => annotation && AnnotationFactory.determineAnnotation(annotation.json)),
     annotation => annotation && annotation.present(),
   ),
 );
@@ -48,7 +49,8 @@ const getPresentAnnotationsOnSelectedCanvases = createSelector(
     getAnnotationsOnSelectedCanvases,
   ],
   annotations => filter(
-    Object.values(annotations).map(annotation => annotation && new AnnotationList(annotation.json)),
+    Object.values(annotations)
+      .map(annotation => annotation && AnnotationFactory.determineAnnotation(annotation.json)),
     annotation => annotation && annotation.present(),
   ),
 );

--- a/src/state/selectors/annotations.js
+++ b/src/state/selectors/annotations.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import filter from 'lodash/filter';
 import flatten from 'lodash/flatten';
-import Annotation from '../../lib/Annotation';
+import AnnotationList from '../../lib/AnnotationList';
 import { getCanvas, getVisibleCanvases } from './canvases';
 
 const getAnnotationsOnCanvas = createSelector(
@@ -22,7 +22,7 @@ const getPresentAnnotationsCanvas = createSelector(
     getAnnotationsOnCanvas,
   ],
   annotations => filter(
-    Object.values(annotations).map(annotation => annotation && new Annotation(annotation.json)),
+    Object.values(annotations).map(annotation => annotation && new AnnotationList(annotation.json)),
     annotation => annotation && annotation.present(),
   ),
 );
@@ -48,7 +48,7 @@ const getPresentAnnotationsOnSelectedCanvases = createSelector(
     getAnnotationsOnSelectedCanvases,
   ],
   annotations => filter(
-    Object.values(annotations).map(annotation => annotation && new Annotation(annotation.json)),
+    Object.values(annotations).map(annotation => annotation && new AnnotationList(annotation.json)),
     annotation => annotation && annotation.present(),
   ),
 );

--- a/src/state/selectors/searches.js
+++ b/src/state/selectors/searches.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import { LanguageMap } from 'manifesto.js';
 import flatten from 'lodash/flatten';
-import Annotation from '../../lib/Annotation';
+import AnnotationList from '../../lib/AnnotationList';
 import { getCanvas, getCanvases } from './canvases';
 import { getWindow } from './windows';
 import { getManifestLocale } from './manifests';
@@ -109,7 +109,7 @@ export const getSortedSearchHitsForCompanionWindow = createSelector(
 const searchResultsToAnnotation = (results) => {
   const annotations = results.map((result) => {
     if (!result || !result.json || result.isFetching || !result.json.resources) return undefined;
-    const anno = new Annotation(result.json);
+    const anno = new AnnotationList(result.json);
     return {
       id: anno.id,
       resources: anno.resources,


### PR DESCRIPTION
This PR implements a refactor to better extend how annotations can be supported. It uses factory/adapter patterns (with a missing layer) to support both Open Annotation and Web Annotation models. Originally paired on this concept with @GroovinChip

Its worth calling this out for future 👀 

M3 Supported Type | M3 Class | IIIF Pres v2.x | IIIF Pres v3.x
--- | --- | --- | ---
[IIIF - AnnotationList](https://iiif.io/api/presentation/2.1/#annotation-list) | `AnnotationList` | ✅  | 
[Open Annotation - Annotation](http://openannotation.org/spec/core/core.html) | `AnnotationResource` | ✅  | 
[IIIF - AnnotationPage](https://iiif.io/api/presentation/3.0/#55-annotation-page) | `AnnotationPage` | | ✅ 
[Web Annotation - Annotation](https://www.w3.org/TR/annotation-model/#annotations) | `AnnotationItem` | | ✅ 


You can demo this by using this manifest: `https://gist.githubusercontent.com/mejackreed/9f7a2965be9ca879c97a3e1707aae2c8/raw/manifest.json`

![webanno](https://user-images.githubusercontent.com/1656824/70081143-d59b9680-15bc-11ea-839d-8d2a1db94dc2.gif)

Potential future enhancements would be to add `AnnotationItemAdapter` and `AnnotationResourceAdapter` classes to further encapsulate this logic, but I held back from going there. 