### PR TITLE
Infer sc:AnnotationList from otherContent strings

### DIFF
--- a/__tests__/fixtures/version-2/BibliographicResource_3000126341277.json
+++ b/__tests__/fixtures/version-2/BibliographicResource_3000126341277.json
@@ -1,0 +1,110 @@
+{
+  "@type" : "sc:Manifest",
+  "@id" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/manifest",
+  "@context" : "http://iiif.io/api/presentation/2/context.json",
+  "within" : "http://data.theeuropeanlibrary.org/Collection/a0611",
+  "label" : [ {
+    "@value" : "Uusi Aura, nr: 274A - 1909-11-26"
+  } ],
+  "metadata" : [ {
+    "label" : "type",
+    "value" : [ {
+      "@value" : "http://schema.org/PublicationIssue"
+    }, {
+      "@language" : "en",
+      "@value" : "Analytic serial"
+    }, {
+      "@language" : "en",
+      "@value" : "Newspaper"
+    }, {
+      "@language" : "en",
+      "@value" : "Newspaper Issue"
+    } ]
+  }, {
+    "label" : "language",
+    "value" : [ {
+      "@value" : "fin"
+    } ]
+  }, {
+    "label" : "source",
+    "value" : [ {
+      "@value" : "http://digi.kansalliskirjasto.fi/sanomalehti/binding/803341"
+    } ]
+  } ],
+  "thumbnail" : {
+    "@type" : "dctypes:Image",
+    "@id" : "https://api.europeana.eu/api/v2/thumbnail-by-url.json?uri=https%3A%2F%2Fiiif.europeana.eu%2Fimage%2FZL7BQFMZHWA34ENQ6ZEWBTQK2R3ZWL3I5PS46AILJEODMY6UM4TA%2Fpresentation_images%2Fd461d710-02ca-11e6-a651-fa163e2dd531%2Fnode-4%2Fimage%2FNLF%2FUusi_Aura%2F1909%2F11%2F26%2F274B_1%2F19091126_274B_1-0001%2Ffull%2Ffull%2F0%2Fdefault.jpg&type=TEXT"
+  },
+  "navDate" : "1909-11-26T00:00:00Z",
+  "attribution" : "Uusi Aura, nr: 274A - 1909-11-26 - https://www.europeana.eu/portal/record/9200301/BibliographicResource_3000126341277.html. National Library of Finland. Public Domain Mark - http://creativecommons.org/publicdomain/mark/1.0/",
+  "license" : "http://creativecommons.org/publicdomain/mark/1.0/",
+  "logo" : "https://style.europeana.eu/images/europeana-logo-default.png",
+  "seeAlso" : [ {
+    "@id" : "https://www.europeana.eu/api/v2/record/9200301/BibliographicResource_3000126341277.json-ld",
+    "format" : "application/ld+json",
+    "profile" : "http://www.europeana.eu/schemas/edm/"
+  }, {
+    "@id" : "https://www.europeana.eu/api/v2/record/9200301/BibliographicResource_3000126341277.json",
+    "format" : "application/json",
+    "profile" : "http://www.europeana.eu/schemas/edm/"
+  }, {
+    "@id" : "https://www.europeana.eu/api/v2/record/9200301/BibliographicResource_3000126341277.rdf",
+    "format" : "application/rdf+xml",
+    "profile" : "http://www.europeana.eu/schemas/edm/"
+  } ],
+  "sequences" : [ {
+    "@type" : "sc:Sequence",
+    "@id" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/sequence/s1",
+    "label" : "Current Page Order",
+    "startCanvas" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/canvas/p1",
+    "canvases" : [ {
+      "@type" : "sc:Canvas",
+      "@id" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/canvas/p1",
+      "label" : "p. 1",
+      "height" : 2594,
+      "width" : 1890,
+      "attribution" : "Uusi Aura, nr: 274A - 1909-11-26 - https://www.europeana.eu/portal/record/9200301/BibliographicResource_3000126341277.html. National Library of Finland. Public Domain Mark - http://creativecommons.org/publicdomain/mark/1.0/",
+      "images" : [ {
+        "@type" : "oa:Annotation",
+        "@id" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/annotation/p1",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@type" : "dctypes:Image",
+          "@id" : "https://iiif.europeana.eu/image/ZL7BQFMZHWA34ENQ6ZEWBTQK2R3ZWL3I5PS46AILJEODMY6UM4TA/presentation_images/d461d710-02ca-11e6-a651-fa163e2dd531/node-4/image/NLF/Uusi_Aura/1909/11/26/274B_1/19091126_274B_1-0001/full/full/0/default.jpg",
+          "format" : "image/jpeg",
+          "service" : {
+            "@id" : "https://iiif.europeana.eu/image/ZL7BQFMZHWA34ENQ6ZEWBTQK2R3ZWL3I5PS46AILJEODMY6UM4TA/presentation_images/d461d710-02ca-11e6-a651-fa163e2dd531/node-4/image/NLF/Uusi_Aura/1909/11/26/274B_1/19091126_274B_1-0001",
+            "profile" : "http://iiif.io/api/image/2/level1.json",
+            "@context" : "http://iiif.io/api/image/2/context.json"
+          }
+        },
+        "on" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/canvas/p1"
+      } ],
+      "otherContent" : [ "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/annopage/1" ]
+    }, {
+      "@type" : "sc:Canvas",
+      "@id" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/canvas/p2",
+      "label" : "p. 2",
+      "height" : 2656,
+      "width" : 1882,
+      "attribution" : "Uusi Aura, nr: 274A - 1909-11-26 - https://www.europeana.eu/portal/record/9200301/BibliographicResource_3000126341277.html. National Library of Finland. Public Domain Mark - http://creativecommons.org/publicdomain/mark/1.0/",
+      "images" : [ {
+        "@type" : "oa:Annotation",
+        "@id" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/annotation/p2",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@type" : "dctypes:Image",
+          "@id" : "https://iiif.europeana.eu/image/ZL7BQFMZHWA34ENQ6ZEWBTQK2R3ZWL3I5PS46AILJEODMY6UM4TA/presentation_images/d461d710-02ca-11e6-a651-fa163e2dd531/node-4/image/NLF/Uusi_Aura/1909/11/26/274B_1/19091126_274B_1-0002/full/full/0/default.jpg",
+          "format" : "image/jpeg",
+          "service" : {
+            "@id" : "https://iiif.europeana.eu/image/ZL7BQFMZHWA34ENQ6ZEWBTQK2R3ZWL3I5PS46AILJEODMY6UM4TA/presentation_images/d461d710-02ca-11e6-a651-fa163e2dd531/node-4/image/NLF/Uusi_Aura/1909/11/26/274B_1/19091126_274B_1-0002",
+            "profile" : "http://iiif.io/api/image/2/level1.json",
+            "@context" : "http://iiif.io/api/image/2/context.json"
+          }
+        },
+        "on" : "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/canvas/p2"
+      } ],
+      "otherContent" : [ "https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/annopage/2" ]
+    } ]
+  } ]
+}

--- a/__tests__/src/lib/ManifestoCanvas.test.js
+++ b/__tests__/src/lib/ManifestoCanvas.test.js
@@ -6,6 +6,7 @@ import imagev1Fixture from '../../fixtures/version-2/Osbornfa1.json';
 import emptyCanvasFixture from '../../fixtures/version-2/emptyCanvas.json';
 import serviceFixture from '../../fixtures/version-2/canvasService.json';
 import otherContentFixture from '../../fixtures/version-2/299843.json';
+import otherContentStringsFixture from '../../fixtures/version-2/BibliographicResource_3000126341277.json';
 
 describe('ManifestoCanvas', () => {
   let instance;
@@ -25,14 +26,27 @@ describe('ManifestoCanvas', () => {
       });
     });
     describe('when annotationLists are present', () => {
-      it('returns an array of uris', () => {
-        const otherContentInstance = new ManifestoCanvas(
-          manifesto.create(otherContentFixture).getSequences()[0].getCanvases()[0],
-        );
-        expect(otherContentInstance.annotationListUris.length).toEqual(1);
-        expect(otherContentInstance.annotationListUris).toEqual([
-          'https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174896',
-        ]);
+      describe('with items as objects', () => {
+        it('returns an array of uris', () => {
+          const otherContentInstance = new ManifestoCanvas(
+            manifesto.create(otherContentFixture).getSequences()[0].getCanvases()[0],
+          );
+          expect(otherContentInstance.annotationListUris.length).toEqual(1);
+          expect(otherContentInstance.annotationListUris).toEqual([
+            'https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174896',
+          ]);
+        });
+      });
+      describe('with items as strings', () => {
+        it('returns an array of uris', () => {
+          const otherContentInstance = new ManifestoCanvas(
+            manifesto.create(otherContentStringsFixture).getSequences()[0].getCanvases()[0],
+          );
+          expect(otherContentInstance.annotationListUris.length).toEqual(1);
+          expect(otherContentInstance.annotationListUris).toEqual([
+            'https://iiif.europeana.eu/presentation/9200301/BibliographicResource_3000126341277/annopage/1',
+          ]);
+        });
       });
     });
   });

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -34,17 +34,19 @@ export default class ManifestoCanvas {
     return this.canvas.getWidth() / this.canvas.getHeight();
   }
 
-  /** */
+  /**
+   * Fetches AnnotationList URIs from canvas's otherContent property
+   *
+   * Supported otherContent types:
+   * - Objects having @type property of "sc:AnnotationList" and URI in @id
+   * - Strings being the URIs
+   */
   get annotationListUris() {
     return flatten(
       new Array(this.canvas.__jsonld.otherContent), // eslint-disable-line no-underscore-dangle
     )
-      .filter((otherContent) => {
-        return otherContent && (typeof otherContent === 'string' || otherContent['@type'] === 'sc:AnnotationList');
-      })
-      .map((otherContent) => {
-        return typeof otherContent === 'string' ? otherContent : otherContent['@id'];
-      });
+      .filter(otherContent => otherContent && (typeof otherContent === 'string' || otherContent['@type'] === 'sc:AnnotationList'))
+      .map(otherContent => (typeof otherContent === 'string' ? otherContent : otherContent['@id']));
   }
 
   /** */

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -39,8 +39,12 @@ export default class ManifestoCanvas {
     return flatten(
       new Array(this.canvas.__jsonld.otherContent), // eslint-disable-line no-underscore-dangle
     )
-      .filter(otherContent => otherContent && otherContent['@type'] === 'sc:AnnotationList')
-      .map(otherContent => otherContent['@id']);
+      .filter((otherContent) => {
+        return otherContent && (typeof otherContent === 'string' || otherContent['@type'] === 'sc:AnnotationList');
+      })
+      .map((otherContent) => {
+        return typeof otherContent === 'string' ? otherContent : otherContent['@id'];
+      });
   }
 
   /** */


### PR DESCRIPTION
From [IIIF Presentation API 2.1.1](https://iiif.io/api/presentation/2.1/#canvas):
> Note that the items in the otherContent list may be either objects with an @id property or strings. In the case of a string, this is the URI of the annotation list and the type of “sc:AnnotationList” can be inferred.