### PR TITLE
Fixes a regression where companion window would not scroll

### DIFF
--- a/__tests__/src/components/CompanionWindow.test.js
+++ b/__tests__/src/components/CompanionWindow.test.js
@@ -105,7 +105,7 @@ describe('CompanionWindow', () => {
     companionWindow = createWrapper();
     expect(companionWindow.find(Rnd).length).toBe(1);
     expect(companionWindow.find(Rnd).prop('enableResizing').left).toBe(true);
-    expect(companionWindow.find(Rnd).prop('default')).toEqual({ height: 'auto', width: 235 });
+    expect(companionWindow.find(Rnd).prop('default')).toEqual({ height: '100%', width: 235 });
 
     companionWindow = createWrapper({ position: 'bottom' });
     expect(companionWindow.find(Rnd).length).toBe(1);

--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -71,7 +71,7 @@ export class CompanionWindow extends Component {
           className={[classes.rnd]}
           style={{ display: 'flex', position: 'relative' }}
           default={{
-            height: isBottom ? 201 : 'auto',
+            height: isBottom ? 201 : '100%',
             width: isBottom ? 'auto' : 235,
           }}
           disableDragging


### PR DESCRIPTION
Fixes a bug introduced in #2907 

This was due to an update in react-rnd, introduced in v10.1.1, by updating re-resizable https://github.com/bokuweb/react-rnd/commit/c3fa43f584d8455f27a92848529a41494549f2ff

This was due to an upstream bug fix in re-resizable that sets `flexShrink: 0` for the parent `div` without a way to override it. https://github.com/bokuweb/re-resizable/pull/541/files