### PR TITLE
Make OpenSeaDragon configurable from the settings fixes #1330

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -56,19 +56,14 @@ export class OpenSeadragonViewer extends Component {
    * React lifecycle event
    */
   componentDidMount() {
-    const { viewer } = this.props;
+    const { osdConfig, viewer } = this.props;
     if (!this.ref.current) {
       return;
     }
 
     this.viewer = new OpenSeadragon({
-      alwaysBlend: false,
-      blendTime: 0.1,
       id: this.ref.current.id,
-      preserveImageSizeOnResize: true,
-      preserveViewport: true,
-      showNavigationControl: false,
-
+      ...osdConfig,
     });
 
     this.osdCanvasOverlay = new OpenSeadragonCanvasOverlay(this.viewer);
@@ -327,6 +322,7 @@ OpenSeadragonViewer.defaultProps = {
   children: null,
   highlightedAnnotations: [],
   label: null,
+  osdConfig: {},
   palette: {},
   searchAnnotations: [],
   selectedAnnotations: [],
@@ -341,6 +337,7 @@ OpenSeadragonViewer.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   highlightedAnnotations: PropTypes.arrayOf(PropTypes.object),
   label: PropTypes.string,
+  osdConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   palette: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   searchAnnotations: PropTypes.arrayOf(PropTypes.object),
   selectedAnnotations: PropTypes.arrayOf(PropTypes.object),

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -268,5 +268,12 @@ export default {
   galleryView: {
     height: 120, // height of gallery view thumbnails
     width: null, // width of gallery view thumbnails (or null, to auto-calculate an aspect-ratio appropriate size)
+  },
+  osdConfig: { // Default config used for OpenSeadragon
+    alwaysBlend: false,
+    blendTime: 0.1,
+    preserveImageSizeOnResize: true,
+    preserveViewport: true,
+    showNavigationControl: false,
   }
 };

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -34,6 +34,7 @@ const mapStateToProps = (state, { companionWindowId, windowId }) => ({
     canvasId: (getCurrentCanvas(state, { windowId }) || {}).id,
     windowId,
   }),
+  osdConfig: state.config.osdConfig,
   palette: getTheme(state).palette,
   searchAnnotations: getSearchAnnotationsForWindow(
     state,


### PR DESCRIPTION
This will enable Mirador instances to configure OSD settings without having to fork Mirador.