### PR TITLE
Move localepicker to settings so that adopters could turn this…

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -225,6 +225,7 @@ export default {
     defaultSideBarPanel: 'info', // Configure which sidebar is selected by default. Options: info, attribution, canvas, annotations, search
     defaultView: 'single',  // Configure which viewing mode (e.g. single, book, gallery) for windows to be opened in
     hideWindowTitle: false, // Configure if the window title is shown in the window title bar or not
+    showLocalePicker: false, // Configure locale picker for multi-lingual metadata
     sideBarOpenByDefault: false, // Configure if the sidebar (and its content panel) is open by default
     panels: { // Configure which panels are visible in WindowSideBarButtons
       info: true,

--- a/src/containers/WindowSideBarInfoPanel.js
+++ b/src/containers/WindowSideBarInfoPanel.js
@@ -20,6 +20,7 @@ const mapStateToProps = (state, { id, windowId }) => ({
   availableLocales: getMetadataLocales(state, { companionWindowId: id, windowId }),
   locale: state.companionWindows[id].locale || getManifestLocale(state, { windowId }),
   selectedCanvases: getVisibleCanvases(state, { windowId }),
+  showLocalePicker: state.config.window.showLocalePicker,
 });
 
 /** */


### PR DESCRIPTION
…e on

Manifest that could be tested: https://iiif.hab.de/object/mss_272-helmst/manifest.json

### Manifest with multilingual metadata; setting enabled
![Info panels showing menu with available metadata locales](https://user-images.githubusercontent.com/5402927/71923381-c8387580-3141-11ea-8b04-4cad5b4640e4.png)
