### PR TITLE
WIP: Use a getter function to access Mirador state

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -2,23 +2,23 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getTheme } from '../state/selectors';
+import { getTheme, getMiradorState } from '../state/selectors';
 import { App } from '../components/App';
-
 
 /**
  * mapStateToProps - to hook up connect
  * @memberof App
  * @private
  */
-const mapStateToProps = state => (
-  {
+function mapStateToProps(globalState) {
+  const state = getMiradorState(globalState);
+  return {
     isFullscreenEnabled: state.workspace.isFullscreenEnabled,
     language: state.config.language,
     theme: getTheme(state),
     translations: state.config.translations,
-  }
-);
+  };
+}
 
 /**
  * mapDispatchToProps - used to hook up connect to action creators

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -6,3 +6,4 @@ export * from './manifests';
 export * from './windows';
 export * from './workspace';
 export * from './searches';
+export * from './miradorState';

--- a/src/state/selectors/miradorState.js
+++ b/src/state/selectors/miradorState.js
@@ -1,0 +1,13 @@
+
+/** */
+let _getMiradorState = globalState => globalState; // eslint-disable-line no-underscore-dangle
+
+/** */
+export function setMiradorStateGetter(customGetter) {
+  _getMiradorState = customGetter;
+}
+
+/** */
+export function getMiradorState(globalState) {
+  return _getMiradorState(globalState);
+}


### PR DESCRIPTION
This shows a possible approach to solve the second point in #2931 (Mirador should not know about the global state, but only the possition of it's own state slices)

The idea is that: 

* There is a `getMiradorState(globalState: any) => MiradorState` selector that defaults to return the global state. Any time you want to read from the state you first have to get the Mirador state via this function

* There is a `setMirdorStateGetter(customGetter: (globalState: any) => MiradorState) => void` function that can be used by host applications to direct Mirador to it's state. This enables the host application to place the root reducer of Mirador to any state slice it wants to.

