### PR TITLE
Update annotations reducer to be able to merge state at the canvas level

### DIFF
--- a/__tests__/src/reducers/annotations.test.js
+++ b/__tests__/src/reducers/annotations.test.js
@@ -46,6 +46,78 @@ describe('annotation reducer', () => {
       },
     });
   });
+  it('should be able to RECEIVE_ANNOTATION from multiple sources and merge state', () => {
+    const firstReduction = annotationsReducer(
+      {
+        foo: {
+          abc123: {
+            id: 'abc123',
+            isFetching: true,
+          },
+        },
+      },
+      {
+        annotationId: 'efg456',
+        annotationJson: {
+          '@type': 'sc:AnnotationList',
+          content: 'anno stuff',
+          id: 'efg456',
+        },
+        targetId: 'foo',
+        type: ActionTypes.RECEIVE_ANNOTATION,
+      },
+    );
+    expect(firstReduction).toMatchObject({
+      foo: {
+        abc123: {
+          id: 'abc123',
+          isFetching: true,
+        },
+        efg456: {
+          isFetching: false,
+          json: {
+            '@type': 'sc:AnnotationList',
+            content: 'anno stuff',
+            id: 'efg456',
+          },
+        },
+      },
+    });
+    const secondReduction = annotationsReducer(
+      firstReduction,
+      {
+        annotationId: 'abc123',
+        annotationJson: {
+          '@type': 'sc:AnnotationList',
+          content: 'anno stuff',
+          id: 'abc123',
+        },
+        targetId: 'foo',
+        type: ActionTypes.RECEIVE_ANNOTATION,
+      },
+    );
+    expect(secondReduction).toMatchObject({
+      foo: {
+        abc123: {
+          id: 'abc123',
+          isFetching: false,
+          json: {
+            '@type': 'sc:AnnotationList',
+            content: 'anno stuff',
+            id: 'abc123',
+          },
+        },
+        efg456: {
+          isFetching: false,
+          json: {
+            '@type': 'sc:AnnotationList',
+            content: 'anno stuff',
+            id: 'efg456',
+          },
+        },
+      },
+    });
+  });
   it('should handle RECEIVE_ANNOTATION_FAILURE', () => {
     expect(annotationsReducer(
       {

--- a/src/state/reducers/annotations.js
+++ b/src/state/reducers/annotations.js
@@ -9,6 +9,7 @@ export const annotationsReducer = (state = {}, action) => {
       return {
         ...state,
         [action.targetId]: {
+          ...state[action.targetId],
           [action.annotationId]: {
             id: action.annotationId,
             isFetching: true,
@@ -19,6 +20,7 @@ export const annotationsReducer = (state = {}, action) => {
       return {
         ...state,
         [action.targetId]: {
+          ...state[action.targetId],
           [action.annotationId]: {
             id: action.annotationId,
             isFetching: false,
@@ -30,6 +32,7 @@ export const annotationsReducer = (state = {}, action) => {
       return {
         ...state,
         [action.targetId]: {
+          ...state[action.targetId],
           [action.annotationId]: {
             error: action.error,
             id: action.annotationId,


### PR DESCRIPTION
Fixes #2941

This will support asynchronous annotations from multiple sources for a
canvas. Previously this worked as a last in only out.