### PR TITLE
accessibility testing scenarios for UB Leipzig

### DIFF
--- a/__tests__/integration/mirador/1-start.html
+++ b/__tests__/integration/mirador/1-start.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       windows: [],
+       manifests: {
+         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
+         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
+         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
+         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
+         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
+         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
+         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
+         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
+         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
+         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
+         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+       }
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/integration/mirador/1-start.html
+++ b/__tests__/integration/mirador/1-start.html
@@ -15,17 +15,10 @@
        id: 'mirador',
        windows: [],
        manifests: {
-         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
-         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
-         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
-         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
-         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
-         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
-         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
-         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
-         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
-         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
-         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+         "https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00068386/manifest": { provider: "Bayerische Staatsbibliothek"},
+         "https://purl.stanford.edu/db076zm5895/iiif/manifest": { provider: "Stanford University Libraries"},
+         "https://purl.stanford.edu/np593hr6132/iiif/manifest": { provider: "Stanford University Libraries"},
+         'https://wellcomelibrary.org/iiif/b18035723/manifest': { provider: "Wellcome Library"},
        }
      });
     </script>

--- a/__tests__/integration/mirador/3-two-up.html
+++ b/__tests__/integration/mirador/3-two-up.html
@@ -22,17 +22,10 @@
          canvasIndex: 1,
        }],
        manifests: {
-         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
-         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
-         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
-         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
-         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
-         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
-         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
-         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
-         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
-         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
-         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+         "https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00068386/manifest": { provider: "Bayerische Staatsbibliothek"},
+         "https://purl.stanford.edu/db076zm5895/iiif/manifest": { provider: "Stanford University Libraries"},
+         "https://purl.stanford.edu/np593hr6132/iiif/manifest": { provider: "Stanford University Libraries"},
+         'https://wellcomelibrary.org/iiif/b18035723/manifest': { provider: "Wellcome Library"},
        }
      });
     </script>

--- a/__tests__/integration/mirador/3-two-up.html
+++ b/__tests__/integration/mirador/3-two-up.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       windows: [{
+         manifestId: 'https://purl.stanford.edu/db076zm5895/iiif/manifest',
+         canvasIndex: 1,
+       },
+       {
+         manifestId: 'https://purl.stanford.edu/np593hr6132/iiif/manifest',
+         canvasIndex: 1,
+       }],
+       manifests: {
+         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
+         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
+         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
+         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
+         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
+         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
+         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
+         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
+         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
+         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
+         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+       }
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/integration/mirador/4-annotations.html
+++ b/__tests__/integration/mirador/4-annotations.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       window: {
+         sideBarOpenByDefault: true,
+         defaultSideBarPanel: 'annotations',
+       },
+       windows: [{
+         manifestId: 'https://wellcomelibrary.org/iiif/b18035723/manifest',
+         canvasIndex: 4,
+       }],
+       manifests: {
+         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
+         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
+         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
+         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
+         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
+         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
+         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
+         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
+         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
+         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
+         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+       }
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/integration/mirador/4-annotations.html
+++ b/__tests__/integration/mirador/4-annotations.html
@@ -22,17 +22,10 @@
          canvasIndex: 4,
        }],
        manifests: {
-         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
-         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
-         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
-         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
-         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
-         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
-         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
-         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
-         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
-         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
-         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+         "https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00068386/manifest": { provider: "Bayerische Staatsbibliothek"},
+         "https://purl.stanford.edu/db076zm5895/iiif/manifest": { provider: "Stanford University Libraries"},
+         "https://purl.stanford.edu/np593hr6132/iiif/manifest": { provider: "Stanford University Libraries"},
+         'https://wellcomelibrary.org/iiif/b18035723/manifest': { provider: "Wellcome Library"},
        }
      });
     </script>

--- a/__tests__/integration/mirador/5-search.html
+++ b/__tests__/integration/mirador/5-search.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       window: {
+         defaultSideBarPanel: 'search',
+         sideBarOpenByDefault: true,
+       },
+       windows: [{
+         manifestId: 'https://wellcomelibrary.org/iiif/b18035723/manifest',
+         canvasIndex: 4,
+       }],
+       manifests: {
+         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
+         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
+         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
+         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
+         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
+         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
+         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
+         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
+         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
+         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
+         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+       }
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/integration/mirador/5-search.html
+++ b/__tests__/integration/mirador/5-search.html
@@ -22,17 +22,10 @@
          canvasIndex: 4,
        }],
        manifests: {
-         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
-         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
-         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
-         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
-         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
-         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
-         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
-         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
-         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
-         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
-         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+         "https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00068386/manifest": { provider: "Bayerische Staatsbibliothek"},
+         "https://purl.stanford.edu/db076zm5895/iiif/manifest": { provider: "Stanford University Libraries"},
+         "https://purl.stanford.edu/np593hr6132/iiif/manifest": { provider: "Stanford University Libraries"},
+         'https://wellcomelibrary.org/iiif/b18035723/manifest': { provider: "Wellcome Library"},
        }
      });
     </script>

--- a/__tests__/integration/mirador/7-language-switch.html
+++ b/__tests__/integration/mirador/7-language-switch.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       window: {
+         defaultSideBarPanel: 'info',
+         sideBarOpenByDefault: true,
+       },
+       windows: [{
+         manifestId: 'https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00068386/manifest',
+         canvasIndex: 5,
+       }],
+       manifests: {
+         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
+         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
+         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
+         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
+         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
+         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
+         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
+         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
+         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
+         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
+         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+       }
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/integration/mirador/7-language-switch.html
+++ b/__tests__/integration/mirador/7-language-switch.html
@@ -22,17 +22,10 @@
          canvasIndex: 5,
        }],
        manifests: {
-         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
-         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
-         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
-         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
-         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
-         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
-         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
-         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
-         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
-         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
-         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
+         "https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00068386/manifest": { provider: "Bayerische Staatsbibliothek"},
+         "https://purl.stanford.edu/db076zm5895/iiif/manifest": { provider: "Stanford University Libraries"},
+         "https://purl.stanford.edu/np593hr6132/iiif/manifest": { provider: "Stanford University Libraries"},
+         'https://wellcomelibrary.org/iiif/b18035723/manifest': { provider: "Wellcome Library"},
        }
      });
     </script>


### PR DESCRIPTION
Please post feedback on this testing scenario in #2936.

# 1. [Start](https://deploy-preview-2943--mirador-dev.netlify.com/__tests__/integration/mirador/1-start.html)
<img width="500" alt="start" src="https://user-images.githubusercontent.com/6945691/73987136-44b2a580-48f4-11ea-9f2c-e1e9f7c9ad56.png">

**Tasks**: Assess opening screen; open catalog

# 2. Catalog
<img width="500" alt="catalog" src="https://user-images.githubusercontent.com/6945691/73987191-66139180-48f4-11ea-82fc-99eca9357161.png">

**Tasks**: Add a resource; open a resource

**Manifests**: Catalog should not include resources that cannot be opened (e.g. "The biological basis of medicine"). Probably should include all the manifests included in the testing?

# 3. [Two-up comparison](https://deploy-preview-2943--mirador-dev.netlify.com/__tests__/integration/mirador/3-two-up.html)
<img width="500" alt="2-up mss" src="https://user-images.githubusercontent.com/6945691/73987267-a115c500-48f4-11ea-8b09-50bb886fc347.png">

**Tasks**: Open a second resource.

**Manifests**: Two related manifests with metadata and meaningful canvas labels.

- Civitates Orbis Terrarum.
https://purl.stanford.edu/db076zm5895/iiif/manifest
- Cambridge, Corpus Christi College, MS 298: Laurence Wade OSB, Life of Becket. Canterbury Documents
https://purl.stanford.edu/np593hr6132/iiif/manifest

### 3.1 Metadata
<img width="500" alt="metadata mss" src="https://user-images.githubusercontent.com/6945691/73987289-b7238580-48f4-11ea-9b8c-e597eabf8e48.png">

**Task**: Read/compare metadata of two manuscripts. Requires using the toggle to open the sidebar in both windows.

### 3.2 Navigation
<img width="500" alt="navigate mss" src="https://user-images.githubusercontent.com/6945691/73987296-bbe83980-48f4-11ea-939c-366aa47d7990.png">

**Tasks**: Use the index to navigate to different pages in the manuscripts. Requires using the sidebar menu to select the index for both manuscripts. 

# 4. [Annotations](https://deploy-preview-2943--mirador-dev.netlify.com/__tests__/integration/mirador/4-annotations.html)
<img width="500" alt="annotations" src="https://user-images.githubusercontent.com/6945691/73987349-ec2fd800-48f4-11ea-82ed-28c287afbf78.png">

**Tasks**: Read the text of the transcript annotations. Navigate between annotations and across pages.

**Manifest**: Book with searchable full-text annotations
- Wunder der Vererbung
https://wellcomelibrary.org/iiif/b18035723/manifest

# 5. [Search](https://deploy-preview-2943--mirador-dev.netlify.com/__tests__/integration/mirador/5-search.html)
<img width="500" alt="search" src="https://user-images.githubusercontent.com/6945691/73987368-010c6b80-48f5-11ea-9ee1-f8771b2f0346.png">

**Tasks**: Use the sidebar menu to navigate to Search; enter a search term; navigate the results. 

**Manifest**: Book with searchable full-text annotations
- Wunder der Vererbung
https://wellcomelibrary.org/iiif/b18035723/manifest

# 6. [Download](https://purl.stanford.edu/yg239bh0641)
<img width="500" alt="download" src="https://user-images.githubusercontent.com/6945691/73988571-ee476600-48f7-11ea-9b37-41e394ae1268.png">

**Tasks**: Start from a page with 2 images. Navigate to the "Download & share" menu; select Download; select an option (page A, page B, whole object).

**Notes**: I don't think download is implemented in core Mirador, but it is in Stanford's embedded Mirador. This introduces another layer to the test:  The viewer embedded in a web page that has its own content (and potential issues). 

**Manifest**: Multi-page object that has a whole-object option.
- The songs of Mario Paci : recital [program]
https://purl.stanford.edu/yg239bh0641

# 7. [Switch language](https://deploy-preview-2943--mirador-dev.netlify.com/__tests__/integration/mirador/7-language-switch.html)
<img width="500" alt="language menu" src="https://user-images.githubusercontent.com/6945691/73987456-534d8c80-48f5-11ea-9d45-6abbdf9acc7a.png">

**Tasks**:  Navigate to the workspace sidebar and select Workspace options; select Language; select an alternate language. 

**Manifest**:  Object that has labels and/or metadata in the starting and target languages. 
- Wang, Anshi, 1021-1086: Xin ke Linchuan Wang Jiefu xian sheng shi wen ji. 2
https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00068386/manifest