### PR TITLE
Enable default toc selection based off of range existence

### DIFF
--- a/__tests__/src/selectors/ranges.test.js
+++ b/__tests__/src/selectors/ranges.test.js
@@ -1,10 +1,12 @@
 import { setIn } from 'immutable';
+import noRangesJson from '../../fixtures/version-2/001.json';
 import manifestJson from '../../fixtures/version-2/structures.json';
 import {
   getVisibleNodeIds,
   getManuallyExpandedNodeIds,
   getExpandedNodeIds,
   getNodeIdToScrollTo,
+  getDefaultSidebarVariant,
 } from '../../../src/state/selectors';
 
 const state = {
@@ -128,5 +130,15 @@ describe('getNodeIdToScrollTo', () => {
   it('returns no node id if current canvas is not contained in any range', () => {
     const rangeFreeCanvasState = setIn(expandedNodesState, ['windows', 'w1', 'canvasId'], 'http://foo.test/1/canvas/c12');
     expect(getNodeIdToScrollTo(rangeFreeCanvasState, { companionWindowId: 'cw123', windowId: 'w1' })).toBe(null);
+  });
+});
+
+describe('getDefaultSidebarVariant', () => {
+  it('returns thumbnail when no ranges exist', () => {
+    const noRangeState = setIn(state, ['manifests', 'mID', 'json'], noRangesJson);
+    expect(getDefaultSidebarVariant(noRangeState, { windowId: 'w1' })).toBe('thumbnail');
+  });
+  it('returns tableOfContents when ranges exist', () => {
+    expect(getDefaultSidebarVariant(state, { windowId: 'w1' })).toBe('tableOfContents');
   });
 });

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -117,10 +117,6 @@ WindowSideBarCanvasPanel.propTypes = {
   t: PropTypes.func.isRequired,
   toggleDraggingEnabled: PropTypes.func.isRequired,
   updateVariant: PropTypes.func.isRequired,
-  variant: PropTypes.oneOf(['compact', 'thumbnail', 'tableOfContents']),
+  variant: PropTypes.oneOf(['compact', 'thumbnail', 'tableOfContents']).isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowSideBarCanvasPanel.defaultProps = {
-  variant: 'tableOfContents',
 };

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -7,6 +7,7 @@ import * as actions from '../state/actions';
 import { WindowSideBarCanvasPanel } from '../components/WindowSideBarCanvasPanel';
 import {
   getCompanionWindow,
+  getDefaultSidebarVariant,
   getManifestCanvases,
   getVisibleCanvases,
 } from '../state/selectors';
@@ -21,7 +22,8 @@ const mapStateToProps = (state, { id, windowId }) => {
     canvases,
     config,
     selectedCanvases: getVisibleCanvases(state, { windowId }),
-    variant: getCompanionWindow(state, { companionWindowId: id, windowId }).variant,
+    variant: getCompanionWindow(state, { companionWindowId: id, windowId }).variant
+      || getDefaultSidebarVariant(state, { windowId }),
   };
 };
 

--- a/src/state/selectors/ranges.js
+++ b/src/state/selectors/ranges.js
@@ -129,3 +129,15 @@ export function getNodeIdToScrollTo(state, { ...args }) {
   }
   return null;
 }
+
+/**
+ * Returns the default sidebar variant depending on whether or not ranges exist
+ */
+export const getDefaultSidebarVariant = createSelector(
+  [
+    getManifestTreeStructure,
+  ],
+  tree => (
+    tree && tree.nodes && tree.nodes.length > 0 ? 'tableOfContents' : 'thumbnail'
+  ),
+);


### PR DESCRIPTION
@lutzhelm what do you think?

This selector now sets the default view as `tableOfContents` only if ranges are present.