### PR TITLE
Make sidebar panel width configurable via settings

### DIFF
--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -51,7 +51,7 @@ export class CompanionWindow extends Component {
   render() {
     const {
       ariaLabel, classes, paperClassName, id, onCloseClick, updateCompanionWindow, isDisplayed,
-      position, t, windowId, title, children, titleControls, size,
+      position, t, windowId, title, children, titleControls, size, defaultSidebarPanelWidth,
     } = this.props;
 
     const isBottom = (position === 'bottom' || position === 'far-bottom');
@@ -72,7 +72,7 @@ export class CompanionWindow extends Component {
           style={{ display: 'flex', position: 'relative' }}
           default={{
             height: isBottom ? 201 : '100%',
-            width: isBottom ? 'auto' : 235,
+            width: isBottom ? 'auto' : defaultSidebarPanelWidth,
           }}
           disableDragging
           enableResizing={this.resizeHandles()}
@@ -155,6 +155,7 @@ CompanionWindow.propTypes = {
   ariaLabel: PropTypes.string,
   children: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  defaultSidebarPanelWidth: PropTypes.number,
   id: PropTypes.string.isRequired,
   isDisplayed: PropTypes.bool,
   onCloseClick: PropTypes.func,
@@ -174,6 +175,7 @@ CompanionWindow.propTypes = {
 CompanionWindow.defaultProps = {
   ariaLabel: undefined,
   children: undefined,
+  defaultSidebarPanelWidth: 235,
   isDisplayed: false,
   onCloseClick: () => {},
   paperClassName: '',

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -223,6 +223,7 @@ export default {
     allowWindowSideBar: true, // Configure if side bar menu is visible or not
     authNewWindowCenter: 'parent', // Configure how to center a new window created by the authentication flow. Options: parent, screen
     defaultSideBarPanel: 'info', // Configure which sidebar is selected by default. Options: info, attribution, canvas, annotations, search
+    defaultSidebarPanelWidth: 235, // Configure default sidebar width in pixels
     defaultView: 'single',  // Configure which viewing mode (e.g. single, book, gallery) for windows to be opened in
     hideWindowTitle: false, // Configure if the window title is shown in the window title bar or not
     showLocalePicker: false, // Configure locale picker for multi-lingual metadata

--- a/src/containers/CompanionWindow.js
+++ b/src/containers/CompanionWindow.js
@@ -15,9 +15,11 @@ import { CompanionWindow } from '../components/CompanionWindow';
  */
 const mapStateToProps = (state, { id, windowId }) => {
   const companionWindow = getCompanionWindow(state, { companionWindowId: id });
+  const { defaultSidebarPanelWidth } = state.config.window;
 
   return {
     ...companionWindow,
+    defaultSidebarPanelWidth,
     isDisplayed: (companionWindow
                   && companionWindow.content
                   && companionWindow.content.length > 0),


### PR DESCRIPTION
Fixes #2947 

This PR exposes the default sidebar panel width to `/src/config/settings.js`.

Side note: 
🤷‍♀️ I'm not sure what to do about naming variables here. We use "sidebar" in the settings page, even though the component terminology is CompanionWindow. Should we try to get these variable names sorted out before 3.0 release? 