### PR TITLE
Enable basic code chunking by using React.Lazy

### DIFF
--- a/__tests__/src/components/App.test.js
+++ b/__tests__/src/components/App.test.js
@@ -4,7 +4,6 @@ import { MuiThemeProvider } from '@material-ui/core/styles';
 import Fullscreen from 'react-full-screen';
 import AccessTokenSender from '../../../src/containers/AccessTokenSender';
 import AuthenticationSender from '../../../src/containers/AuthenticationSender';
-import WorkspaceArea from '../../../src/containers/WorkspaceArea';
 import { App } from '../../../src/components/App';
 import settings from '../../../src/config/settings';
 
@@ -30,7 +29,7 @@ describe('App', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(MuiThemeProvider).length).toBe(1);
     expect(wrapper.find(Fullscreen).length).toBe(1);
-    expect(wrapper.find(WorkspaceArea).length).toBe(1);
+    expect(wrapper.find('Suspense').length).toBe(1);
     expect(wrapper.find(AuthenticationSender).length).toBe(1);
     expect(wrapper.find(AccessTokenSender).length).toBe(1);
   });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,13 +1,14 @@
-import React, { Component } from 'react';
+import React, { Component, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import Fullscreen from 'react-full-screen';
 import { I18nextProvider } from 'react-i18next';
 import { LiveAnnouncer } from 'react-aria-live';
 import createI18nInstance from '../i18n';
-import WorkspaceArea from '../containers/WorkspaceArea';
 import AuthenticationSender from '../containers/AuthenticationSender';
 import AccessTokenSender from '../containers/AccessTokenSender';
+
+const WorkspaceArea = lazy(() => import('../containers/WorkspaceArea'));
 
 /**
  * This is the top level Mirador component.
@@ -64,7 +65,11 @@ export class App extends Component {
             <MuiThemeProvider theme={createMuiTheme(theme)}>
               <AuthenticationSender />
               <AccessTokenSender />
-              <WorkspaceArea />
+              <Suspense
+                fallback={<div />}
+              >
+                <WorkspaceArea />
+              </Suspense>
             </MuiThemeProvider>
           </LiveAnnouncer>
         </I18nextProvider>

--- a/src/containers/WorkspaceMosaic.js
+++ b/src/containers/WorkspaceMosaic.js
@@ -37,7 +37,7 @@ const styles = {
       boxShadow: 'none',
     },
     '& .mosaic-window-toolbar': {
-      display: 'none',
+      display: 'none !important',
     },
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,13 @@ const baseConfig = [
 module.exports = (env, options) => {
   const isProduction = options.mode === 'production';
   return baseConfig.map((config) => {
-    config.devtool = !isProduction ? 'eval-source-map' : false; // eslint-disable-line no-param-reassign
+    if (isProduction) {
+      config.plugins.push(new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }));
+    } else {
+      config.devtool = 'eval-source-map'; // eslint-disable-line no-param-reassign
+    }
     return config;
   });
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,7 @@ const baseConfig = [
       libraryExport: 'default',
       libraryTarget: 'umd',
       path: path.join(__dirname, 'dist'),
+      publicPath: '/dist/',
     },
     plugins: [
       new webpack.IgnorePlugin({


### PR DESCRIPTION
This PR adds React.lazy and Suspence for loading the `App` component. This has the impact of enabling basic code splitting (using Webpacks SplitChunksPlugin). The result here is a quicker First Contentful Paint and First Meaningful Paint.

## Before
All JavaScript is loaded up in a single umd js file ~1.74MB. The browser does not start doing anything until this is fully loaded and parsed.
![Screen Shot 2020-03-26 at 2 11 08 PM](https://user-images.githubusercontent.com/1656824/77692306-0177c900-6f6c-11ea-8a30-366cf5bb9a0e.png)

![Screen Shot 2020-03-26 at 2 14 48 PM](https://user-images.githubusercontent.com/1656824/77692412-2b30f000-6f6c-11ea-8179-aee71923933d.png)

## After
The JavaScript is now split into 3 different chunks, equaling approximately the same size (but a bit smaller 1.72MB). The big difference here is that the browser can start loading Mirador after the first chunk is downloaded and parsed. This reduces our paint times.
![Screen Shot 2020-03-26 at 2 10 01 PM](https://user-images.githubusercontent.com/1656824/77692449-384ddf00-6f6c-11ea-946d-441a2b1ee81f.png)
![Screen Shot 2020-03-26 at 2 19 23 PM](https://user-images.githubusercontent.com/1656824/77692760-cfb33200-6f6c-11ea-8cda-682a4a57a17f.png)

## Browser compatibility
This does seem to work fine with Chrome, Firefox, and even IE 11.
![Screen Shot 2020-03-26 at 2 23 46 PM](https://user-images.githubusercontent.com/1656824/77693103-6c75cf80-6f6d-11ea-86be-45a3ea2aca78.png)

## Future implications
There maybe future useful implications of this functionality. Where plugins that may show other types of content might also be able to chunk out JS dependencies and only show them when needed. There are also other places where things could be chunked.

## Other Considerations
Should we modify the chunk naming scheme?
Does this have any impact who may want to use the `mirador.min.js` from unpkg.com?
