### PR TITLE
Fix some TOC behavior issues

### DIFF
--- a/__tests__/fixtures/version-2/structures.json
+++ b/__tests__/fixtures/version-2/structures.json
@@ -55,17 +55,22 @@
         {
           "@id": "http://foo.test/1/canvas/c10", 
           "@type": "sc:Canvas", 
-          "label": "Canvas: 9" 
+          "label": "Canvas: 10" 
         },
         {
           "@id": "http://foo.test/1/canvas/c11", 
           "@type": "sc:Canvas", 
-          "label": "Canvas: 9" 
+          "label": "Canvas: 11" 
         },
         {
           "@id": "http://foo.test/1/canvas/c12", 
           "@type": "sc:Canvas", 
-          "label": "Canvas: 9" 
+          "label": "Canvas: 12" 
+        },
+        {
+          "@id": "http://foo.test/1/canvas/c13", 
+          "@type": "sc:Canvas", 
+          "label": "Canvas: 13" 
         }
       ]
     }
@@ -78,7 +83,9 @@
       "ranges": [
         "http://foo.test/1/range/0-0",
         "http://foo.test/1/range/0-1",
-        "http://foo.test/1/range/0-2"
+        "http://foo.test/1/range/0-2",
+        "http://foo.test/1/range/0-3",
+        "http://foo.test/1/range/0-4"
       ],
       "canvases": []
     },
@@ -249,6 +256,32 @@
       "canvases": [
         "http://foo.test/1/canvas/c9"
       ]
+    },
+    {
+      "@id": "http://foo.test/1/range/0-3",
+      "@type": "sc:Range",
+      "ranges": [],
+      "canvases": [
+        "http://foo.test/1/canvas/c10",
+        "http://foo.test/1/canvas/c11"
+     ],
+     "startCanvas": "http://foo.test/1/canvas/c11"
+    },
+    {
+      "@id": "http://foo.test/1/range/0-4",
+      "@type": "sc:Range",
+      "ranges": [
+        "http://foo.test/1/range/0-4-0"
+      ],
+      "canvases": [
+        "http://foo.test/1/canvas/c13"
+     ]
+    },
+    {
+      "@id": "http://foo.test/1/range/0-4-0",
+      "@type": "sc:Range",
+      "ranges": [],
+      "canvases": []
     }
   ]
 }

--- a/__tests__/fixtures/version-3/structures.json
+++ b/__tests__/fixtures/version-3/structures.json
@@ -25,7 +25,31 @@
       "type": "Canvas"
     },
     {
-      "id": "http://foo.test/1/canvas/c4",
+      "id": "http://foo.test/1/canvas/c5",
+      "type": "Canvas"
+    },
+    {
+      "id": "http://foo.test/1/canvas/c6",
+      "type": "Canvas"
+    },
+    {
+      "id": "http://foo.test/1/canvas/c7",
+      "type": "Canvas"
+    },
+    {
+      "id": "http://foo.test/1/canvas/c8",
+      "type": "Canvas"
+    },
+    {
+      "id": "http://foo.test/1/canvas/c9",
+      "type": "Canvas"
+    },
+    {
+      "id": "http://foo.test/1/canvas/c10",
+      "type": "Canvas"
+    },
+    {
+      "id": "http://foo.test/1/canvas/c11",
       "type": "Canvas"
     }
   ],
@@ -66,7 +90,57 @@
         },
         {
           "id": "http://foo.test/1/range/0-0-1",
-          "type": "Range"
+          "type": "Range",
+          "items": [
+            {
+              "id": "http://foo.test/1/canvas/c6",
+              "type": "Canvas"
+            },
+            {
+              "id": "http://foo.test/1/canvas/c7",
+              "type": "Canvas"
+            }
+          ],
+          "start": {
+            "id": "http://foo.test/1/canvas/c7",
+            "type": "Canvas"
+          }
+        },
+        {
+          "id": "http://foo.test/1/range/0-0-2",
+          "type": "Range",
+          "items": [
+            {
+              "id": "http://foo.test/1/canvas/c8",
+              "type": "Canvas"
+            },
+            {
+              "id": "http://foo.test/1/canvas/c9",
+              "type": "Canvas"
+            }
+          ],
+          "start": {
+            "type": "SpecificResource",
+            "source": "http://foo.test/1/canvas/c9"
+          }
+        },
+        {
+          "id": "http://foo.test/1/range/0-0-3",
+          "type": "Range",
+          "label": { "none": "missing start canvas" },
+          "items": [
+            {
+              "id": "http://foo.test/1/canvas/c10",
+              "type": "Canvas"
+            },
+            {
+              "id": "http://foo.test/1/canvas/c11",
+              "type": "Canvas"
+            }
+          ],
+          "start": {
+            "type": "SpecificResource"
+          }
         }
       ]
     }

--- a/__tests__/src/components/SidebarIndexTableOfContents.test.js
+++ b/__tests__/src/components/SidebarIndexTableOfContents.test.js
@@ -4,14 +4,15 @@ import manifesto from 'manifesto.js';
 import TreeItem from '@material-ui/lab/TreeItem';
 import TreeView from '@material-ui/lab/TreeView';
 import { SidebarIndexTableOfContents } from '../../../src/components/SidebarIndexTableOfContents';
-import manifestJson from '../../fixtures/version-2/structures.json';
+import manifestVersion2 from '../../fixtures/version-2/structures.json';
+import manifestVersion3 from '../../fixtures/version-3/structures.json';
 
 /**
  * Create shallow enzyme wrapper for SidebarIndexTableOfContents component
  * @param {*} props
  */
 function createWrapper(props) {
-  const manifest = manifesto.create(manifestJson);
+  const manifest = manifesto.create(props.manifest ? props.manifest : manifestVersion2);
   return shallow(
     <SidebarIndexTableOfContents
       id="something"
@@ -56,7 +57,7 @@ describe('SidebarIndexTableOfContents', () => {
 
   it('renders a tree item for every node', () => {
     const structuresWrapper = createWrapper({});
-    expect(structuresWrapper.find(TreeItem)).toHaveLength(18);
+    expect(structuresWrapper.find(TreeItem)).toHaveLength(21);
     const simpleTreeWrapper = createWrapper({
       treeStructure: {
         nodes: [
@@ -196,6 +197,43 @@ describe('SidebarIndexTableOfContents', () => {
     expect(node1.prop('nodeId')).toBe('0-1');
     node1.simulate(...createKeydownProps('ArrowRight'));
     expect(setCanvas).toHaveBeenCalledTimes(4);
+  });
+
+  it('sets the canvas to a start canvas if present', () => {
+    const version2wrapper = createWrapper({
+      setCanvas,
+      toggleNode,
+      windowId: 'w1',
+    });
+    const treeView = version2wrapper.children(TreeView).at(0);
+    const node3 = treeView.childAt(3);
+    expect(node3.prop('nodeId')).toBe('0-3');
+    node3.simulate('click');
+    expect(setCanvas).toHaveBeenCalledWith('w1', 'http://foo.test/1/canvas/c11');
+
+    const version3wrapper = createWrapper({
+      manifest: manifestVersion3,
+      setCanvas,
+      toggleNode,
+      windowId: 'w1',
+    });
+    const treeViewVersion3 = version3wrapper.children(TreeView).at(0);
+    const rootNode = treeViewVersion3.childAt(0);
+
+    const version3node1 = rootNode.childAt(1);
+    expect(version3node1.prop('nodeId')).toBe('0-0-1');
+    version3node1.simulate('click');
+    expect(setCanvas).toHaveBeenLastCalledWith('w1', 'http://foo.test/1/canvas/c7');
+
+    const version3node2 = rootNode.childAt(2);
+    expect(version3node2.prop('nodeId')).toBe('0-0-2');
+    version3node2.simulate('click');
+    expect(setCanvas).toHaveBeenLastCalledWith('w1', 'http://foo.test/1/canvas/c9');
+
+    const version3node3 = rootNode.childAt(3);
+    expect(version3node3.prop('nodeId')).toBe('0-0-3');
+    version3node3.simulate('click');
+    expect(setCanvas).toHaveBeenLastCalledWith('w1', 'http://foo.test/1/canvas/c10');
   });
 
   it('does not select a canvas when opening a node with the right arrow key', () => {

--- a/__tests__/src/selectors/ranges.test.js
+++ b/__tests__/src/selectors/ranges.test.js
@@ -156,6 +156,12 @@ describe('getExpandedNodeIds', () => {
     ]));
     expect(expandedNodeIds.length).toBe(5);
   });
+
+  it('does not contain ids of nodes whos descendants do not contain currently visible canvases', () => {
+    const canvas13State = setIn(state, ['windows', 'w1', 'canvasId'], 'http://foo.test/1/canvas/c13');
+    const expandedNodeIds = getExpandedNodeIds(canvas13State, { companionWindowId: 'cw123', windowId: 'w1' });
+    expect(expandedNodeIds.length).toBe(0);
+  });
 });
 
 describe('getNodeIdToScrollTo', () => {
@@ -179,7 +185,8 @@ describe('getNodeIdToScrollTo', () => {
   });
 
   it('returns no node id if current canvas is not contained in any range', () => {
-    const rangeFreeCanvasState = setIn(expandedNodesState, ['windows', 'w1', 'canvasId'], 'http://foo.test/1/canvas/c12');
+    const singleViewState = setIn(expandedNodesState, ['windows', 'w1', 'view'], 'single');
+    const rangeFreeCanvasState = setIn(singleViewState, ['windows', 'w1', 'canvasId'], 'http://foo.test/1/canvas/c12');
     expect(getNodeIdToScrollTo(rangeFreeCanvasState, { companionWindowId: 'cw123', windowId: 'w1' })).toBe(null);
   });
 });

--- a/src/components/SidebarIndexTableOfContents.js
+++ b/src/components/SidebarIndexTableOfContents.js
@@ -8,6 +8,23 @@ import TreeItem from '@material-ui/lab/TreeItem';
 import { ScrollTo } from './ScrollTo';
 
 /** */
+function getStartCanvasId(node) {
+  const jsonld = node.data.__jsonld; // eslint-disable-line no-underscore-dangle
+  if (jsonld.startCanvas && typeof jsonld.startCanvas === 'string') {
+    return jsonld.startCanvas;
+  }
+  if (jsonld.start) {
+    if (jsonld.start.type === 'Canvas' && typeof jsonld.start.id === 'string') {
+      return jsonld.start.id;
+    }
+    if (jsonld.start.type === 'SpecificResource' && typeof jsonld.start.source === 'string') {
+      return jsonld.start.source;
+    }
+  }
+  return node.data.getCanvasIds()[0];
+}
+
+/** */
 export class SidebarIndexTableOfContents extends Component {
   /** */
   selectTreeItem(node) {
@@ -19,9 +36,7 @@ export class SidebarIndexTableOfContents extends Component {
     if (!node.data.getCanvasIds() || node.data.getCanvasIds().length === 0) {
       return;
     }
-    const target = node.data.__jsonld.startCanvas // eslint-disable-line no-underscore-dangle
-      || node.data.__jsonld.start // eslint-disable-line no-underscore-dangle
-      || node.data.getCanvasIds()[0];
+    const target = getStartCanvasId(node);
     const canvasId = target.indexOf('#') === -1 ? target : target.substr(0, target.indexOf('#'));
     setCanvas(windowId, canvasId);
   }

--- a/src/components/SidebarIndexTableOfContents.js
+++ b/src/components/SidebarIndexTableOfContents.js
@@ -19,7 +19,9 @@ export class SidebarIndexTableOfContents extends Component {
     if (!node.data.getCanvasIds() || node.data.getCanvasIds().length === 0) {
       return;
     }
-    const target = node.data.getCanvasIds()[0];
+    const target = node.data.__jsonld.startCanvas
+      || node.data.__jsonld.start
+      || node.data.getCanvasIds()[0];
     const canvasId = target.indexOf('#') === -1 ? target : target.substr(0, target.indexOf('#'));
     setCanvas(windowId, canvasId);
   }

--- a/src/components/SidebarIndexTableOfContents.js
+++ b/src/components/SidebarIndexTableOfContents.js
@@ -19,8 +19,8 @@ export class SidebarIndexTableOfContents extends Component {
     if (!node.data.getCanvasIds() || node.data.getCanvasIds().length === 0) {
       return;
     }
-    const target = node.data.__jsonld.startCanvas
-      || node.data.__jsonld.start
+    const target = node.data.__jsonld.startCanvas // eslint-disable-line no-underscore-dangle
+      || node.data.__jsonld.start // eslint-disable-line no-underscore-dangle
       || node.data.getCanvasIds()[0];
     const canvasId = target.indexOf('#') === -1 ? target : target.substr(0, target.indexOf('#'));
     setCanvas(windowId, canvasId);

--- a/src/state/selectors/ranges.js
+++ b/src/state/selectors/ranges.js
@@ -44,6 +44,7 @@ function getVisibleNodeIdsInSubTree(nodes, canvasIds) {
     if (nodeContainsVisibleCanvas || subTreeVisibleNodeIds.length > 0) {
       result.push({
         containsVisibleCanvas: nodeContainsVisibleCanvas,
+        descendantsContainVisibleCanvas: subTreeVisibleNodeIds.length > 0,
         id: node.id,
         leaf: node.nodes.length === 0,
         parentIds: getAllParentIds(node),
@@ -81,7 +82,7 @@ const getVisibleBranchNodeIds = createSelector(
     getVisibleLeafAndBranchNodeIds,
   ],
   visibleLeafAndBranchNodeIds => visibleLeafAndBranchNodeIds.reduce(
-    (acc, item) => (item.leaf ? acc : [...acc, item.id]),
+    (acc, item) => (item.leaf || !item.descendantsContainVisibleCanvas ? acc : [...acc, item.id]),
     [],
   ),
 );


### PR DESCRIPTION
* Use `start` / `startCanvas` if present.
* Do not auto-open nodes that do themselves contain currently visible canvases if none of their descendants do.

Will add testcases for both changes tomorrow.