### PR TITLE
Adds back in the displayable canvas width as a way to compute line width

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -355,7 +355,7 @@ describe('OpenSeadragonViewer', () => {
       wrapper.instance().annotationsToContext(annotations);
       const context = wrapper.instance().osdCanvasOverlay.context2d;
       expect(context.strokeStyle).toEqual('yellow');
-      expect(context.lineWidth).toEqual(20);
+      expect(context.lineWidth).toEqual(4);
       expect(strokeRect).toHaveBeenCalledWith(10, 10, 100, 200);
     });
   });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -184,12 +184,13 @@ export class OpenSeadragonViewer extends Component {
     const { canvasWorld } = this.props;
     const context = this.osdCanvasOverlay.context2d;
     const zoom = this.viewer.viewport.getZoom(true);
+    const width = canvasWorld.worldBounds()[2];
     annotations.forEach((annotation) => {
       annotation.resources.forEach((resource) => {
         if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
         const offset = canvasWorld.offsetByCanvas(resource.targetId);
         const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
-          color, offset, resource, zoom,
+          color, offset, resource, width, zoom,
         });
         canvasAnnotationDisplay.toContext(context);
       });

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -5,12 +5,13 @@
 export default class CanvasAnnotationDisplay {
   /** */
   constructor({
-    resource, color, zoom, offset,
+    resource, color, zoom, offset, width,
   }) {
     this.resource = resource;
     this.color = color;
     this.zoom = zoom;
     this.offset = offset;
+    this.width = width || 1000;
   }
 
   /** */
@@ -60,7 +61,7 @@ export default class CanvasAnnotationDisplay {
 
   /** */
   lineWidth() {
-    return Math.ceil(1 / (this.zoom * 100));
+    return Math.ceil(10 / (this.zoom * this.width));
   }
 
   /** */


### PR DESCRIPTION
Removed in 58cf710b3199e8b9ed8968be98931e171da4dcf7 as I thought this might be a better algorithm for determining lineWidth, but it seems worse in many scenarios.

Open to other ways to do this if anyone else has other ideas.

See https://purl.stanford.edu/fg165hz3589/iiif/manifest

## Before
<img width="1117" alt="Screen Shot 2020-04-15 at 2 49 10 PM" src="https://user-images.githubusercontent.com/1656824/79387322-b62c5700-7f28-11ea-9fba-f00c012df192.png">

## After
<img width="1115" alt="Screen Shot 2020-04-15 at 2 48 43 PM" src="https://user-images.githubusercontent.com/1656824/79387328-b7f61a80-7f28-11ea-985e-1bda04f1e6b0.png">
