### PR TITLE
Better level 0 support (updated canvases and v3)

### DIFF
--- a/__tests__/fixtures/version-3/minimumRequired.json
+++ b/__tests__/fixtures/version-3/minimumRequired.json
@@ -1,0 +1,39 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Image 1"
+    ]
+  },
+  "items": [
+    {
+      "id": "https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/canvas/p1",
+      "type": "Canvas",
+      "height": 1800,
+      "width": 1200,
+      "items": [
+        {
+          "id": "https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                "type": "Image",
+                "format": "image/png",
+                "height": 1800,
+                "width": 1200
+              },
+              "target": "https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -35,6 +35,9 @@ describe('OpenSeadragonViewer', () => {
           height: 201,
           width: 150,
         }]}
+        nonTiledImages={[{
+          id: 'http://foo',
+        }]}
         windowId="base"
         config={{}}
         updateViewport={updateViewport}
@@ -115,6 +118,22 @@ describe('OpenSeadragonViewer', () => {
     });
     it('when the @ids do match', () => {
       expect(wrapper.instance().tileSourcesMatch([{ '@id': 'http://foo' }])).toBe(true);
+    });
+  });
+
+  describe('nonTiledImagedMatch', () => {
+    it('when they do not match', () => {
+      expect(wrapper.instance().nonTiledImagedMatch([])).toBe(false);
+    });
+    it('with an empty array', () => {
+      wrapper.instance().viewer = {
+        close: () => {},
+      };
+      wrapper.setProps({ nonTiledImages: [] });
+      expect(wrapper.instance().nonTiledImagedMatch([])).toBe(true);
+    });
+    it('when the ids do match', () => {
+      expect(wrapper.instance().nonTiledImagedMatch([{ id: 'http://foo' }])).toBe(true);
     });
   });
 

--- a/__tests__/src/selectors/canvases.test.js
+++ b/__tests__/src/selectors/canvases.test.js
@@ -1,6 +1,7 @@
 import manifestFixture001 from '../../fixtures/version-2/001.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import minimumRequired from '../../fixtures/version-2/minimumRequired.json';
+import minimumRequired3 from '../../fixtures/version-3/minimumRequired.json';
 
 import {
   getVisibleCanvases,
@@ -414,5 +415,24 @@ describe('getVisibleCanvasNonTiledResources', () => {
     expect(getVisibleCanvasNonTiledResources(
       state, { windowId: 'a' },
     )[0].id).toBe('http://iiif.io/api/presentation/2.0/example/fixtures/resources/page1-full.png');
+  });
+  it('works for v3 Presentation API', () => {
+    const state = {
+      manifests: {
+        'https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/manifest.json': {
+          id: 'https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/manifest.json',
+          json: minimumRequired3,
+        },
+      },
+      windows: {
+        a: {
+          canvasId: 'https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/canvas/p1',
+          manifestId: 'https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/manifest.json',
+        },
+      },
+    };
+    expect(getVisibleCanvasNonTiledResources(
+      state, { windowId: 'a' },
+    )[0].id).toBe('http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png');
   });
 });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -123,7 +123,9 @@ export class OpenSeadragonViewer extends Component {
       this.viewer.forceRedraw();
     }
 
-    if (!this.tileSourcesMatch(prevProps.tileSources)) {
+    if (!this.tileSourcesMatch(prevProps.tileSources)
+      || !this.nonTiledImagedMatch(prevProps.nonTiledImages)
+    ) {
       this.viewer.close();
       this.addAllImageSources();
     } else if (viewer && !this.osdUpdating) {
@@ -271,6 +273,25 @@ export class OpenSeadragonViewer extends Component {
         return false;
       }
       if (tileSource['@id'] === prevTileSources[index]['@id']) {
+        return true;
+      }
+      return false;
+    });
+  }
+
+  /**
+   * nonTiledImagedMatch - compares previous images to current to determin
+   * whether a refresh of the OSD viewer is needed
+   */
+  nonTiledImagedMatch(prevNonTiledImages) {
+    const { nonTiledImages } = this.props;
+    if (nonTiledImages.length === 0 && prevNonTiledImages.length === 0) return true;
+
+    return nonTiledImages.some((image, index) => {
+      if (!prevNonTiledImages[index]) {
+        return false;
+      }
+      if (image.id === prevNonTiledImages[index].id) {
         return true;
       }
       return false;

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -175,11 +175,25 @@ export const getVisibleCanvasNonTiledResources = createSelector(
   [
     getVisibleCanvases,
   ],
-  canvases => canvases && flatten(canvases
+  canvases => canvases
+    && iiifV2NonTiledResources(canvases).concat(iiifV3NonTiledResources(canvases)),
+);
+
+/** */
+function iiifV2NonTiledResources(canvases) {
+  return flatten(canvases
     .map(canvas => canvas.getImages()
       .map(image => image.getResource())))
-    .filter(resource => resource.getServices().length < 1),
-);
+    .filter(resource => resource.getServices().length < 1);
+}
+
+/** */
+function iiifV3NonTiledResources(canvases) {
+  return flatten(canvases
+    .map(canvas => flatten(canvas.getContent()
+      .map(image => image.getBody()))))
+    .filter(body => body.getServices().length < 1);
+}
 
 export const selectInfoResponse = createSelector(
   [


### PR DESCRIPTION
A follow on to #2976 this pr supports level 0 for Presentation v3 content and updates the OSD viewer when non-tiled images change (canvas nav)

v3 manifest for testing https://preview.iiif.io/cookbook/master/recipe/0001-mvm-image/manifest.json