### PR TITLE
RTL fixes for dir="rtl" viewing of Mirador.

### DIFF
--- a/__tests__/src/components/App.test.js
+++ b/__tests__/src/components/App.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { MuiThemeProvider } from '@material-ui/core/styles';
+import { ThemeProvider, StylesProvider } from '@material-ui/core/styles';
 import Fullscreen from 'react-full-screen';
 import AccessTokenSender from '../../../src/containers/AccessTokenSender';
 import AuthenticationSender from '../../../src/containers/AuthenticationSender';
@@ -27,7 +27,8 @@ function createWrapper(props) {
 describe('App', () => {
   it('should render all needed elements ', () => {
     const wrapper = createWrapper();
-    expect(wrapper.find(MuiThemeProvider).length).toBe(1);
+    expect(wrapper.find(ThemeProvider).length).toBe(1);
+    expect(wrapper.find(StylesProvider).length).toBe(1);
     expect(wrapper.find(Fullscreen).length).toBe(1);
     expect(wrapper.find('Suspense').length).toBe(1);
     expect(wrapper.find(AuthenticationSender).length).toBe(1);
@@ -36,7 +37,7 @@ describe('App', () => {
 
   it('sets up a theme based on the config passed in merged w/ MaterialUI', () => {
     const wrapper = createWrapper();
-    const { theme } = wrapper.find(MuiThemeProvider).props();
+    const { theme } = wrapper.find(ThemeProvider).props();
     expect(theme.palette.type).toEqual('light');
     expect(theme.typography.useNextVariants).toBe(true);
     expect(Object.keys(theme).length).toBeGreaterThan(10);

--- a/__tests__/src/components/CompanionArea.test.js
+++ b/__tests__/src/components/CompanionArea.test.js
@@ -10,6 +10,7 @@ function createWrapper(props) {
   return shallow(
     <CompanionArea
       classes={{ horizontal: 'horizontal' }}
+      direction="ltr"
       windowId="abc123"
       position="right"
       companionAreaOpen

--- a/__tests__/src/components/CompanionArea.test.js
+++ b/__tests__/src/components/CompanionArea.test.js
@@ -27,6 +27,23 @@ describe('CompanionArea', () => {
     expect(wrapper.find(Slide).prop('direction')).toBe('left');
   });
 
+  it('when rtl, the left slide should be from the right', () => {
+    const wrapper = createWrapper({
+      direction: 'rtl',
+    });
+    expect(wrapper.find(CompanionWindowFactory).length).toBe(2);
+    expect(wrapper.find(Slide).prop('direction')).toBe('right');
+  });
+
+  it('when rtl, the right slide should be from the left', () => {
+    const wrapper = createWrapper({
+      direction: 'rtl',
+      position: 'left',
+    });
+    expect(wrapper.find(CompanionWindowFactory).length).toBe(2);
+    expect(wrapper.find(Slide).prop('direction')).toBe('left');
+  });
+
   it('should add the appropriate classes when the companion area fills the full width', () => {
     const wrapper = createWrapper({ position: 'bottom' });
     expect(wrapper.find('div.horizontal').length).toBe(2);

--- a/__tests__/src/components/CompanionWindow.test.js
+++ b/__tests__/src/components/CompanionWindow.test.js
@@ -9,6 +9,7 @@ function createWrapper(props) {
   return shallow(
     <CompanionWindow
       id="abc123"
+      direction="ltr"
       windowId="x"
       classes={{ horizontal: 'horizontal', small: 'small', vertical: 'vertical' }}
       companionWindow={{}}

--- a/__tests__/src/components/SearchPanelNavigation.test.js
+++ b/__tests__/src/components/SearchPanelNavigation.test.js
@@ -10,6 +10,7 @@ function createWrapper(props) {
   return shallow(
     <SearchPanelNavigation
       companionWindowId="cw"
+      direction="ltr"
       windowId="window"
       {...props}
     />,

--- a/__tests__/src/components/WindowSideBar.test.js
+++ b/__tests__/src/components/WindowSideBar.test.js
@@ -26,4 +26,14 @@ describe('WindowSideBar', () => {
     expect(wrapper.find(Drawer).length).toBe(1);
     expect(wrapper.find(Drawer).prop('open')).toBe(true);
   });
+  it('when ltr', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find(Drawer).prop('anchor')).toBe('left');
+  });
+  it('when rtl', () => {
+    const wrapper = createWrapper({
+      direction: 'rtl',
+    });
+    expect(wrapper.find(Drawer).prop('anchor')).toBe('right');
+  });
 });

--- a/__tests__/src/components/WindowThumbnailSettings.test.js
+++ b/__tests__/src/components/WindowThumbnailSettings.test.js
@@ -10,6 +10,7 @@ function createWrapper(props) {
   return shallow(
     <WindowThumbnailSettings
       classes={{}}
+      direction="ltr"
       windowId="xyz"
       setWindowThumbnailPosition={() => {}}
       thumbnailNavigationPosition="off"
@@ -46,5 +47,10 @@ describe('WindowThumbnailSettings', () => {
     expect(setWindowThumbnailPosition).toHaveBeenCalledWith('xyz', 'off');
     wrapper.find(MenuItem).at(2).simulate('click');
     expect(setWindowThumbnailPosition).toHaveBeenCalledWith('xyz', 'far-right');
+  });
+
+  it('when rtl flips an icon', () => {
+    const wrapper = createWrapper({ direction: 'rtl' });
+    expect(wrapper.find(FormControlLabel).at(2).props().control.props.style).toEqual({ transform: 'rotate(180deg)' });
   });
 });

--- a/__tests__/src/selectors/config.test.js
+++ b/__tests__/src/selectors/config.test.js
@@ -4,6 +4,7 @@ import {
   getTheme,
   getThemeIds,
   getContainerId,
+  getThemeDirection,
 } from '../../../src/state/selectors';
 
 describe('getLanguagesFromConfigWithCurrent', () => {
@@ -93,5 +94,16 @@ describe('getContainerId', () => {
   it('returns the container id', () => {
     const state = { config: { id: 'mirador' } };
     expect(getContainerId(state)).toEqual('mirador');
+  });
+});
+
+describe('getThemeDirection', () => {
+  it('returns the configured theme direction', () => {
+    const state = { config: { theme: { direction: 'rtl' } } };
+    expect(getThemeDirection(state)).toBe('rtl');
+  });
+  it('returns ltr as default', () => {
+    const state = { config: { theme: { } } };
+    expect(getThemeDirection(state)).toBe('ltr');
   });
 });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "immutable": "^4.0.0-rc.12",
     "intersection-observer": "^0.7.0",
     "isomorphic-unfetch": "^3.0.0",
+    "jss": "^10.1.1",
+    "jss-rtl": "^0.3.0",
     "lodash": "^4.17.11",
     "manifesto.js": "^4.0.1",
     "normalize-url": "^4.2.0",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,11 @@
 import React, { Component, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import {
+  ThemeProvider, StylesProvider, createMuiTheme, jssPreset,
+} from '@material-ui/core/styles';
 import Fullscreen from 'react-full-screen';
+import { create } from 'jss';
+import rtl from 'jss-rtl';
 import { I18nextProvider } from 'react-i18next';
 import { LiveAnnouncer } from 'react-aria-live';
 import createI18nInstance from '../i18n';
@@ -62,15 +66,19 @@ export class App extends Component {
       >
         <I18nextProvider i18n={this.i18n}>
           <LiveAnnouncer>
-            <MuiThemeProvider theme={createMuiTheme(theme)}>
-              <AuthenticationSender />
-              <AccessTokenSender />
-              <Suspense
-                fallback={<div />}
-              >
-                <WorkspaceArea />
-              </Suspense>
-            </MuiThemeProvider>
+            <ThemeProvider
+              theme={createMuiTheme(theme)}
+            >
+              <StylesProvider jss={create({ plugins: [...jssPreset().plugins, rtl()] })}>
+                <AuthenticationSender />
+                <AccessTokenSender />
+                <Suspense
+                  fallback={<div />}
+                >
+                  <WorkspaceArea />
+                </Suspense>
+              </StylesProvider>
+            </ThemeProvider>
           </LiveAnnouncer>
         </I18nextProvider>
       </Fullscreen>

--- a/src/components/CollapsibleSection.js
+++ b/src/components/CollapsibleSection.js
@@ -35,7 +35,15 @@ export class CollapsibleSection extends Component {
 
     return (
       <>
-        <div>
+        <div className={classes.container}>
+          <Typography
+            className={classes.heading}
+            id={id}
+            onClick={this.toggleSection}
+            variant="overline"
+          >
+            {label}
+          </Typography>
           <MiradorMenuButton
             aria-label={
               t(
@@ -48,14 +56,6 @@ export class CollapsibleSection extends Component {
           >
             {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
           </MiradorMenuButton>
-          <Typography
-            className={classes.heading}
-            id={id}
-            onClick={this.toggleSection}
-            variant="overline"
-          >
-            {label}
-          </Typography>
         </div>
         {open && children}
       </>

--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -20,17 +20,19 @@ export class CompanionArea extends Component {
 
   /** @private */
   slideDirection() {
-    const { position } = this.props;
+    const { direction, position } = this.props;
+    const defaultPosition = direction === 'rtl' ? 'left' : 'right';
+    const oppositePosition = direction === 'rtl' ? 'right' : 'left';
 
     switch (position) {
       case 'right':
       case 'far-right':
-        return 'left';
+        return oppositePosition;
       case 'bottom':
       case 'far-bottom':
         return 'up';
       default:
-        return 'right';
+        return defaultPosition;
     }
   }
 
@@ -77,6 +79,7 @@ CompanionArea.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
   companionAreaOpen: PropTypes.bool.isRequired,
   companionWindowIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  direction: PropTypes.string.isRequired,
   position: PropTypes.string.isRequired,
   setCompanionAreaOpen: PropTypes.func,
   sideBarOpen: PropTypes.bool,

--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -21,13 +21,12 @@ export class CompanionArea extends Component {
   /** */
   collapseIcon() {
     const { companionAreaOpen, direction } = this.props;
-    if (companionAreaOpen) {
-      if (direction === 'ltr') {
-        return <ArrowLeftIcon />;
-      }
-      return <ArrowRightIcon />;
+    if (direction === 'rtl') {
+      if (companionAreaOpen) return <ArrowRightIcon />;
+      return <ArrowLeftIcon />;
     }
-    if (direction === 'rtl') return <ArrowLeftIcon />;
+
+    if (companionAreaOpen) return <ArrowLeftIcon />;
     return <ArrowRightIcon />;
   }
 

--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -18,6 +18,19 @@ export class CompanionArea extends Component {
     return (position === 'bottom' || position === 'far-bottom') ? classes.horizontal : null;
   }
 
+  /** */
+  collapseIcon() {
+    const { companionAreaOpen, direction } = this.props;
+    if (companionAreaOpen) {
+      if (direction === 'ltr') {
+        return <ArrowLeftIcon />;
+      }
+      return <ArrowRightIcon />;
+    }
+    if (direction === 'rtl') return <ArrowLeftIcon />;
+    return <ArrowRightIcon />;
+  }
+
   /** @private */
   slideDirection() {
     const { direction, position } = this.props;
@@ -56,7 +69,7 @@ export class CompanionArea extends Component {
                 onClick={() => { setCompanionAreaOpen(windowId, !companionAreaOpen); }}
                 TooltipProps={{ placement: 'right' }}
               >
-                {companionAreaOpen ? <ArrowLeftIcon /> : <ArrowRightIcon />}
+                {this.collapseIcon()}
               </MiradorMenuButton>
             </div>
           )

--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -15,8 +15,27 @@ import ns from '../config/css-ns';
  */
 export class CompanionWindow extends Component {
   /** */
+  openInNewStyle() {
+    const { direction } = this.props;
+    if (direction === 'rtl') return { transform: 'scale(-1, 1)' };
+    return {};
+  }
+
+
+  /** */
   resizeHandles() {
-    const { position } = this.props;
+    const { direction, position } = this.props;
+    const positions = {
+      ltr: {
+        default: 'left',
+        opposite: 'right',
+      },
+      rtl: {
+        default: 'right',
+        opposite: 'left',
+      },
+    };
+
 
     const base = {
       bottom: false,
@@ -30,11 +49,11 @@ export class CompanionWindow extends Component {
     };
 
     if (position === 'right' || position === 'far-right') {
-      return { ...base, left: true };
+      return { ...base, [positions[direction].default]: true };
     }
 
     if (position === 'left') {
-      return { ...base, right: true };
+      return { ...base, [positions[direction].opposite]: true };
     }
 
     if (position === 'bottom' || position === 'far-bottom') {
@@ -100,7 +119,7 @@ export class CompanionWindow extends Component {
                       aria-label={t('openInCompanionWindow')}
                       onClick={() => { updateCompanionWindow(windowId, id, { position: 'right' }); }}
                     >
-                      <OpenInNewIcon />
+                      <OpenInNewIcon style={this.openInNewStyle()} />
                     </MiradorMenuButton>
                   )
                 : (
@@ -156,6 +175,7 @@ CompanionWindow.propTypes = {
   children: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   defaultSidebarPanelWidth: PropTypes.number,
+  direction: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   isDisplayed: PropTypes.bool,
   onCloseClick: PropTypes.func,

--- a/src/components/SearchPanelNavigation.js
+++ b/src/components/SearchPanelNavigation.js
@@ -42,8 +42,11 @@ export class SearchPanelNavigation extends Component {
   */
   render() {
     const {
-      searchHits, selectedContentSearchAnnotation, classes, t,
+      searchHits, selectedContentSearchAnnotation, classes, t, direction,
     } = this.props;
+
+    const iconStyle = direction === 'rtl' ? { transform: 'rotate(180deg)' } : {};
+
     const currentHitIndex = searchHits
       .findIndex(val => val.annotations.includes(selectedContentSearchAnnotation[0]));
     return (
@@ -55,15 +58,17 @@ export class SearchPanelNavigation extends Component {
               disabled={!this.hasPreviousResult(currentHitIndex)}
               onClick={() => this.previousSearchResult(currentHitIndex)}
             >
-              <ChevronLeftIcon />
+              <ChevronLeftIcon style={iconStyle} />
             </MiradorMenuButton>
+            <span style={{ unicodeBidi: 'plaintext' }}>
               {t('pagination', { current: currentHitIndex + 1, total: searchHits.length })}
+            </span>
             <MiradorMenuButton
               aria-label={t('searchNextResult')}
               disabled={!this.hasNextResult(currentHitIndex)}
               onClick={() => this.nextSearchResult(currentHitIndex)}
             >
-              <ChevronRightIcon />
+              <ChevronRightIcon style={iconStyle} />
             </MiradorMenuButton>
           </Typography>
         )}
@@ -73,6 +78,7 @@ export class SearchPanelNavigation extends Component {
 }
 SearchPanelNavigation.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
+  direction: PropTypes.string.isRequired,
   searchHits: PropTypes.arrayOf(PropTypes.object),
   searchService: PropTypes.shape({
     id: PropTypes.string,

--- a/src/components/WindowSideBar.js
+++ b/src/components/WindowSideBar.js
@@ -14,7 +14,7 @@ export class WindowSideBar extends Component {
    */
   render() {
     const {
-      classes, t, windowId, sideBarOpen,
+      classes, direction, t, windowId, sideBarOpen,
     } = this.props;
 
     return (
@@ -23,13 +23,13 @@ export class WindowSideBar extends Component {
           variant="persistent"
           className={classNames(classes.drawer)}
           classes={{ paper: classNames(classes.paper) }}
-          anchor="left"
+          anchor={direction === 'rtl' ? 'right' : 'left'}
           PaperProps={{
             'aria-label': t('sidebarPanelsNavigation'),
             component: 'nav',
-            style: { position: 'relative' },
+            style: { height: '100%', position: 'relative' },
           }}
-          SlideProps={{ mountOnEnter: true, unmountOnExit: true }}
+          SlideProps={{ direction: direction === 'rtl' ? 'left' : 'right', mountOnEnter: true, unmountOnExit: true }}
           open={sideBarOpen}
         >
           <WindowSideBarButtons windowId={windowId} />
@@ -41,6 +41,7 @@ export class WindowSideBar extends Component {
 
 WindowSideBar.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  direction: PropTypes.string.isRequired,
   sideBarOpen: PropTypes.bool,
   t: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,

--- a/src/components/WindowThumbnailSettings.js
+++ b/src/components/WindowThumbnailSettings.js
@@ -34,7 +34,7 @@ export class WindowThumbnailSettings extends Component {
    */
   render() {
     const {
-      classes, handleClose, t, thumbnailNavigationPosition,
+      classes, handleClose, t, thumbnailNavigationPosition, direction,
     } = this.props;
 
     return (
@@ -67,9 +67,12 @@ export class WindowThumbnailSettings extends Component {
           <FormControlLabel
             value="far-right"
             classes={{ label: thumbnailNavigationPosition === 'far-right' ? classes.selectedLabel : classes.label }}
-            control={
-              <ThumbnailNavigationRightIcon color={thumbnailNavigationPosition === 'far-right' ? 'secondary' : undefined} />
-            }
+            control={(
+              <ThumbnailNavigationRightIcon
+                color={thumbnailNavigationPosition === 'far-right' ? 'secondary' : undefined}
+                style={direction === 'rtl' ? { transform: 'rotate(180deg)' } : {}}
+              />
+            )}
             label={t('right')}
             labelPlacement="bottom"
           />
@@ -81,6 +84,7 @@ export class WindowThumbnailSettings extends Component {
 
 WindowThumbnailSettings.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  direction: PropTypes.string.isRequired,
   handleClose: PropTypes.func,
   setWindowThumbnailPosition: PropTypes.func.isRequired,
   t: PropTypes.func,

--- a/src/containers/CollapsibleSection.js
+++ b/src/containers/CollapsibleSection.js
@@ -5,8 +5,11 @@ import { CollapsibleSection } from '../components/CollapsibleSection';
 
 const styles = {
   button: {
-    float: 'right',
     padding: 0,
+  },
+  container: {
+    display: 'flex',
+    justifyContent: 'space-between',
   },
   heading: {
     cursor: 'pointer',

--- a/src/containers/CompanionArea.js
+++ b/src/containers/CompanionArea.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
-import { getCompanionWindowIdsForPosition, getCompanionAreaVisibility, getWindow } from '../state/selectors';
+import {
+  getCompanionWindowIdsForPosition, getCompanionAreaVisibility, getThemeDirection, getWindow,
+} from '../state/selectors';
 import * as actions from '../state/actions';
 import { CompanionArea } from '../components/CompanionArea';
 
@@ -11,6 +13,7 @@ import { CompanionArea } from '../components/CompanionArea';
 const mapStateToProps = (state, { windowId, position }) => ({
   companionAreaOpen: getCompanionAreaVisibility(state, { position, windowId }),
   companionWindowIds: getCompanionWindowIdsForPosition(state, { position, windowId }),
+  direction: getThemeDirection(state),
   sideBarOpen: (getWindow(state, { windowId }) || {}).sideBarOpen,
 });
 

--- a/src/containers/CompanionWindow.js
+++ b/src/containers/CompanionWindow.js
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core';
 import { withSize } from 'react-sizeme';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getCompanionWindow } from '../state/selectors';
+import { getCompanionWindow, getThemeDirection } from '../state/selectors';
 import { CompanionWindow } from '../components/CompanionWindow';
 
 /**
@@ -20,6 +20,7 @@ const mapStateToProps = (state, { id, windowId }) => {
   return {
     ...companionWindow,
     defaultSidebarPanelWidth,
+    direction: getThemeDirection(state),
     isDisplayed: (companionWindow
                   && companionWindow.content
                   && companionWindow.content.length > 0),

--- a/src/containers/SearchPanelNavigation.js
+++ b/src/containers/SearchPanelNavigation.js
@@ -8,6 +8,7 @@ import * as actions from '../state/actions';
 import {
   getSelectedContentSearchAnnotationIds,
   getSortedSearchHitsForCompanionWindow,
+  getThemeDirection,
 } from '../state/selectors';
 
 /**
@@ -16,6 +17,7 @@ import {
  * @private
  */
 const mapStateToProps = (state, { companionWindowId, windowId }) => ({
+  direction: getThemeDirection(state),
   searchHits: getSortedSearchHitsForCompanionWindow(state, { companionWindowId, windowId }),
   selectedContentSearchAnnotation: getSelectedContentSearchAnnotationIds(state, {
     companionWindowId, windowId,

--- a/src/containers/ViewerInfo.js
+++ b/src/containers/ViewerInfo.js
@@ -32,6 +32,7 @@ const styles = {
     overflow: 'hidden',
     paddingBottom: 3,
     textOverflow: 'ellipsis',
+    unicodeBidi: 'plaintext',
     whiteSpace: 'nowrap',
     width: '100%',
   },

--- a/src/containers/WindowSideBar.js
+++ b/src/containers/WindowSideBar.js
@@ -36,6 +36,7 @@ const styles = theme => ({
     flexGrow: 1,
   },
   paper: {
+    borderInlineEnd: `1px solid ${theme.palette.divider}`,
     overflowX: 'hidden',
     width: 48,
   },

--- a/src/containers/WindowSideBar.js
+++ b/src/containers/WindowSideBar.js
@@ -4,7 +4,7 @@ import { withStyles } from '@material-ui/core';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import { WindowSideBar } from '../components/WindowSideBar';
-import { getWindow } from '../state/selectors';
+import { getThemeDirection, getWindow } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -13,6 +13,7 @@ import { getWindow } from '../state/selectors';
  */
 const mapStateToProps = (state, { windowId }) => (
   {
+    direction: getThemeDirection(state),
     sideBarOpen: (getWindow(state, { windowId }) || {}).sideBarOpen,
     sideBarPanel: (getWindow(state, { windowId }) || {}).sideBarPanel,
   }
@@ -28,7 +29,6 @@ const styles = theme => ({
   drawer: {
     flexShrink: 0,
     height: '100%',
-    left: 0,
     order: -1000,
     zIndex: theme.zIndex.appBar - 1,
   },

--- a/src/containers/WindowThumbnailSettings.js
+++ b/src/containers/WindowThumbnailSettings.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getThumbnailNavigationPosition } from '../state/selectors';
+import { getThumbnailNavigationPosition, getThemeDirection } from '../state/selectors';
 import { WindowThumbnailSettings } from '../components/WindowThumbnailSettings';
 
 /**
@@ -21,6 +21,7 @@ const mapDispatchToProps = { setWindowThumbnailPosition: actions.setWindowThumbn
  */
 const mapStateToProps = (state, { windowId }) => (
   {
+    direction: getThemeDirection(state),
     thumbnailNavigationPosition: getThumbnailNavigationPosition(state, { windowId }),
   }
 );

--- a/src/state/selectors/config.js
+++ b/src/state/selectors/config.js
@@ -51,3 +51,8 @@ export const getDefaultView = createSelector(
   [getConfig],
   ({ window }) => window && window.defaultView,
 );
+
+export const getThemeDirection = createSelector(
+  [getConfig],
+  ({ theme }) => theme.direction || 'ltr',
+);


### PR DESCRIPTION
Fixes part of #2843 and fixes part of https://github.com/sul-dlss/dlme/issues/942
![Kapture 2020-04-21 at 17 06 43](https://user-images.githubusercontent.com/1656824/79923342-88e11c80-83f2-11ea-88d4-e0a577714523.gif)

The main piece of work this does not capture is the relabeling of section headers for "book view" multi canvas metadata. I think that should be done separately or we should talk about how best to handle that.
