### PR TITLE
Support SVG/m2 styling of svg annos

### DIFF
--- a/__tests__/integration/mirador/svg_annos.html
+++ b/__tests__/integration/mirador/svg_annos.html
@@ -15,6 +15,9 @@
        id: 'mirador',
        windows: [
          {
+           manifestId: 'https://collections.st-andrews.ac.uk/manifest-test/555859.json',
+         },
+         {
            manifestId: 'https://collections.st-andrews.ac.uk/manifest-test/test-manifest.json',
          },
          {

--- a/__tests__/integration/mirador/svg_annos.html
+++ b/__tests__/integration/mirador/svg_annos.html
@@ -15,7 +15,7 @@
        id: 'mirador',
        windows: [
          {
-           manifestId: 'https://api.myjson.com/bins/ahd5y',
+           manifestId: 'https://collections.st-andrews.ac.uk/manifest-test/test-manifest.json',
          },
          {
            manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/748a9d50-5a3a-440e-ab9d-567dd68b6abb.json',

--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -412,7 +412,8 @@ describe('OpenSeadragonViewer', () => {
       };
       wrapper.instance().viewer = {
         viewport: {
-          getZoom: () => (0.0005),
+          getMaxZoom: () => (1),
+          getZoom: () => (0.05),
         },
       };
 
@@ -424,7 +425,7 @@ describe('OpenSeadragonViewer', () => {
       wrapper.instance().annotationsToContext(annotations);
       const context = wrapper.instance().osdCanvasOverlay.context2d;
       expect(context.strokeStyle).toEqual('yellow');
-      expect(context.lineWidth).toEqual(4);
+      expect(context.lineWidth).toEqual(20);
       expect(strokeRect).toHaveBeenCalledWith(10, 10, 100, 200);
     });
   });

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -10,7 +10,7 @@ function createSubject(args) {
       x: -100,
       y: 0,
     },
-    zoom: 0.0005,
+    zoomRatio: 0.5,
     ...args,
   });
 }
@@ -72,7 +72,7 @@ describe('CanvasAnnotationDisplay', () => {
       expect(context.restore).toHaveBeenCalledWith();
       expect(context.translate).toHaveBeenCalledWith(-100, 0);
       expect(context.strokeStyle).toEqual('#00bfff');
-      expect(context.lineWidth).toEqual(617.4334);
+      expect(context.lineWidth).toEqual(61.74334);
       expect(context.fill).toHaveBeenCalled();
     });
   });
@@ -88,7 +88,7 @@ describe('CanvasAnnotationDisplay', () => {
       subject.fragmentContext();
       expect(context.strokeRect).toHaveBeenCalledWith(-90, 10, 100, 200);
       expect(context.strokeStyle).toEqual('blue');
-      expect(context.lineWidth).toEqual(20);
+      expect(context.lineWidth).toEqual(2);
     });
   });
 });

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -57,6 +57,7 @@ describe('CanvasAnnotationDisplay', () => {
       const context = {
         restore: jest.fn(),
         save: jest.fn(),
+        setLineDash: jest.fn(),
         stroke: jest.fn(),
         translate: jest.fn(),
       };
@@ -68,8 +69,8 @@ describe('CanvasAnnotationDisplay', () => {
       expect(context.save).toHaveBeenCalledWith();
       expect(context.restore).toHaveBeenCalledWith();
       expect(context.translate).toHaveBeenCalledWith(-100, 0);
-      expect(context.strokeStyle).toEqual('blue');
-      expect(context.lineWidth).toEqual(20);
+      expect(context.strokeStyle).toEqual('#00bfff');
+      expect(context.lineWidth).toEqual(617.4334);
     });
   });
   describe('fragmentContext', () => {

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -55,6 +55,7 @@ describe('CanvasAnnotationDisplay', () => {
   describe('svgContext', () => {
     it('draws the paths with selected arguments', () => {
       const context = {
+        fill: jest.fn(),
         restore: jest.fn(),
         save: jest.fn(),
         setLineDash: jest.fn(),
@@ -72,6 +73,7 @@ describe('CanvasAnnotationDisplay', () => {
       expect(context.translate).toHaveBeenCalledWith(-100, 0);
       expect(context.strokeStyle).toEqual('#00bfff');
       expect(context.lineWidth).toEqual(617.4334);
+      expect(context.fill).toHaveBeenCalled();
     });
   });
   describe('fragmentContext', () => {

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -75,6 +75,23 @@ describe('CanvasAnnotationDisplay', () => {
       expect(context.lineWidth).toEqual(61.74334);
       expect(context.fill).toHaveBeenCalled();
     });
+    it('resets the color if selected rather than using the SVG color', () => {
+      const context = {
+        fill: jest.fn(),
+        restore: jest.fn(),
+        save: jest.fn(),
+        setLineDash: jest.fn(),
+        stroke: jest.fn(),
+        translate: jest.fn(),
+      };
+      const subject = createSubject({
+        resource: new AnnotationResource(dualStrategyAnno),
+        selected: true,
+      });
+      subject.context = context;
+      subject.svgContext();
+      expect(subject.context.strokeStyle).toBe('blue');
+    });
   });
   describe('fragmentContext', () => {
     it('draws the fragment with selected arguments', () => {

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -64,7 +64,8 @@ describe('CanvasAnnotationDisplay', () => {
       const subject = createSubject({
         resource: new AnnotationResource(dualStrategyAnno),
       });
-      subject.svgContext(context);
+      subject.context = context;
+      subject.svgContext();
       expect(context.stroke).toHaveBeenCalledWith({});
       expect(context.save).toHaveBeenCalledWith();
       expect(context.restore).toHaveBeenCalledWith();
@@ -81,7 +82,8 @@ describe('CanvasAnnotationDisplay', () => {
       const subject = createSubject({
         resource: new AnnotationResource({ on: 'www.example.com/#xywh=10,10,100,200' }),
       });
-      subject.fragmentContext(context);
+      subject.context = context;
+      subject.fragmentContext();
       expect(context.strokeRect).toHaveBeenCalledWith(-90, 10, 100, 200);
       expect(context.strokeStyle).toEqual('blue');
       expect(context.lineWidth).toEqual(20);

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -188,14 +188,13 @@ export class OpenSeadragonViewer extends Component {
   annotationsToContext(annotations, color = 'yellow') {
     const { canvasWorld } = this.props;
     const context = this.osdCanvasOverlay.context2d;
-    const zoom = this.viewer.viewport.getZoom(true);
-    const width = canvasWorld.worldBounds()[2];
+    const zoomRatio = this.viewer.viewport.getZoom(true) / this.viewer.viewport.getMaxZoom();
     annotations.forEach((annotation) => {
       annotation.resources.forEach((resource) => {
         if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
         const offset = canvasWorld.offsetByCanvas(resource.targetId);
         const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
-          color, offset, resource, width, zoom,
+          color, offset, resource, zoomRatio,
         });
         canvasAnnotationDisplay.toContext(context);
       });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -185,7 +185,7 @@ export class OpenSeadragonViewer extends Component {
   /**
    * annotationsToContext - converts anontations to a canvas context
    */
-  annotationsToContext(annotations, color = 'yellow') {
+  annotationsToContext(annotations, color = 'yellow', selected = false) {
     const { canvasWorld } = this.props;
     const context = this.osdCanvasOverlay.context2d;
     const zoomRatio = this.viewer.viewport.getZoom(true) / this.viewer.viewport.getMaxZoom();
@@ -194,7 +194,7 @@ export class OpenSeadragonViewer extends Component {
         if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
         const offset = canvasWorld.offsetByCanvas(resource.targetId);
         const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
-          color, offset, resource, zoomRatio,
+          color, offset, resource, selected, zoomRatio,
         });
         canvasAnnotationDisplay.toContext(context);
       });
@@ -358,10 +358,11 @@ export class OpenSeadragonViewer extends Component {
     this.annotationsToContext(
       selectedContentSearchAnnotations,
       palette.highlights.primary,
+      true,
     );
 
     this.annotationsToContext(highlightedAnnotations, palette.highlights.secondary);
-    this.annotationsToContext(selectedAnnotations, palette.highlights.primary);
+    this.annotationsToContext(selectedAnnotations, palette.highlights.primary, true);
   }
 
   /**

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -16,10 +16,11 @@ export default class CanvasAnnotationDisplay {
 
   /** */
   toContext(context) {
+    this.context = context;
     if (this.resource.svgSelector) {
-      this.svgContext(context);
+      this.svgContext();
     } else {
-      this.fragmentContext(context);
+      this.fragmentContext();
     }
   }
 
@@ -29,15 +30,15 @@ export default class CanvasAnnotationDisplay {
   }
 
   /** */
-  svgContext(context) {
+  svgContext() {
     [...this.svgPaths].forEach((element) => {
       /**
        *  Note: Path2D is not supported in IE11.
        *  TODO: Support multi canvas offset
        *  One example: https://developer.mozilla.org/en-US/docs/Web/API/Path2D/addPath
        */
-      context.save();
-      context.translate(this.offset.x, this.offset.y);
+      this.context.save();
+      this.context.translate(this.offset.x, this.offset.y);
       const p = new Path2D(element.attributes.d.nodeValue);
       /**
        * Note: we could do something to return the svg styling attributes as
@@ -46,35 +47,34 @@ export default class CanvasAnnotationDisplay {
        *  context.strokeStyle = element.attributes.stroke.nodeValue;
        *  context.lineWidth = element.attributes['stroke-width'].nodeValue;
        */
-      this.setupLineDash(context, element.attributes);
-      context.strokeStyle = this.strokeColor( // eslint-disable-line no-param-reassign
+      this.setupLineDash(element.attributes);
+      this.context.strokeStyle = this.strokeColor( // eslint-disable-line no-param-reassign
         element.attributes,
       );
-      context.lineWidth = this.lineWidth( // eslint-disable-line no-param-reassign
+      this.context.lineWidth = this.lineWidth( // eslint-disable-line no-param-reassign
         element.attributes,
       );
-      context.stroke(p);
-      context.restore();
+      this.context.stroke(p);
+      this.context.restore();
     });
   }
 
-  /* eslint-disable  require-jsdoc, class-methods-use-this */
-  setupLineDash(context, elementAttributes) {
+  /** */
+  setupLineDash(elementAttributes) {
     // stroke-dasharray
     if (elementAttributes['stroke-dasharray']) {
-      context.setLineDash(elementAttributes['stroke-dasharray'].nodeValue.split(','));
+      this.context.setLineDash(elementAttributes['stroke-dasharray'].nodeValue.split(','));
     }
   }
-  /* eslint-enable  require-jsdoc, class-methods-use-this */
 
   /** */
-  fragmentContext(context) {
+  fragmentContext() {
     const fragment = this.resource.fragmentSelector;
     fragment[0] += this.offset.x;
     fragment[1] += this.offset.y;
-    context.strokeStyle = this.color; // eslint-disable-line no-param-reassign
-    context.lineWidth = this.lineWidth(); // eslint-disable-line no-param-reassign
-    context.strokeRect(...fragment);
+    this.context.strokeStyle = this.color; // eslint-disable-line no-param-reassign
+    this.context.lineWidth = this.lineWidth(); // eslint-disable-line no-param-reassign
+    this.context.strokeRect(...fragment);
   }
 
   /** */

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -5,13 +5,12 @@
 export default class CanvasAnnotationDisplay {
   /** */
   constructor({
-    resource, color, zoom, offset, width,
+    resource, color, zoomRatio, offset,
   }) {
     this.resource = resource;
     this.color = color;
-    this.zoom = zoom;
+    this.zoomRatio = zoomRatio;
     this.offset = offset;
-    this.width = width || 1000;
   }
 
   /** */
@@ -53,6 +52,7 @@ export default class CanvasAnnotationDisplay {
         'stroke-linecap': 'lineCap',
         'stroke-linejoin': 'lineJoin',
         'stroke-miterlimit': 'miterlimit',
+        'stroke-width': 'lineWidth',
       };
       Object.keys(svgToCanvasMap).forEach((key) => {
         if (element.attributes[key]) {
@@ -60,9 +60,8 @@ export default class CanvasAnnotationDisplay {
         }
       });
 
-      this.context.lineWidth = this.lineWidth( // eslint-disable-line no-param-reassign
-        element.attributes,
-      );
+      // Resize the stroke based off of the zoomRatio (currentZoom / maxZoom)
+      this.context.lineWidth /= this.zoomRatio;
       this.context.stroke(p);
 
       // Wait to set the fill, so we can adjust the globalAlpha value if we need to
@@ -81,19 +80,9 @@ export default class CanvasAnnotationDisplay {
     const fragment = this.resource.fragmentSelector;
     fragment[0] += this.offset.x;
     fragment[1] += this.offset.y;
-    this.context.strokeStyle = this.color; // eslint-disable-line no-param-reassign
-    this.context.lineWidth = this.lineWidth(); // eslint-disable-line no-param-reassign
+    this.context.strokeStyle = this.color;
+    this.context.lineWidth = 1 / this.zoomRatio;
     this.context.strokeRect(...fragment);
-  }
-
-  /** */
-  lineWidth(elementAttributes) {
-    console.log(this.zoom, this.width);
-    let calculatedWidth = Math.ceil(10 / (this.zoom * this.width));
-    if (elementAttributes && elementAttributes['stroke-width']) {
-      calculatedWidth *= elementAttributes['stroke-width'].nodeValue;
-    }
-    return calculatedWidth;
   }
 
   /** */

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -5,12 +5,13 @@
 export default class CanvasAnnotationDisplay {
   /** */
   constructor({
-    resource, color, zoomRatio, offset,
+    resource, color, zoomRatio, offset, selected,
   }) {
     this.resource = resource;
     this.color = color;
     this.zoomRatio = zoomRatio;
     this.offset = offset;
+    this.selected = selected;
   }
 
   /** */
@@ -62,6 +63,10 @@ export default class CanvasAnnotationDisplay {
 
       // Resize the stroke based off of the zoomRatio (currentZoom / maxZoom)
       this.context.lineWidth /= this.zoomRatio;
+      // Reset the color if it is selected
+      if (this.selected) {
+        this.context.strokeStyle = this.color;
+      }
       this.context.stroke(p);
 
       // Wait to set the fill, so we can adjust the globalAlpha value if we need to

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -46,12 +46,26 @@ export default class CanvasAnnotationDisplay {
        *  context.strokeStyle = element.attributes.stroke.nodeValue;
        *  context.lineWidth = element.attributes['stroke-width'].nodeValue;
        */
-      context.strokeStyle = this.color; // eslint-disable-line no-param-reassign
-      context.lineWidth = this.lineWidth(); // eslint-disable-line no-param-reassign
+      this.setupLineDash(context, element.attributes);
+      context.strokeStyle = this.strokeColor( // eslint-disable-line no-param-reassign
+        element.attributes,
+      );
+      context.lineWidth = this.lineWidth( // eslint-disable-line no-param-reassign
+        element.attributes,
+      );
       context.stroke(p);
       context.restore();
     });
   }
+
+  /* eslint-disable  require-jsdoc, class-methods-use-this */
+  setupLineDash(context, elementAttributes) {
+    // stroke-dasharray
+    if (elementAttributes['stroke-dasharray']) {
+      context.setLineDash(elementAttributes['stroke-dasharray'].nodeValue.split(','));
+    }
+  }
+  /* eslint-enable  require-jsdoc, class-methods-use-this */
 
   /** */
   fragmentContext(context) {
@@ -64,8 +78,20 @@ export default class CanvasAnnotationDisplay {
   }
 
   /** */
-  lineWidth() {
-    return Math.ceil(10 / (this.zoom * this.width));
+  strokeColor(elementAttributes) {
+    if (elementAttributes && elementAttributes.stroke) {
+      return elementAttributes.stroke.nodeValue;
+    }
+    return this.color;
+  }
+
+  /** */
+  lineWidth(elementAttributes) {
+    let calculatedWidth = Math.ceil(10 / (this.zoom * this.width));
+    if (elementAttributes && elementAttributes['stroke-width']) {
+      calculatedWidth *= elementAttributes['stroke-width'].nodeValue;
+    }
+    return calculatedWidth;
   }
 
   /** */


### PR DESCRIPTION
Fixes #2953 and Fixes #2989 

This pull request implements SVG styling of canvas elements, similar to how Mirador 2 did this. One thing to note, is Mirador 2 didn't actually respect the SVG attributes but used the non-standard PaperJS attributes which we shouldn't support.

For example in the manifest https://collections.st-andrews.ac.uk/manifest-test/555859.json having the AnnotationList https://collections.st-andrews.ac.uk/manifest-test/333026.json

The following SVG in Mirador 2 uses the paperjs attributes, but the `stroke-width` is quite large. We should use the provided stroke-width. This is the reason for the discrepancy in the views.

```
<svg
	xmlns='http://www.w3.org/2000/svg'>
	<path
		xmlns=\"http://www.w3.org/2000/svg\" d=\"M2429.43758,2391.51515l353.94424,-315.68l765.28485,377.85939l-234.36848,679.1903l-750.93576,-229.58545z\" data-paper-data=\"{&quot;strokeWidth&quot;:1,&quot;annotation&quot;:null,&quot;editable&quot;:true}\" id=\"rough_path_4ec4c8ee-dcc3-4be0-8bfe-1a85c20786ef\" fill-opacity=\"0.00001\" fill=\"#00bfff\" fill-rule=\"nonzero\" stroke=\"#6f3488\" stroke-width=\"33.77311\" stroke-linecap=\"butt\" stroke-linejoin=\"miter\" stroke-miterlimit=\"10\" stroke-dasharray=\"2,5,7,5\" stroke-dashoffset=\"0\" font-family=\"none\" font-weight=\"none\" font-size=\"none\" text-anchor=\"none\" style=\"mix-blend-mode: normal\"/>
	</svg>

```

Also this PR modifies again the lineWidth calculation which has been changed a few times (#2970). Just a heads up on this. I _think_ this is finally correct.

## Mirador 2
<img width="1278" alt="Screen Shot 2020-04-28 at 5 19 17 PM" src="https://user-images.githubusercontent.com/1656824/80547114-9bb89b80-8974-11ea-9786-15f1701fa3c6.png">

## Mirador 3
<img width="1278" alt="Screen Shot 2020-04-28 at 5 17 56 PM" src="https://user-images.githubusercontent.com/1656824/80547124-9e1af580-8974-11ea-96ca-7ae9f6d53a04.png">
