### PR TITLE
Enable images and image services to be placed on a canvas using a fragment

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -201,15 +201,12 @@ describe('OpenSeadragonViewer', () => {
 
       wrapper.instance().refreshTileProperties();
 
-      expect(setOpacity).toHaveBeenCalledTimes(2);
+      expect(setOpacity).toHaveBeenCalledTimes(1);
       expect(setOpacity.mock.calls[0]).toEqual([0.5]);
-      expect(setOpacity.mock.calls[1]).toEqual([0.5]);
 
-      expect(setItemIndex).toHaveBeenCalledTimes(2);
-      expect(setItemIndex.mock.calls[0][0].source.id).toEqual(0);
-      expect(setItemIndex.mock.calls[0][1]).toEqual(1);
-      expect(setItemIndex.mock.calls[1][0].source.id).toEqual(1);
-      expect(setItemIndex.mock.calls[1][1]).toEqual(0);
+      expect(setItemIndex).toHaveBeenCalledTimes(1);
+      expect(setItemIndex.mock.calls[0][0].source.id).toEqual(1);
+      expect(setItemIndex.mock.calls[0][1]).toEqual(0);
     });
   });
 

--- a/__tests__/src/lib/CanvasWorld.test.js
+++ b/__tests__/src/lib/CanvasWorld.test.js
@@ -1,5 +1,6 @@
 import { Utils } from 'manifesto.js/dist-esmodule/Utils';
 import fixture from '../../fixtures/version-2/019.json';
+import fragmentFixture from '../../fixtures/version-2/hamilton.json';
 import CanvasWorld from '../../../src/lib/CanvasWorld';
 
 const canvases = Utils.parseManifest(fixture).getSequences()[0].getCanvases();
@@ -27,6 +28,13 @@ describe('CanvasWorld', () => {
     it('supports RTL orientations', () => {
       expect(new CanvasWorld(canvasSubset, null, 'right-to-left').contentResourceToWorldCoordinates({ id: 'https://stacks.stanford.edu/image/iiif/rz176rt6531%2FPC0170_s3_Tree_Calendar_20081101_152516_0410/full/full/0/default.jpg' }))
         .toEqual([0, 0, 2848, 4288]);
+    });
+    it('when placed by a fragment contains the offset', () => {
+      const subject = new CanvasWorld(
+        [Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0]],
+      );
+      expect(subject.contentResourceToWorldCoordinates({ id: 'https://prtd.app/image/iiif/2/hamilton%2fHL_524_1r_00_PC17/full/739,521/0/default.jpg' }))
+        .toEqual([552, 1584, 3360, 2368]);
     });
   });
   describe('canvasToWorldCoordinates', () => {

--- a/__tests__/src/lib/ManifestoCanvas.test.js
+++ b/__tests__/src/lib/ManifestoCanvas.test.js
@@ -7,6 +7,7 @@ import emptyCanvasFixture from '../../fixtures/version-2/emptyCanvas.json';
 import serviceFixture from '../../fixtures/version-2/canvasService.json';
 import otherContentFixture from '../../fixtures/version-2/299843.json';
 import otherContentStringsFixture from '../../fixtures/version-2/BibliographicResource_3000126341277.json';
+import fragmentFixture from '../../fixtures/version-2/hamilton.json';
 
 describe('ManifestoCanvas', () => {
   let instance;
@@ -152,6 +153,26 @@ describe('ManifestoCanvas', () => {
 
     it('returns undefined if there is no service', () => {
       expect(instance.service).toBeUndefined();
+    });
+  });
+  describe('resourceAnnotation', () => {
+    it('returns the containing Annotation for a given contentResource id', () => {
+      instance = new ManifestoCanvas(
+        Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0],
+      );
+      expect(
+        instance.resourceAnnotation('https://prtd.app/image/iiif/2/hamilton%2fHL_524_1r_00_PC17/full/739,521/0/default.jpg').id,
+      ).toEqual('https://prtd.app/hamilton/canvas/p1/anno-02.json');
+    });
+  });
+  describe('onFragment', () => {
+    it('when a fragment selector exists for a given contentResources id, returns that fragment', () => {
+      instance = new ManifestoCanvas(
+        Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0],
+      );
+      expect(
+        instance.onFragment('https://prtd.app/image/iiif/2/hamilton%2fHL_524_1r_00_PC17/full/739,521/0/default.jpg'),
+      ).toEqual([552, 1584, 3360, 2368]);
     });
   });
 });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -275,6 +275,7 @@ export class OpenSeadragonViewer extends Component {
 
     items.forEach((item, i) => {
       const contentResource = canvasWorld.contentResource(item.source['@id'] || item.source.id);
+      if (!contentResource) return;
       const newIndex = canvasWorld.layerIndexOfImageResource(contentResource);
       if (i !== newIndex) world.setItemIndex(item, newIndex);
       item.setOpacity(canvasWorld.layerOpacityOfImageResource(contentResource));

--- a/src/lib/CanvasWorld.js
+++ b/src/lib/CanvasWorld.js
@@ -29,11 +29,20 @@ export default class CanvasWorld {
     const manifestoCanvasIndex = this.canvases.findIndex(c => (
       c.imageResources.find(r => r.id === contentResource.id)
     ));
-    const { aspectRatio } = this.canvases[manifestoCanvasIndex];
-    const scaledWidth = Math.floor(wholeBounds[3] * aspectRatio);
+    const canvas = this.canvases[manifestoCanvasIndex];
+    const scaledWidth = Math.floor(wholeBounds[3] * canvas.aspectRatio);
     let x = 0;
     if (manifestoCanvasIndex === this.secondCanvasIndex) {
       x = wholeBounds[2] - scaledWidth;
+    }
+    const fragmentOffset = canvas.onFragment(contentResource.id);
+    if (fragmentOffset) {
+      return [
+        x + fragmentOffset[0],
+        0 + fragmentOffset[1],
+        fragmentOffset[2],
+        fragmentOffset[3],
+      ];
     }
     return [
       x,
@@ -76,7 +85,6 @@ export default class CanvasWorld {
       normalizeUrl(id, { stripAuthentication: false })
         === normalizeUrl(infoResponseId, { stripAuthentication: false }))));
     if (!manifestoCanvas) return undefined;
-
     return manifestoCanvas.imageResources
       .find(r => (
         normalizeUrl(r.getServices()[0].id, { stripAuthentication: false })

--- a/src/lib/ManifestoCanvas.js
+++ b/src/lib/ManifestoCanvas.js
@@ -117,6 +117,36 @@ export default class ManifestoCanvas {
   }
 
   /** */
+  get resourceAnnotations() {
+    return flattenDeep([
+      this.canvas.getImages(),
+      this.canvas.getContent(),
+    ]);
+  }
+
+  /**
+   * Returns a given resource Annotation, based on a contained resource or body
+   * id
+   */
+  resourceAnnotation(id) {
+    return this.resourceAnnotations.find(
+      anno => anno.getResource().id === id || anno.getBody().id === id,
+    );
+  }
+
+  /**
+   * Returns the fragment placement values if a resourceAnnotation is placed on
+   * a canvas somewhere besides the full extent
+   */
+  onFragment(id) {
+    const resourceAnnotation = this.resourceAnnotation(id);
+    if (!resourceAnnotation) return undefined;
+    const fragmentMatch = resourceAnnotation.getProperty('on').match(/xywh=(.*)$/);
+    if (!fragmentMatch) return undefined;
+    return fragmentMatch[1].split(',').map(str => parseInt(str, 10));
+  }
+
+  /** */
   get iiifImageResources() {
     return this.imageResources
       .filter(r => r && r.getServices()[0] && r.getServices()[0].id);


### PR DESCRIPTION
Fixes #2991 

This enables the quintessential IIIF "Reunification" demo from Biblissima 

https://demos.biblissima.fr/iiif/metadata/BVMM/chateauroux/manifest.json

cc @regisrob 

## Before

![Kapture 2020-04-27 at 12 19 56](https://user-images.githubusercontent.com/1656824/80406645-a1818480-8881-11ea-868d-996b87d23ea7.gif)

## After

![Kapture 2020-04-27 at 12 18 43](https://user-images.githubusercontent.com/1656824/80406651-a6463880-8881-11ea-897e-004426daf1ce.gif)
