### PR TITLE
Rename ManifestoCanvas to MiradorCanvas

### DIFF
--- a/__tests__/src/lib/MiradorCanvas.test.js
+++ b/__tests__/src/lib/MiradorCanvas.test.js
@@ -1,5 +1,5 @@
 import { Utils } from 'manifesto.js/dist-esmodule/Utils';
-import ManifestoCanvas from '../../../src/lib/ManifestoCanvas';
+import MiradorCanvas from '../../../src/lib/MiradorCanvas';
 import fixture from '../../fixtures/version-2/019.json';
 import v3fixture from '../../fixtures/version-3/001.json';
 import imagev1Fixture from '../../fixtures/version-2/Osbornfa1.json';
@@ -9,14 +9,14 @@ import otherContentFixture from '../../fixtures/version-2/299843.json';
 import otherContentStringsFixture from '../../fixtures/version-2/BibliographicResource_3000126341277.json';
 import fragmentFixture from '../../fixtures/version-2/hamilton.json';
 
-describe('ManifestoCanvas', () => {
+describe('MiradorCanvas', () => {
   let instance;
   let v3Instance;
   beforeAll(() => {
-    instance = new ManifestoCanvas(
+    instance = new MiradorCanvas(
       Utils.parseManifest(fixture).getSequences()[0].getCanvases()[0],
     );
-    v3Instance = new ManifestoCanvas(
+    v3Instance = new MiradorCanvas(
       Utils.parseManifest(v3fixture).getSequences()[0].getCanvases()[0],
     );
   });
@@ -29,7 +29,7 @@ describe('ManifestoCanvas', () => {
     describe('when annotationLists are present', () => {
       describe('with items as objects', () => {
         it('returns an array of uris', () => {
-          const otherContentInstance = new ManifestoCanvas(
+          const otherContentInstance = new MiradorCanvas(
             Utils.parseManifest(otherContentFixture).getSequences()[0].getCanvases()[0],
           );
           expect(otherContentInstance.annotationListUris.length).toEqual(1);
@@ -40,7 +40,7 @@ describe('ManifestoCanvas', () => {
       });
       describe('with items as strings', () => {
         it('returns an array of uris', () => {
-          const otherContentInstance = new ManifestoCanvas(
+          const otherContentInstance = new MiradorCanvas(
             Utils.parseManifest(otherContentStringsFixture).getSequences()[0].getCanvases()[0],
           );
           expect(otherContentInstance.annotationListUris.length).toEqual(1);
@@ -66,7 +66,7 @@ describe('ManifestoCanvas', () => {
   describe('processAnnotations', () => {
     describe('v2', () => {
       it('fetches annotations for each annotationList', () => {
-        const otherContentInstance = new ManifestoCanvas(
+        const otherContentInstance = new MiradorCanvas(
           Utils.parseManifest(otherContentFixture).getSequences()[0].getCanvases()[0],
         );
         const fetchMock = jest.fn();
@@ -89,14 +89,14 @@ describe('ManifestoCanvas', () => {
       expect(instance.imageInformationUri()).toEqual('https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44/info.json');
     });
     it('correctly returns an image information url for a v1 Image API', () => {
-      const imagev1Instance = new ManifestoCanvas(
+      const imagev1Instance = new MiradorCanvas(
         Utils.parseManifest(imagev1Fixture).getSequences()[0].getCanvases()[0],
       );
       expect(imagev1Instance.imageInformationUri()).toEqual('https://images.britishart.yale.edu/iiif/b38081da-8991-4464-a71e-d9891226a35f/info.json');
     });
 
     it('is undefined if a canvas is empty (e.g. has no images)', () => {
-      const emptyCanvasInstance = new ManifestoCanvas(
+      const emptyCanvasInstance = new MiradorCanvas(
         Utils.parseManifest(emptyCanvasFixture).getSequences()[0].getCanvases()[3],
       );
 
@@ -135,7 +135,7 @@ describe('ManifestoCanvas', () => {
     });
 
     it('returns undefined if there are no images to generate a thumbnail from', () => {
-      const emptyCanvasInstance = new ManifestoCanvas(
+      const emptyCanvasInstance = new MiradorCanvas(
         Utils.parseManifest(emptyCanvasFixture).getSequences()[0].getCanvases()[3],
       );
 
@@ -144,7 +144,7 @@ describe('ManifestoCanvas', () => {
   });
   describe('service', () => {
     it('correctly returns the service information for the given canvas', () => {
-      const serviceInstance = new ManifestoCanvas(
+      const serviceInstance = new MiradorCanvas(
         Utils.parseManifest(serviceFixture).getSequences()[0].getCanvases()[0],
       );
 
@@ -157,7 +157,7 @@ describe('ManifestoCanvas', () => {
   });
   describe('resourceAnnotation', () => {
     it('returns the containing Annotation for a given contentResource id', () => {
-      instance = new ManifestoCanvas(
+      instance = new MiradorCanvas(
         Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0],
       );
       expect(
@@ -167,7 +167,7 @@ describe('ManifestoCanvas', () => {
   });
   describe('onFragment', () => {
     it('when a fragment selector exists for a given contentResources id, returns that fragment', () => {
-      instance = new ManifestoCanvas(
+      instance = new MiradorCanvas(
         Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0],
       );
       expect(

--- a/src/components/CanvasLayers.js
+++ b/src/components/CanvasLayers.js
@@ -15,7 +15,7 @@ import VisibilityOffIcon from '@material-ui/icons/VisibilityOffSharp';
 import OpacityIcon from '@material-ui/icons/OpacitySharp';
 import Typography from '@material-ui/core/Typography';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
+import MiradorCanvas from '../lib/MiradorCanvas';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 import { CanvasThumbnail } from './CanvasThumbnail';
 
@@ -123,7 +123,7 @@ export class CanvasLayers extends Component {
       t,
     } = this.props;
 
-    const manifestoCanvas = new ManifestoCanvas(canvas);
+    const miradorCanvas = new MiradorCanvas(canvas);
     const { width, height } = { height: undefined, width: 50 };
 
     const layer = {
@@ -137,11 +137,11 @@ export class CanvasLayers extends Component {
         <div style={{ alignItems: 'flex-start', display: 'flex' }}>
           <div style={{ minWidth: 50 }}>
             <CanvasThumbnail
-              isValid={manifestoCanvas.hasValidDimensions}
-              imageUrl={manifestoCanvas.thumbnail(width, height, resource.id)}
+              isValid={miradorCanvas.hasValidDimensions}
+              imageUrl={miradorCanvas.thumbnail(width, height, resource.id)}
               maxHeight={height}
               maxWidth={width}
-              aspectRatio={manifestoCanvas.aspectRatio}
+              aspectRatio={miradorCanvas.aspectRatio}
               ImageProps={{ className: classes.image }}
             />
           </div>

--- a/src/components/CaptionedCanvasThumbnail.js
+++ b/src/components/CaptionedCanvasThumbnail.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
+import MiradorCanvas from '../lib/MiradorCanvas';
 import { CanvasThumbnail } from './CanvasThumbnail';
 import ns from '../config/css-ns';
 
@@ -11,7 +11,7 @@ export class CaptionedCanvasThumbnail extends Component {
   /** */
   render() {
     const { canvas, classes, height } = this.props;
-    const manifestoCanvas = new ManifestoCanvas(canvas);
+    const miradorCanvas = new MiradorCanvas(canvas);
     return (
       <div
         key={canvas.id}
@@ -19,13 +19,13 @@ export class CaptionedCanvasThumbnail extends Component {
       >
         <CanvasThumbnail
           imageUrl={
-            manifestoCanvas.thumbnail(null, 200)
+            miradorCanvas.thumbnail(null, 200)
             // TODO: When we make these areas resizable, we should probably not hard code this
           }
-          isValid={manifestoCanvas.hasValidDimensions}
+          isValid={miradorCanvas.hasValidDimensions}
           maxHeight={height}
           style={{
-            maxWidth: `${Math.ceil(height * manifestoCanvas.aspectRatio)}px`,
+            maxWidth: `${Math.ceil(height * miradorCanvas.aspectRatio)}px`,
           }}
         />
         <div
@@ -40,7 +40,7 @@ export class CaptionedCanvasThumbnail extends Component {
               classes={{ root: classes.title }}
               variant="caption"
             >
-              {manifestoCanvas.getLabel()}
+              {miradorCanvas.getLabel()}
             </Typography>
           </div>
         </div>

--- a/src/components/GalleryViewThumbnail.js
+++ b/src/components/GalleryViewThumbnail.js
@@ -4,7 +4,7 @@ import Avatar from '@material-ui/core/Avatar';
 import Chip from '@material-ui/core/Chip';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
+import MiradorCanvas from '../lib/MiradorCanvas';
 import { CanvasThumbnail } from './CanvasThumbnail';
 
 /**
@@ -71,7 +71,7 @@ export class GalleryViewThumbnail extends Component {
       annotationsCount, annotationSelected, canvas, classes, config, selected,
     } = this.props;
 
-    const manifestoCanvas = new ManifestoCanvas(canvas);
+    const miradorCanvas = new MiradorCanvas(canvas);
 
     return (
       <div
@@ -89,17 +89,17 @@ export class GalleryViewThumbnail extends Component {
         tabIndex={0}
       >
         <CanvasThumbnail
-          imageUrl={manifestoCanvas.thumbnail(config.width, config.height)}
-          isValid={manifestoCanvas.hasValidDimensions}
+          imageUrl={miradorCanvas.thumbnail(config.width, config.height)}
+          isValid={miradorCanvas.hasValidDimensions}
           maxHeight={config.height}
-          aspectRatio={manifestoCanvas.aspectRatio}
+          aspectRatio={miradorCanvas.aspectRatio}
           style={{
             margin: '0 auto',
-            maxWidth: `${Math.ceil(config.height * manifestoCanvas.aspectRatio)}px`,
+            maxWidth: `${Math.ceil(config.height * miradorCanvas.aspectRatio)}px`,
           }}
         />
         <Typography variant="caption" className={classes.galleryViewCaption}>
-          {manifestoCanvas.getLabel()}
+          {miradorCanvas.getLabel()}
         </Typography>
         { annotationsCount > 0 && (
           <Chip

--- a/src/components/SidebarIndexList.js
+++ b/src/components/SidebarIndexList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import { ScrollTo } from './ScrollTo';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
+import MiradorCanvas from '../lib/MiradorCanvas';
 import SidebarIndexItem from '../containers/SidebarIndexItem';
 import SidebarIndexThumbnail from '../containers/SidebarIndexThumbnail';
 
@@ -15,7 +15,7 @@ export class SidebarIndexList extends Component {
 
     return canvases.map((canvas, index) => ({
       id: canvas.id,
-      label: new ManifestoCanvas(canvas).getLabel(),
+      label: new MiradorCanvas(canvas).getLabel(),
     }));
   }
 

--- a/src/components/SidebarIndexThumbnail.js
+++ b/src/components/SidebarIndexThumbnail.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
+import MiradorCanvas from '../lib/MiradorCanvas';
 import { CanvasThumbnail } from './CanvasThumbnail';
 
 /** */
@@ -14,18 +14,18 @@ export class SidebarIndexThumbnail extends Component {
     } = this.props;
 
     const { width, height } = config.canvasNavigation;
-    const manifestoCanvas = new ManifestoCanvas(otherCanvas);
+    const miradorCanvas = new MiradorCanvas(otherCanvas);
 
     return (
       <>
         <div style={{ minWidth: 50 }}>
           <CanvasThumbnail
             className={classNames(classes.clickable)}
-            isValid={manifestoCanvas.hasValidDimensions}
-            imageUrl={manifestoCanvas.thumbnail(width, height)}
+            isValid={miradorCanvas.hasValidDimensions}
+            imageUrl={miradorCanvas.thumbnail(width, height)}
             maxHeight={config.canvasNavigation.height}
             maxWidth={config.canvasNavigation.width}
-            aspectRatio={manifestoCanvas.aspectRatio}
+            aspectRatio={miradorCanvas.aspectRatio}
           />
         </div>
         <Typography

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import flatten from 'lodash/flatten';
 import OSDViewer from '../containers/OpenSeadragonViewer';
 import WindowCanvasNavigationControls from '../containers/WindowCanvasNavigationControls';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
+import MiradorCanvas from '../lib/MiradorCanvas';
 
 /**
  * Represents a WindowViewer in the mirador workspace. Responsible for mounting
@@ -33,11 +33,11 @@ export class WindowViewer extends Component {
 
     if (!this.infoResponseIsInStore()) {
       currentCanvases.forEach((canvas) => {
-        const manifestoCanvas = new ManifestoCanvas(canvas);
-        manifestoCanvas.imageResources.forEach((imageResource) => {
+        const miradorCanvas = new MiradorCanvas(canvas);
+        miradorCanvas.imageResources.forEach((imageResource) => {
           fetchInfoResponse({ imageResource });
         });
-        manifestoCanvas.processAnnotations(fetchAnnotation, receiveAnnotation);
+        miradorCanvas.processAnnotations(fetchAnnotation, receiveAnnotation);
       });
     }
   }
@@ -55,16 +55,16 @@ export class WindowViewer extends Component {
       || (prevProps.currentCanvasId !== currentCanvasId && !this.infoResponseIsInStore())
     ) {
       currentCanvases.forEach((canvas) => {
-        const manifestoCanvas = new ManifestoCanvas(canvas);
-        manifestoCanvas.imageResources.forEach((imageResource) => {
+        const miradorCanvas = new MiradorCanvas(canvas);
+        miradorCanvas.imageResources.forEach((imageResource) => {
           fetchInfoResponse({ imageResource });
         });
-        manifestoCanvas.processAnnotations(fetchAnnotation, receiveAnnotation);
+        miradorCanvas.processAnnotations(fetchAnnotation, receiveAnnotation);
       });
 
-      currentCanvases.map(canvas => new ManifestoCanvas(canvas))
-        .map(manifestoCanvas => manifestoCanvas.annotationListUris.forEach((uri) => {
-          fetchAnnotation(manifestoCanvas.canvas.id, uri);
+      currentCanvases.map(canvas => new MiradorCanvas(canvas))
+        .map(miradorCanvas => miradorCanvas.annotationListUris.forEach((uri) => {
+          fetchAnnotation(miradorCanvas.canvas.id, uri);
         }));
     }
   }
@@ -86,7 +86,7 @@ export class WindowViewer extends Component {
   imageServiceIds() {
     const { currentCanvases } = this.props;
 
-    return flatten(currentCanvases.map(canvas => new ManifestoCanvas(canvas).imageServiceIds));
+    return flatten(currentCanvases.map(canvas => new MiradorCanvas(canvas).imageServiceIds));
   }
 
   /**

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -4,7 +4,7 @@ import { withStyles } from '@material-ui/core';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import ManifestoCanvas from '../lib/ManifestoCanvas';
+import MiradorCanvas from '../lib/MiradorCanvas';
 import {
   getCanvases,
   getVisibleCanvases,
@@ -30,7 +30,7 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
 
 /** */
 function hasLayers(canvases) {
-  return canvases && canvases.some(c => new ManifestoCanvas(c).imageResources.length > 1);
+  return canvases && canvases.some(c => new MiradorCanvas(c).imageResources.length > 1);
 }
 
 /**

--- a/src/lib/CanvasWorld.js
+++ b/src/lib/CanvasWorld.js
@@ -1,5 +1,5 @@
 import normalizeUrl from 'normalize-url';
-import ManifestoCanvas from './ManifestoCanvas';
+import MiradorCanvas from './MiradorCanvas';
 
 /**
  * CanvasWorld
@@ -10,7 +10,7 @@ export default class CanvasWorld {
    * world from.
    */
   constructor(canvases, layers, viewingDirection = 'left-to-right') {
-    this.canvases = canvases.map(c => new ManifestoCanvas(c));
+    this.canvases = canvases.map(c => new MiradorCanvas(c));
     this.layers = layers;
     this.viewingDirection = viewingDirection;
   }
@@ -26,13 +26,13 @@ export default class CanvasWorld {
    */
   contentResourceToWorldCoordinates(contentResource) {
     const wholeBounds = this.worldBounds();
-    const manifestoCanvasIndex = this.canvases.findIndex(c => (
+    const miradorCanvasIndex = this.canvases.findIndex(c => (
       c.imageResources.find(r => r.id === contentResource.id)
     ));
-    const canvas = this.canvases[manifestoCanvasIndex];
+    const canvas = this.canvases[miradorCanvasIndex];
     const scaledWidth = Math.floor(wholeBounds[3] * canvas.aspectRatio);
     let x = 0;
-    if (manifestoCanvasIndex === this.secondCanvasIndex) {
+    if (miradorCanvasIndex === this.secondCanvasIndex) {
       x = wholeBounds[2] - scaledWidth;
     }
     const fragmentOffset = canvas.onFragment(contentResource.id);
@@ -55,11 +55,11 @@ export default class CanvasWorld {
   /** */
   canvasToWorldCoordinates(canvasId) {
     const wholeBounds = this.worldBounds();
-    const manifestoCanvasIndex = this.canvases.findIndex(c => (c.id === canvasId));
-    const { aspectRatio } = this.canvases[manifestoCanvasIndex];
+    const miradorCanvasIndex = this.canvases.findIndex(c => (c.id === canvasId));
+    const { aspectRatio } = this.canvases[miradorCanvasIndex];
     const scaledWidth = Math.floor(wholeBounds[3] * aspectRatio);
     let x = 0;
-    if (manifestoCanvasIndex === this.secondCanvasIndex) {
+    if (miradorCanvasIndex === this.secondCanvasIndex) {
       x = wholeBounds[2] - scaledWidth;
     }
     return [
@@ -81,11 +81,11 @@ export default class CanvasWorld {
 
   /** Get the IIIF content resource for an image */
   contentResource(infoResponseId) {
-    const manifestoCanvas = this.canvases.find(c => c.imageServiceIds.some(id => (
+    const miradorCanvas = this.canvases.find(c => c.imageServiceIds.some(id => (
       normalizeUrl(id, { stripAuthentication: false })
         === normalizeUrl(infoResponseId, { stripAuthentication: false }))));
-    if (!manifestoCanvas) return undefined;
-    return manifestoCanvas.imageResources
+    if (!miradorCanvas) return undefined;
+    return miradorCanvas.imageResources
       .find(r => (
         normalizeUrl(r.getServices()[0].id, { stripAuthentication: false })
         === normalizeUrl(infoResponseId, { stripAuthentication: false })));
@@ -94,22 +94,22 @@ export default class CanvasWorld {
   /** @private */
   getLayerMetadata(contentResource) {
     if (!this.layers) return undefined;
-    const manifestoCanvas = this.canvases.find(c => (
+    const miradorCanvas = this.canvases.find(c => (
       c.imageResources.find(r => r.id === contentResource.id)
     ));
 
-    if (!manifestoCanvas) return undefined;
+    if (!miradorCanvas) return undefined;
 
-    const resourceIndex = manifestoCanvas.imageResources
+    const resourceIndex = miradorCanvas.imageResources
       .findIndex(r => r.id === contentResource.id);
 
-    const layer = this.layers[manifestoCanvas.canvas.id];
+    const layer = this.layers[miradorCanvas.canvas.id];
     const imageResourceLayer = layer && layer[contentResource.id];
 
     return {
       index: resourceIndex,
       opacity: 1,
-      total: manifestoCanvas.imageResources.length,
+      total: miradorCanvas.imageResources.length,
       visibility: true,
       ...imageResourceLayer,
     };

--- a/src/lib/MiradorCanvas.js
+++ b/src/lib/MiradorCanvas.js
@@ -2,12 +2,12 @@ import flatten from 'lodash/flatten';
 import flattenDeep from 'lodash/flattenDeep';
 import { Canvas, Utils } from 'manifesto.js';
 /**
- * ManifestoCanvas - adds additional, testable logic around Manifesto's Canvas
+ * MiradorCanvas - adds additional, testable logic around Manifesto's Canvas
  * https://iiif-commons.github.io/manifesto/classes/_canvas_.manifesto.canvas.html
  */
-export default class ManifestoCanvas {
+export default class MiradorCanvas {
   /**
-   * @param {ManifestoCanvas} canvas
+   * @param {MiradorCanvas} canvas
    */
   constructor(canvas) {
     this.canvas = canvas;

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import { Utils } from 'manifesto.js/dist-esmodule/Utils';
 import flatten from 'lodash/flatten';
 import CanvasGroupings from '../../lib/CanvasGroupings';
-import ManifestoCanvas from '../../lib/ManifestoCanvas';
+import MiradorCanvas from '../../lib/MiradorCanvas';
 import { getManifestoInstance } from './manifests';
 import { getWindow, getWindowViewType } from './windows';
 
@@ -177,7 +177,7 @@ export const getVisibleCanvasNonTiledResources = createSelector(
     getVisibleCanvases,
   ],
   canvases => flatten(canvases
-    .map(canvas => new ManifestoCanvas(canvas).imageResources))
+    .map(canvas => new MiradorCanvas(canvas).imageResources))
     .filter(resource => resource.getServices().length < 1),
 );
 
@@ -188,8 +188,8 @@ export const selectInfoResponse = createSelector(
   ],
   (canvas, infoResponses) => {
     if (!canvas) return undefined;
-    const manifestoCanvas = new ManifestoCanvas(canvas);
-    const image = manifestoCanvas.iiifImageResources[0];
+    const miradorCanvas = new MiradorCanvas(canvas);
+    const image = miradorCanvas.iiifImageResources[0];
     const iiifServiceId = image && image.getServices()[0].id;
 
     return iiifServiceId && infoResponses[iiifServiceId]

--- a/src/state/selectors/layers.js
+++ b/src/state/selectors/layers.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import ManifestoCanvas from '../../lib/ManifestoCanvas';
+import MiradorCanvas from '../../lib/MiradorCanvas';
 import { getCanvas, getVisibleCanvases } from './canvases';
 
 /**
@@ -11,8 +11,8 @@ export const getCanvasLayers = createSelector(
   ],
   (canvas) => {
     if (!canvas) return [];
-    const manifestoCanvas = new ManifestoCanvas(canvas);
-    return manifestoCanvas.imageResources;
+    const miradorCanvas = new MiradorCanvas(canvas);
+    return miradorCanvas.imageResources;
   },
 );
 

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import createCachedSelector from 're-reselect';
 import { LanguageMap } from 'manifesto.js/dist-esmodule/LanguageMap';
 import { Utils } from 'manifesto.js/dist-esmodule/Utils';
-import ManifestoCanvas from '../../lib/ManifestoCanvas';
+import MiradorCanvas from '../../lib/MiradorCanvas';
 
 /** */
 function createManifestoInstance(json, locale) {
@@ -231,9 +231,9 @@ export function getManifestThumbnail(state, props) {
 
     if (canvases.length === 0) return null;
 
-    const manifestoCanvas = new ManifestoCanvas(canvases[0]);
+    const miradorCanvas = new MiradorCanvas(canvases[0]);
 
-    return manifestoCanvas.thumbnail(null, 80);
+    return miradorCanvas.thumbnail(null, 80);
   }
 
   return getTopLevelManifestThumbnail()


### PR DESCRIPTION
When discussing this class in a recent pairing session, we kind of got into a "Who's on first" situation. This PR renames ManifestoCanvas to MiradorCanvas in an attempt to be more precise.