### PR TITLE
Only create a sidebar panel if a default panel type is configured

### DIFF
--- a/__tests__/src/actions/window.test.js
+++ b/__tests__/src/actions/window.test.js
@@ -150,7 +150,9 @@ describe('window actions', () => {
         companionWindows: {},
         config: {
           thumbnailNavigation: {},
-          window: {},
+          window: {
+            defaultSideBarPanel: 'info',
+          },
         },
         windows: {},
       };
@@ -166,6 +168,35 @@ describe('window actions', () => {
       expect(action.window.companionWindowIds.length).toEqual(3);
       expect(action.window.companionWindowIds[2]).toEqual(action.companionWindows[2].id);
       expect(action.companionWindows[2]).toMatchObject({ content: 'attribution', position: 'right' });
+    });
+    it('creates a new window without a default sidebar', () => {
+      const options = {
+        canvasIndex: 1,
+        companionWindows: [],
+        id: 'helloworld',
+      };
+
+      const mockState = {
+        companionWindows: {},
+        config: {
+          thumbnailNavigation: {},
+          window: {
+            defaultSideBarPanel: null,
+          },
+        },
+        windows: {},
+      };
+
+      const mockDispatch = jest.fn(() => ({}));
+      const mockGetState = jest.fn(() => mockState);
+      const thunk = actions.addWindow(options);
+
+      thunk(mockDispatch, mockGetState);
+
+      const action = mockDispatch.mock.calls[0][0];
+
+      expect(action.window.companionWindowIds.length).toEqual(1);
+      expect(action.companionWindows[0]).toMatchObject({ content: 'thumbnailNavigation' });
     });
   });
 

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -42,14 +42,37 @@ export function addWindow({ companionWindows, ...options }) {
     const { config, windows } = getState();
     const numWindows = Object.keys(windows).length;
 
-    const cwDefault = `cw-${uuid()}`;
     const cwThumbs = `cw-${uuid()}`;
-    const additionalCompanionWindowIds = (companionWindows || []).map(e => `cw-${uuid()}`);
+
+    const defaultCompanionWindows = [
+      {
+        content: 'thumbnailNavigation',
+        default: true,
+        id: cwThumbs,
+        position: options.thumbnailNavigationPosition
+          || config.thumbnailNavigation.defaultPosition,
+      },
+      ...(
+        (companionWindows || []).map((cw, i) => ({ ...cw, id: `cw-${uuid()}` }))
+      ),
+    ];
+
+    if (config.window.defaultSideBarPanel) {
+      defaultCompanionWindows.unshift(
+        {
+          content: config.window.defaultSideBarPanel,
+          default: true,
+          id: `cw-${uuid()}`,
+          position: 'left',
+        },
+      );
+    }
+
     const defaultOptions = {
       canvasId: undefined,
       collectionIndex: 0,
       companionAreaOpen: true,
-      companionWindowIds: [cwDefault, cwThumbs, ...additionalCompanionWindowIds],
+      companionWindowIds: defaultCompanionWindows.map(cw => cw.id),
       displayAllAnnotations: config.displayAllAnnotations || false,
       draggingEnabled: true,
       id: `window-${uuid()}`,
@@ -59,7 +82,7 @@ export function addWindow({ companionWindows, ...options }) {
       rangeId: null,
       rotation: null,
       selectedAnnotations: {},
-      sideBarOpen: config.window.sideBarOpenByDefault,
+      sideBarOpen: config.window.defaultSideBarPanel && config.window.sideBarOpenByDefault,
       sideBarPanel: config.window.defaultSideBarPanel,
       thumbnailNavigationId: cwThumbs,
     };
@@ -72,24 +95,7 @@ export function addWindow({ companionWindows, ...options }) {
     };
 
     dispatch({
-      companionWindows: [
-        {
-          content: config.window.defaultSideBarPanel,
-          default: true,
-          id: cwDefault,
-          position: 'left',
-        },
-        {
-          content: 'thumbnailNavigation',
-          default: true,
-          id: cwThumbs,
-          position: options.thumbnailNavigationPosition
-            || config.thumbnailNavigation.defaultPosition,
-        },
-        ...(
-          (companionWindows || []).map((cw, i) => ({ ...cw, id: additionalCompanionWindowIds[i] }))
-        ),
-      ],
+      companionWindows: defaultCompanionWindows,
       elasticLayout,
       type: ActionTypes.ADD_WINDOW,
       window: { ...defaultOptions, ...options },


### PR DESCRIPTION
Fixes #3000 

<img width="131" alt="Screen Shot 2020-05-08 at 07 40 23" src="https://user-images.githubusercontent.com/111218/81416856-30529480-90ff-11ea-8519-432ba3f942bf.png">

The default configuration is  still to initialize with  a default sidebar, but  this can be disabled  with the initial configuration:

```
       window: {
         defaultSideBarPanel: null,
       }, 
```