### PR TITLE
Refactor CanvasWorld/CanvasGroupings to support top-to-bottom and con…

### DIFF
--- a/__tests__/src/components/WindowViewSettings.test.js
+++ b/__tests__/src/components/WindowViewSettings.test.js
@@ -7,11 +7,12 @@ import { WindowViewSettings } from '../../../src/components/WindowViewSettings';
 
 /** create wrapper */
 function createWrapper(props) {
-  return shallow(
+  return mount(
     <WindowViewSettings
       classes={{}}
       windowId="xyz"
       setWindowViewType={() => {}}
+      viewTypes={['single', 'book', 'scroll', 'gallery']}
       windowViewType="single"
       {...props}
     />,
@@ -64,6 +65,7 @@ describe('WindowViewSettings', () => {
         classes={{}}
         windowId="xyz"
         setWindowViewType={() => {}}
+        viewTypes={['single', 'book', 'scroll', 'gallery']}
         windowViewType="single"
       />,
     );

--- a/__tests__/src/components/WindowViewSettings.test.js
+++ b/__tests__/src/components/WindowViewSettings.test.js
@@ -23,10 +23,11 @@ describe('WindowViewSettings', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(ListSubheader).length).toBe(1);
     const labels = wrapper.find(FormControlLabel);
-    expect(labels.length).toBe(3);
+    expect(labels.length).toBe(4);
     expect(labels.at(0).props().value).toBe('single');
     expect(labels.at(1).props().value).toBe('book');
-    expect(labels.at(2).props().value).toBe('gallery');
+    expect(labels.at(2).props().value).toBe('scroll');
+    expect(labels.at(3).props().value).toBe('gallery');
   });
 
   it('should set the correct label active (by setting the secondary color)', () => {
@@ -37,8 +38,11 @@ describe('WindowViewSettings', () => {
     wrapper = createWrapper({ windowViewType: 'book' });
     expect(wrapper.find(FormControlLabel).at(1).props().control.props.color).toEqual('secondary');
 
-    wrapper = createWrapper({ windowViewType: 'gallery' });
+    wrapper = createWrapper({ windowViewType: 'scroll' });
     expect(wrapper.find(FormControlLabel).at(2).props().control.props.color).toEqual('secondary');
+
+    wrapper = createWrapper({ windowViewType: 'gallery' });
+    expect(wrapper.find(FormControlLabel).at(3).props().control.props.color).toEqual('secondary');
   });
 
   it('updates state when the view config selection changes', () => {
@@ -49,6 +53,8 @@ describe('WindowViewSettings', () => {
     wrapper.find(MenuItem).at(1).simulate('click');
     expect(setWindowViewType).toHaveBeenCalledWith('xyz', 'book');
     wrapper.find(MenuItem).at(2).simulate('click');
+    expect(setWindowViewType).toHaveBeenCalledWith('xyz', 'scroll');
+    wrapper.find(MenuItem).at(3).simulate('click');
     expect(setWindowViewType).toHaveBeenCalledWith('xyz', 'gallery');
   });
 

--- a/__tests__/src/lib/CanvasGroupings.test.js
+++ b/__tests__/src/lib/CanvasGroupings.test.js
@@ -35,6 +35,16 @@ describe('CanvasGroupings', () => {
         expect(subject.groupings()[1]).toEqual([1, 2]);
       });
     });
+    describe('scroll', () => {
+      let subject;
+      beforeEach(() => {
+        subject = new CanvasGroupings([0, 1, 2, 3], 'scroll');
+      });
+      it('creates an array of all the canvases', () => {
+        expect(subject.groupings().length).toEqual(1);
+        expect(subject.groupings()[0]).toEqual([0, 1, 2, 3]);
+      });
+    });
   });
   describe('getCanvases', () => {
     describe('single', () => {
@@ -56,6 +66,12 @@ describe('CanvasGroupings', () => {
       it('selects by index', () => {
         const subject = new CanvasGroupings([0, 1, 2, 3]);
         expect(subject.getCanvases(2)).toEqual([2]);
+      });
+    });
+    describe('scroll', () => {
+      it('selects by index', () => {
+        const subject = new CanvasGroupings([0, 1, 2, 3], 'scroll');
+        expect(subject.getCanvases(0)).toEqual([0, 1, 2, 3]);
       });
     });
   });

--- a/__tests__/src/lib/CanvasWorld.test.js
+++ b/__tests__/src/lib/CanvasWorld.test.js
@@ -29,6 +29,14 @@ describe('CanvasWorld', () => {
       expect(new CanvasWorld(canvasSubset, null, 'right-to-left').contentResourceToWorldCoordinates({ id: 'https://stacks.stanford.edu/image/iiif/rz176rt6531%2FPC0170_s3_Tree_Calendar_20081101_152516_0410/full/full/0/default.jpg' }))
         .toEqual([0, 0, 2848, 4288]);
     });
+    it('supports TTB orientations', () => {
+      expect(new CanvasWorld(canvasSubset, null, 'top-to-bottom').contentResourceToWorldCoordinates({ id: 'https://stacks.stanford.edu/image/iiif/rz176rt6531%2FPC0170_s3_Tree_Calendar_20081101_152516_0410/full/full/0/default.jpg' }))
+        .toEqual([0, 1936, 2848, 4288]);
+    });
+    it('supports BTT orientations', () => {
+      expect(new CanvasWorld(canvasSubset, null, 'bottom-to-top').contentResourceToWorldCoordinates({ id: 'https://stacks.stanford.edu/image/iiif/rz176rt6531%2FPC0170_s3_Tree_Calendar_20081101_152516_0410/full/full/0/default.jpg' }))
+        .toEqual([0, 0, 2848, 4288]);
+    });
     it('when placed by a fragment contains the offset', () => {
       const subject = new CanvasWorld(
         [Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0]],

--- a/__tests__/src/selectors/windows.test.js
+++ b/__tests__/src/selectors/windows.test.js
@@ -11,6 +11,7 @@ import {
   getWindowManifests,
   getWindows,
   getMaximizedWindowsIds,
+  getAllowedWindowViewTypes,
 } from '../../../src/state/selectors/windows';
 
 describe('getWindows', () => {
@@ -104,6 +105,12 @@ describe('getWindowViewType', () => {
     config: {
       window: {
         defaultView: 'default',
+        views: [
+          { behaviors: ['individuals'], key: 'single' },
+          { behaviors: ['paged'], key: 'book' },
+          { behaviors: ['continuous'], key: 'scroll' },
+          { key: 'gallery' },
+        ],
       },
     },
     manifests: {
@@ -147,6 +154,36 @@ describe('getWindowViewType', () => {
   it('should return modified viewingHint for a book', () => {
     const received = getWindowViewType(state, { windowId: 'f' });
     expect(received).toEqual('book');
+  });
+});
+
+describe('getAllowedWindowViewTypes', () => {
+  const state = {
+    config: {
+      window: {
+        defaultView: 'single',
+        views: [
+          { behaviors: ['individuals'], key: 'single' },
+          { behaviors: ['paged'], key: 'book' },
+          { behaviors: ['continuous'], key: 'scroll' },
+          { key: 'gallery' },
+        ],
+      },
+    },
+    manifests: {
+      x: { json: { ...manifestFixture001 } },
+      y: { json: { ...manifestFixture015 } },
+    },
+  };
+
+  it('should return unrestricted view types', () => {
+    const received = getAllowedWindowViewTypes(state, { manifestId: 'x' });
+    expect(received).toEqual(['single', 'gallery']);
+  });
+
+  it('should return view types where behaviors match', () => {
+    const received = getAllowedWindowViewTypes(state, { manifestId: 'y' });
+    expect(received).toEqual(['single', 'book', 'gallery']);
   });
 });
 

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -4,6 +4,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import SingleIcon from '@material-ui/icons/CropOriginalSharp';
+import ScrollViewIcon from '@material-ui/icons/ViewColumn';
 import PropTypes from 'prop-types';
 import BookViewIcon from './icons/BookViewIcon';
 import GalleryViewIcon from './icons/GalleryViewIcon';
@@ -55,53 +56,41 @@ export class WindowViewSettings extends Component {
    */
   render() {
     const {
-      classes, handleClose, t, windowViewType,
+      classes, handleClose, t, windowViewType, viewTypes,
     } = this.props;
+
+    if (viewTypes.length === 0) return null;
+
+    const iconMap = {
+      book: BookViewIcon,
+      gallery: GalleryViewIcon,
+      scroll: ScrollViewIcon,
+      single: SingleIcon,
+    };
+
+    /** */
+    const ViewItem = ({ Icon, value }) => (
+      <MenuItem
+        className={classes.MenuItem}
+        ref={ref => this.handleSelectedRef(ref)}
+        onClick={() => { this.handleChange(value); handleClose(); }}
+      >
+        <FormControlLabel
+          value={value}
+          classes={{ label: windowViewType === value ? classes.selectedLabel : classes.label }}
+          control={Icon && <Icon color={windowViewType === value ? 'secondary' : undefined} />}
+          label={t(value)}
+          labelPlacement="bottom"
+        />
+      </MenuItem>
+    );
 
     return (
       <>
         <ListSubheader role="presentation" disableSticky tabIndex="-1">{t('view')}</ListSubheader>
-
-        <MenuItem
-          className={classes.MenuItem}
-          ref={ref => this.handleSelectedRef(ref)}
-          onClick={() => { this.handleChange('single'); handleClose(); }}
-        >
-          <FormControlLabel
-            value="single"
-            classes={{ label: windowViewType === 'single' ? classes.selectedLabel : classes.label }}
-            control={<SingleIcon color={windowViewType === 'single' ? 'secondary' : undefined} />}
-            label={t('single')}
-            labelPlacement="bottom"
-          />
-        </MenuItem>
-        <MenuItem className={classes.MenuItem} onClick={() => { this.handleChange('book'); handleClose(); }}>
-          <FormControlLabel
-            value="book"
-            classes={{ label: windowViewType === 'book' ? classes.selectedLabel : classes.label }}
-            control={<BookViewIcon color={windowViewType === 'book' ? 'secondary' : undefined} />}
-            label={t('book')}
-            labelPlacement="bottom"
-          />
-        </MenuItem>
-        <MenuItem className={classes.MenuItem} onClick={() => { this.handleChange('scroll'); handleClose(); }}>
-          <FormControlLabel
-            value="scroll"
-            classes={{ label: windowViewType === 'scroll' ? classes.selectedLabel : classes.label }}
-            control={<BookViewIcon color={windowViewType === 'scroll' ? 'secondary' : undefined} />}
-            label={t('scroll')}
-            labelPlacement="bottom"
-          />
-        </MenuItem>
-        <MenuItem className={classes.MenuItem} onClick={() => { this.handleChange('gallery'); handleClose(); }}>
-          <FormControlLabel
-            value="gallery"
-            classes={{ label: windowViewType === 'gallery' ? classes.selectedLabel : classes.label }}
-            control={<GalleryViewIcon color={windowViewType === 'gallery' ? 'secondary' : undefined} />}
-            label={t('gallery')}
-            labelPlacement="bottom"
-          />
-        </MenuItem>
+        {viewTypes.map(value => (
+          <ViewItem Icon={iconMap[value]} key={value} value={value} />
+        ))}
       </>
     );
   }
@@ -112,10 +101,12 @@ WindowViewSettings.propTypes = {
   handleClose: PropTypes.func,
   setWindowViewType: PropTypes.func.isRequired,
   t: PropTypes.func,
+  viewTypes: PropTypes.arrayOf(PropTypes.string),
   windowId: PropTypes.string.isRequired,
   windowViewType: PropTypes.string.isRequired,
 };
 WindowViewSettings.defaultProps = {
   handleClose: () => {},
   t: key => key,
+  viewTypes: [],
 };

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -59,8 +59,6 @@ export class WindowViewSettings extends Component {
       classes, handleClose, t, windowViewType, viewTypes,
     } = this.props;
 
-    if (viewTypes.length === 0) return null;
-
     const iconMap = {
       book: BookViewIcon,
       gallery: GalleryViewIcon,
@@ -68,29 +66,30 @@ export class WindowViewSettings extends Component {
       single: SingleIcon,
     };
 
-    /** */
-    const ViewItem = ({ Icon, value }) => (
+    /** Suspiciously similar to a component, yet if it is invoked through JSX
+        none of the click handlers work? */
+    const menuItem = ({ value, Icon }) => (
       <MenuItem
+        key={value}
         className={classes.MenuItem}
-        ref={ref => this.handleSelectedRef(ref)}
+        ref={windowViewType === value && (ref => this.handleSelectedRef(ref))}
         onClick={() => { this.handleChange(value); handleClose(); }}
       >
         <FormControlLabel
           value={value}
           classes={{ label: windowViewType === value ? classes.selectedLabel : classes.label }}
-          control={Icon && <Icon color={windowViewType === value ? 'secondary' : undefined} />}
+          control={<Icon color={windowViewType === value ? 'secondary' : undefined} />}
           label={t(value)}
           labelPlacement="bottom"
         />
       </MenuItem>
     );
 
+    if (viewTypes.length === 0) return null;
     return (
       <>
         <ListSubheader role="presentation" disableSticky tabIndex="-1">{t('view')}</ListSubheader>
-        {viewTypes.map(value => (
-          <ViewItem Icon={iconMap[value]} key={value} value={value} />
-        ))}
+        { viewTypes.map(value => menuItem({ Icon: iconMap[value], value })) }
       </>
     );
   }

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -84,6 +84,15 @@ export class WindowViewSettings extends Component {
             labelPlacement="bottom"
           />
         </MenuItem>
+        <MenuItem className={classes.MenuItem} onClick={() => { this.handleChange('scroll'); handleClose(); }}>
+          <FormControlLabel
+            value="scroll"
+            classes={{ label: windowViewType === 'scroll' ? classes.selectedLabel : classes.label }}
+            control={<BookViewIcon color={windowViewType === 'scroll' ? 'secondary' : undefined} />}
+            label={t('scroll')}
+            labelPlacement="bottom"
+          />
+        </MenuItem>
         <MenuItem className={classes.MenuItem} onClick={() => { this.handleChange('gallery'); handleClose(); }}>
           <FormControlLabel
             value="gallery"

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -242,7 +242,13 @@ export default {
       canvas: true,
       annotations: true,
       search: true,
-    }
+    },
+    views: [
+      { key: 'single', behaviors: ['individuals'] },
+      { key: 'book', behaviors: ['paged'] },
+      { key: 'scroll', behaviors: ['continuous'] },
+      { key: 'gallery' },
+    ],
   },
   windows: [ // Array of windows to be open when mirador initializes (each object should at least provide a manifestId key with the value of the IIIF presentation manifest to load)
     /**

--- a/src/containers/WindowViewSettings.js
+++ b/src/containers/WindowViewSettings.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getWindowViewType } from '../state/selectors';
+import { getAllowedWindowViewTypes, getWindowViewType } from '../state/selectors';
 import { WindowViewSettings } from '../components/WindowViewSettings';
 
 /**
@@ -21,6 +21,7 @@ const mapDispatchToProps = { setWindowViewType: actions.setWindowViewType };
  */
 const mapStateToProps = (state, { windowId }) => (
   {
+    viewTypes: getAllowedWindowViewTypes(state, { windowId }),
     windowViewType: getWindowViewType(state, { windowId }),
   }
 );

--- a/src/lib/CanvasGroupings.js
+++ b/src/lib/CanvasGroupings.js
@@ -29,7 +29,7 @@ export default class CanvasGroupings {
     if (this._groupings) { // eslint-disable-line no-underscore-dangle
       return this._groupings; // eslint-disable-line no-underscore-dangle
     }
-    if (this.viewType === 'continuous') {
+    if (this.viewType === 'scroll') {
       return [this.canvases];
     }
     if (this.viewType !== 'book') {

--- a/src/lib/CanvasGroupings.js
+++ b/src/lib/CanvasGroupings.js
@@ -29,6 +29,9 @@ export default class CanvasGroupings {
     if (this._groupings) { // eslint-disable-line no-underscore-dangle
       return this._groupings; // eslint-disable-line no-underscore-dangle
     }
+    if (this.viewType === 'continuous') {
+      return [this.canvases];
+    }
     if (this.viewType !== 'book') {
       return this.canvases.map(canvas => [canvas]);
     }

--- a/src/lib/CanvasWorld.js
+++ b/src/lib/CanvasWorld.js
@@ -13,6 +13,7 @@ export default class CanvasWorld {
     this.canvases = canvases.map(c => new MiradorCanvas(c));
     this.layers = layers;
     this.viewingDirection = viewingDirection;
+    this._canvasDimensions = null; // eslint-disable-line no-underscore-dangle
   }
 
   /** */
@@ -20,64 +21,112 @@ export default class CanvasWorld {
     return this.canvases.map(canvas => canvas.id);
   }
 
+  /** */
+  get canvasDimensions() {
+    if (this._canvasDimensions) { // eslint-disable-line no-underscore-dangle
+      return this._canvasDimensions; // eslint-disable-line no-underscore-dangle
+    }
+
+    const [dirX, dirY] = this.canvasDirection;
+    const scale = dirY === 0
+      ? Math.min(...this.canvases.map(c => c.getHeight()))
+      : Math.min(...this.canvases.map(c => c.getWidth()));
+    let incX = 0;
+    let incY = 0;
+
+    const canvasDims = this.canvases.reduce((acc, canvas) => {
+      let canvasHeight;
+      let canvasWidth;
+
+      if (dirY === 0) {
+        // constant height
+        canvasHeight = scale;
+        canvasWidth = Math.floor(scale * canvas.aspectRatio);
+      } else {
+        // constant width
+        canvasWidth = scale;
+        canvasHeight = Math.floor(scale * (1 / canvas.aspectRatio));
+      }
+      acc.push({
+        canvas,
+        height: canvasHeight,
+        width: canvasWidth,
+        x: incX,
+        y: incY,
+      });
+
+      incX += dirX * canvasWidth;
+      incY += dirY * canvasHeight;
+      return acc;
+    }, []);
+
+    const worldHeight = dirY === 0 ? scale : Math.abs(incY);
+    const worldWidth = dirX === 0 ? scale : Math.abs(incX);
+
+    this._canvasDimensions = canvasDims // eslint-disable-line no-underscore-dangle
+      .reduce((acc, dims) => {
+        acc.push({
+          ...dims,
+          x: dirX === -1 ? dims.x + worldWidth - dims.width : dims.x,
+          y: dirY === -1 ? dims.y + worldHeight - dims.height : dims.y,
+        });
+
+        return acc;
+      }, []);
+
+    return this._canvasDimensions; // eslint-disable-line no-underscore-dangle
+  }
+
   /**
    * contentResourceToWorldCoordinates - calculates the contentResource coordinates
    * respective to the world.
    */
   contentResourceToWorldCoordinates(contentResource) {
-    const wholeBounds = this.worldBounds();
     const miradorCanvasIndex = this.canvases.findIndex(c => (
       c.imageResources.find(r => r.id === contentResource.id)
     ));
     const canvas = this.canvases[miradorCanvasIndex];
-    const scaledWidth = Math.floor(wholeBounds[3] * canvas.aspectRatio);
-    let x = 0;
-    if (miradorCanvasIndex === this.secondCanvasIndex) {
-      x = wholeBounds[2] - scaledWidth;
-    }
+    const [x, y, w, h] = this.canvasToWorldCoordinates(canvas.id);
+
     const fragmentOffset = canvas.onFragment(contentResource.id);
     if (fragmentOffset) {
       return [
         x + fragmentOffset[0],
-        0 + fragmentOffset[1],
+        y + fragmentOffset[1],
         fragmentOffset[2],
         fragmentOffset[3],
       ];
     }
     return [
       x,
-      0,
-      scaledWidth,
-      wholeBounds[3],
+      y,
+      w,
+      h,
     ];
   }
 
   /** */
   canvasToWorldCoordinates(canvasId) {
-    const wholeBounds = this.worldBounds();
-    const miradorCanvasIndex = this.canvases.findIndex(c => (c.id === canvasId));
-    const { aspectRatio } = this.canvases[miradorCanvasIndex];
-    const scaledWidth = Math.floor(wholeBounds[3] * aspectRatio);
-    let x = 0;
-    if (miradorCanvasIndex === this.secondCanvasIndex) {
-      x = wholeBounds[2] - scaledWidth;
-    }
+    const canvasDimensions = this.canvasDimensions.find(c => c.canvas.id === canvasId);
+
     return [
-      x,
-      0,
-      scaledWidth,
-      wholeBounds[3],
+      canvasDimensions.x,
+      canvasDimensions.y,
+      canvasDimensions.width,
+      canvasDimensions.height,
     ];
   }
 
-  /**
-   * secondCanvasIndex - index of the second canvas used for determining which
-   * is first
-   */
-  get secondCanvasIndex() {
-    return this.viewingDirection === 'right-to-left' ? 0 : 1;
+  /** */
+  get canvasDirection() {
+    switch (this.viewingDirection) {
+      case 'left-to-right': return [1, 0];
+      case 'right-to-left': return [-1, 0];
+      case 'top-to-bottom': return [0, 1];
+      case 'bottom-to-top': return [0, -1];
+      default: return [0, 1];
+    }
   }
-
 
   /** Get the IIIF content resource for an image */
   contentResource(infoResponseId) {
@@ -149,26 +198,14 @@ export default class CanvasWorld {
    * lined up horizontally starting from left to right.
    */
   worldBounds() {
-    const heights = [];
-    const dimensions = [];
-    this.canvases.forEach((canvas) => {
-      heights.push(canvas.getHeight());
-      dimensions.push({
-        height: canvas.getHeight(),
-        width: canvas.getWidth(),
-      });
-    });
-    const minHeight = Math.min(...heights);
-    let scaledWidth = 0;
-    dimensions.forEach((dim) => {
-      const aspectRatio = dim.width / dim.height;
-      scaledWidth += Math.floor(minHeight * aspectRatio);
-    });
+    const worldWidth = Math.max(...this.canvasDimensions.map(c => c.x + c.width));
+    const worldHeight = Math.max(...this.canvasDimensions.map(c => c.y + c.height));
+
     return [
       0,
       0,
-      scaledWidth,
-      minHeight,
+      worldWidth,
+      worldHeight,
     ];
   }
 }

--- a/src/lib/CanvasWorld.js
+++ b/src/lib/CanvasWorld.js
@@ -124,7 +124,7 @@ export default class CanvasWorld {
       case 'right-to-left': return [-1, 0];
       case 'top-to-bottom': return [0, 1];
       case 'bottom-to-top': return [0, -1];
-      default: return [0, 1];
+      default: return [1, 0];
     }
   }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -104,6 +104,7 @@
     "retry": "Retry",
     "right": "Right",
     "rights": "License",
+    "scroll": "Scroll",
     "searchInputLabel": "search terms",
     "searchNextResult": "Next result",
     "searchNoResults": "No results found",

--- a/src/state/selectors/config.js
+++ b/src/state/selectors/config.js
@@ -52,6 +52,11 @@ export const getDefaultView = createSelector(
   ({ window }) => window && window.defaultView,
 );
 
+export const getViewConfigs = createSelector(
+  [getConfig],
+  ({ window }) => (window && window.views) || [],
+);
+
 export const getThemeDirection = createSelector(
   [getConfig],
   ({ theme }) => theme.direction || 'ltr',

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -88,6 +88,7 @@ export const getWindowViewType = createSelector(
   ],
   (window, manifestViewingHint, manifestBehaviors, defaultView) => {
     const lookup = {
+      continuous: 'continuous',
       individuals: 'single',
       paged: 'book',
     };

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -88,7 +88,7 @@ export const getWindowViewType = createSelector(
   ],
   (window, manifestViewingHint, manifestBehaviors, defaultView) => {
     const lookup = {
-      continuous: 'continuous',
+      continuous: 'scroll',
       individuals: 'single',
       paged: 'book',
     };

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -5,7 +5,7 @@ import {
   getManifestViewingHint,
   getManifestoInstance,
 } from './manifests';
-import { getDefaultView } from './config';
+import { getDefaultView, getViewConfigs } from './config';
 import { getWorkspaceType } from './workspace';
 
 /**
@@ -85,17 +85,39 @@ export const getWindowViewType = createSelector(
     getManifestViewingHint,
     getManifestBehaviors,
     getDefaultView,
+    getViewConfigs,
   ],
-  (window, manifestViewingHint, manifestBehaviors, defaultView) => {
-    const lookup = {
-      continuous: 'scroll',
-      individuals: 'single',
-      paged: 'book',
-    };
-    return (window && window.view)
-      || lookup[manifestBehaviors.find(b => lookup[b]) || manifestViewingHint]
-      || defaultView;
+  (window, manifestViewingHint, manifestBehaviors, defaultView, viewConfig) => {
+    if (window && window.view) return window.view;
+
+    const config = viewConfig.find(view => (
+      view.behaviors
+      && view.behaviors.some(b => manifestViewingHint === b || manifestBehaviors.includes(b))
+    ));
+
+    return (config && config.key) || defaultView;
   },
+);
+
+/** */
+export const getAllowedWindowViewTypes = createSelector(
+  [
+    getManifestViewingHint,
+    getManifestBehaviors,
+    getDefaultView,
+    getViewConfigs,
+  ],
+  (manifestViewingHint, manifestBehaviors, defaultView, viewConfig) => (
+    viewConfig.reduce((allowedViews, view) => {
+      if (
+        view.key === defaultView
+        || !view.behaviors
+        || view.behaviors.some(b => (
+          manifestViewingHint === b || manifestBehaviors.includes(b)
+        ))) allowedViews.push(view.key);
+      return allowedViews;
+    }, [])
+  ),
 );
 
 export const getViewer = createSelector(


### PR DESCRIPTION
…tinuous viewing


Test manifests:
- https://iiif.library.ucla.edu/ark%3A%2F21198%2Fzz001nwthk/manifest (unfortunately doesn't advertise top-to-bottomness)
- http://preview.iiif.io/cookbook/0010-book-2-viewing-direction/recipe/0010-book-2-viewing-direction/manifest-ttb.json (Level 0, loading 4x huge images... major performance drag)

Fixes #2886

TODO:
- [x] top-to-bottom tests
- [x] continuous tests
- [x] manifest behavior tests 
- [x] confirm thumbnail/info/index view behavior for continuous [good enough for now]
- [ ] is there a way for OSD (or our wrapper) to lazy-load canvas data (or, maybe this is only a level 0 issue?)
- [x] maybe  add a way to hide/disable view types (or.. loading up scroll view for something  that   isn't a scroll may be a pretty annoying  mistake) [yes!]

Potential future enhancements:
- only show canvas info for canvases in the viewport
- click-to-zoom to particular canvases
- alternative presentation in the thumbnail strip