### PR TITLE
Enables CompanionWindows to provide its children the ability to close…

### DIFF
--- a/__tests__/src/components/CompanionWindow.test.js
+++ b/__tests__/src/components/CompanionWindow.test.js
@@ -58,6 +58,17 @@ describe('CompanionWindow', () => {
       button.props().onClick(); // Trigger the onClick prop
       expect(removeCompanionWindowEvent).toHaveBeenCalledTimes(1);
     });
+
+    it('allows the children to know about onCloseClick', () => {
+      const removeCompanionWindowEvent = jest.fn();
+      companionWindow = createWrapper({
+        children: <div>HelloWorld</div>,
+        onCloseClick: removeCompanionWindowEvent,
+      });
+      const { parentactions } = companionWindow.children().find('div').props();
+      parentactions.closeCompanionWindow();
+      expect(removeCompanionWindowEvent).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('when the companion window is on the right', () => {

--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -75,6 +75,18 @@ export class CompanionWindow extends Component {
 
     const isBottom = (position === 'bottom' || position === 'far-bottom');
 
+    const childrenWithAdditionalProps = React.Children.map(children, child => (
+      React.cloneElement(
+        child,
+        {
+          parentactions: {
+            closeCompanionWindow: onCloseClick,
+          },
+        },
+      )
+    ));
+
+
     return (
       <Paper
         className={[classes.root, position === 'bottom' ? classes.horizontal : classes.vertical, classes[`companionWindow-${position}`], ns(`companion-window-${position}`), paperClassName].join(' ')}
@@ -162,7 +174,7 @@ export class CompanionWindow extends Component {
             }
           </Toolbar>
           <Paper className={classes.content} elevation={0}>
-            {children}
+            {childrenWithAdditionalProps}
           </Paper>
         </Rnd>
       </Paper>


### PR DESCRIPTION
… itself

This pull request aims to teach children of a CompanionWindow to just know about some of the actions on itself. This removes the need for plugins to jump through hoops where they may not need to.