### PR TITLE
Memoize annotation resources

### DIFF
--- a/src/lib/AnnotationList.js
+++ b/src/lib/AnnotationList.js
@@ -21,8 +21,11 @@ export default class AnnotationList {
 
   /** */
   get resources() {
-    if (!this.json || !this.json.resources) return [];
+    this._resources = this._resources || (() => { // eslint-disable-line no-underscore-dangle
+      if (!this.json || !this.json.resources) return [];
 
-    return flatten([this.json.resources]).map(resource => new AnnotationResource(resource));
+      return flatten([this.json.resources]).map(resource => new AnnotationResource(resource));
+    })();
+    return this._resources; // eslint-disable-line no-underscore-dangle
   }
 }

--- a/src/lib/AnnotationPage.js
+++ b/src/lib/AnnotationPage.js
@@ -24,9 +24,12 @@ export default class AnnotationPage {
 
   /** */
   get items() {
-    if (!this.json || !this.json.items) return [];
+    this._items = this._items || (() => { // eslint-disable-line no-underscore-dangle
+      if (!this.json || !this.json.items) return [];
 
-    return flatten([this.json.items]).map(resource => new AnnotationItem(resource));
+      return flatten([this.json.items]).map(resource => new AnnotationItem(resource));
+    })();
+    return this._items; // eslint-disable-line no-underscore-dangle
   }
 
   /**


### PR DESCRIPTION
Calls to the `resources` and `items` getters for the AnnotationList and AnnotationPage classes, respectively, always instantiate new instances of AnnotationResource or AnnotationItem.

This is expensive and degrades performance notably when there are large numbers of annotations present, as has been noted on #2915.

The changes in this PR simply memoize those getters.

(This gives a decent improvement, but performance is still poor with very large number of annotations.)