### PR TITLE
Pass through the annotation as a prop so that a plugin can use this in a much easier way

### DIFF
--- a/__tests__/src/components/CanvasAnnotations.test.js
+++ b/__tests__/src/components/CanvasAnnotations.test.js
@@ -61,6 +61,11 @@ describe('CanvasAnnotations', () => {
     expect(wrapper.find(ListItem).length).toEqual(2);
   });
 
+  it('pass through the annotation to make plugins life easier', () => {
+    wrapper = createWrapper({ annotations });
+    expect(wrapper.find(ListItem).first().dive().props().annotation.id).toEqual('abc123');
+  });
+
   it('renders nothing when there are no annotations', () => {
     wrapper = createWrapper();
     expect(wrapper.find(Typography).length).toBe(0);

--- a/src/components/CanvasAnnotations.js
+++ b/src/components/CanvasAnnotations.js
@@ -75,6 +75,7 @@ export class CanvasAnnotations extends Component {
                 component={listContainerComponent}
                 className={classes.annotationListItem}
                 key={annotation.id}
+                annotation={annotation}
                 annotationid={annotation.id}
                 selected={selectedAnnotationIds.includes(annotation.id)}
                 onClick={e => this.handleClick(e, annotation)}


### PR DESCRIPTION
The intent here is to pass through the annotation object so that a plugin customizing the display has an easier time.