### PR TITLE
Extract separate state for the workspace catalog

### DIFF
--- a/__tests__/integration/mirador/blank.html
+++ b/__tests__/integration/mirador/blank.html
@@ -14,8 +14,6 @@
      var miradorInstance = Mirador.viewer({
        id: 'mirador',
        windows: [],
-       manifests: {
-       }
      });
     </script>
   </body>

--- a/__tests__/integration/mirador/contentsearch.html
+++ b/__tests__/integration/mirador/contentsearch.html
@@ -18,13 +18,13 @@
          // defaultSearchQuery: 'NSF',
          suggestedSearches: ['NSF'],
        }],
-       manifests: {
-         "https://damsssl.llgc.org.uk/iiif/2.0/4566425/manifest.json": { provider: "LLGC"},
-         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
-         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
-         "https://scta.info/iiif/graciliscommentary/lon/manifest": { provider: "SCTA"},
-         "https://purl.stanford.edu/zx429wp8334/iiif/manifest": { provider: "SUL" },
-       }
+       catalog: [
+         { manifestId: "https://damsssl.llgc.org.uk/iiif/2.0/4566425/manifest.json", provider: "LLGC"},
+         { manifestId: "https://data.ucd.ie/api/img/manifests/ucdlib:33064", provider: "Irish Architectural Archive"},
+         { manifestId: "https://wellcomelibrary.org/iiif/b18035723/manifest", provider: "Wellcome Library"},
+         { manifestId: "https://scta.info/iiif/graciliscommentary/lon/manifest", provider: "SCTA"},
+         { manifestId: "https://purl.stanford.edu/zx429wp8334/iiif/manifest", provider: "SUL" },
+       ]
      });
     </script>
   </body>

--- a/__tests__/integration/mirador/index.html
+++ b/__tests__/integration/mirador/index.html
@@ -21,19 +21,19 @@
        {
          manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json',
        }],
-       manifests: {
-         "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},
-         "https://data.ucd.ie/api/img/manifests/ucdlib:33064": { provider: "Irish Architectural Archive"},
-         "https://wellcomelibrary.org/iiif/b18035723/manifest": { provider: "Wellcome Library"},
-         "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json": { provider: "Biblissima"},
-         "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json": { provider: "e-codices - Virtual Manuscript Library of Switzerland"},
-         "https://wellcomelibrary.org/iiif/collection/b18031511": { provider: "Wellcome Library"},
-         "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json": { provider: "Bibliothèque nationale de France"},
-         "https://manifests.britishart.yale.edu/Osbornfa1": { provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
-         "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json": { provider: "Biblissima"},
-         "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest": { provider: "Durham University Library"},
-         // "https://iiif.vam.ac.uk/collections/O1023003/manifest.json": { provider: "Ocean liners"},
-       }
+       catalog: [
+         { manifestId: "https://media.nga.gov/public/manifests/nga_highlights.json", provider: "National Gallery of Art"},
+         { manifestId: "https://data.ucd.ie/api/img/manifests/ucdlib:33064", provider: "Irish Architectural Archive"},
+         { manifestId: "https://wellcomelibrary.org/iiif/b18035723/manifest", provider: "Wellcome Library"},
+         { manifestId: "https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json", provider: "Biblissima"},
+         { manifestId: "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json", provider: "e-codices - Virtual Manuscript Library of Switzerland"},
+         { manifestId: "https://wellcomelibrary.org/iiif/collection/b18031511", provider: "Wellcome Library"},
+         { manifestId: "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10022508f/manifest.json", provider: "Bibliothèque nationale de France"},
+         { manifestId: "https://manifests.britishart.yale.edu/Osbornfa1", provider: "Beinecke Rare Book and Manuscript Library, Yale University"},
+         { manifestId: "https://iiif.biblissima.fr/chateauroux/B360446201_MS0005/manifest.json", provider: "Biblissima"},
+         { manifestId: "https://iiif.durham.ac.uk/manifests/trifle/32150/t1/m4/q7/t1m4q77fr328/manifest", provider: "Durham University Library"},
+         //{ manifestId: "https://iiif.vam.ac.uk/collections/O1023003/manifest.json", provider: "Ocean liners"},
+       ]
      });
     </script>
   </body>

--- a/__tests__/integration/mirador/layers.html
+++ b/__tests__/integration/mirador/layers.html
@@ -24,12 +24,12 @@
            search: true,
          }
        },
-       manifests: {
-         "https://demos.biblissima.fr/iiif/metadata/BVMM/chateauroux/manifest.json": {},
-         "https://prtd.app/aom/manifest.json": {},
-         "https://prtd.app/fv/manifest.json": {},
-         "https://manifests.britishart.yale.edu/Osbornfa1": {},
-       }
+       catalog: [
+         { manifestId: "https://demos.biblissima.fr/iiif/metadata/BVMM/chateauroux/manifest.json" },
+         { manifestId: "https://prtd.app/aom/manifest.json" },
+         { manifestId: "https://prtd.app/fv/manifest.json" },
+         { manifestId: "https://manifests.britishart.yale.edu/Osbornfa1" },
+       ]
      });
     </script>
   </body>

--- a/__tests__/integration/mirador/toc.html
+++ b/__tests__/integration/mirador/toc.html
@@ -21,15 +21,15 @@
          sideBarOpenByDefault: true,
          defaultSideBarPanel: 'canvas'
        },
-       manifests: {
-         'https://iiif.bodleian.ox.ac.uk/iiif/manifest/390fd0e8-9eae-475d-9564-ed916ab9035c.json': { provider: 'Bodleian Libraries' },
-         'http://dams.llgc.org.uk/iiif/newspaper/issue/3100021/manifest.json': { provider: 'The National Library of Wales' },
-         'https://iiif.lib.harvard.edu/manifests/drs:5981093': { provider: 'Houghton Library (Harvard University)' },
-         'https://cudl.lib.cam.ac.uk/iiif/MS-ADD-03965' : {},
-         'https://iiif.bodleian.ox.ac.uk/iiif/manifest/ca3dc326-4a7b-479f-a754-5aed9d2f2cb4.json': {},
+       catalog: [
+         { manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/390fd0e8-9eae-475d-9564-ed916ab9035c.json', provider: 'Bodleian Libraries' },
+         { manifestId: 'http://dams.llgc.org.uk/iiif/newspaper/issue/3100021/manifest.json', provider: 'The National Library of Wales' },
+         { manifestId: 'https://iiif.lib.harvard.edu/manifests/drs:5981093', provider: 'Houghton Library (Harvard University)' },
+         { manifestId: 'https://cudl.lib.cam.ac.uk/iiif/MS-ADD-03965' },
+         { manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/ca3dc326-4a7b-479f-a754-5aed9d2f2cb4.json' },
         //  'https://gist.githubusercontent.com/jeffreycwitt/90b33c1c4e119e7a48b7a66ea41a48c1/raw/522b132409d6c67a78f8f26b0ceb7346a52cfe62/test-manifest-with-complicated-toc.json': {},
         //  'https://gist.githubusercontent.com/jeffreycwitt/1a75fdb4a97e1c2a98bd35797aad263d/raw/859104cb6cd7bd99f3be668f064066f4b3ba2b29/manifest-with-three-level-deep-toc.json': {},
-       }
+        ]
      });
     </script>
   </body>

--- a/__tests__/src/actions/catalog.test.js
+++ b/__tests__/src/actions/catalog.test.js
@@ -1,0 +1,41 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import * as actions from '../../../src/state/actions';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('addResource', () => {
+  let store = null;
+  beforeEach(() => {
+    store = mockStore({});
+    fetch.mockResponseOnce(JSON.stringify({ data: '12345' })); // eslint-disable-line no-undef
+  });
+
+  it('dispatches ADD_RESOURCE', () => {
+    store.dispatch(actions.addResource('https://purl.stanford.edu/sn904cj3429/iiif/manifest'));
+    expect(store.getActions()[0]).toEqual({
+      manifestId: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest',
+      type: 'mirador/ADD_RESOURCE',
+    });
+  });
+
+  it('dispatches the REQUEST_MANIFEST action', () => {
+    store.dispatch(actions.addResource('https://purl.stanford.edu/sn904cj3429/iiif/manifest'));
+    expect(store.getActions()[1]).toEqual({
+      manifestId: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest',
+      properties: { isFetching: true },
+      type: 'mirador/REQUEST_MANIFEST',
+    });
+  });
+});
+
+describe('removeResource', () => {
+  it('dispatches REMOVE_RESOURCE', () => {
+    expect(actions.removeResource('some-url')).toEqual({
+      manifestId: 'some-url',
+      type: 'mirador/REMOVE_RESOURCE',
+    });
+  });
+});

--- a/__tests__/src/components/ManifestForm.test.js
+++ b/__tests__/src/components/ManifestForm.test.js
@@ -6,7 +6,7 @@ import { ManifestForm } from '../../../src/components/ManifestForm';
 function createWrapper(props) {
   return mount(
     <ManifestForm
-      fetchManifest={() => {}}
+      addResource={() => {}}
       t={str => str}
       {...props}
     />,
@@ -37,15 +37,15 @@ describe('ManifestForm', () => {
   });
 
   it('triggers an action when the form is submitted', () => {
-    const fetchManifest = jest.fn();
+    const addResource = jest.fn();
     const onSubmit = jest.fn();
-    const wrapper = createWrapper({ addResourcesOpen: true, fetchManifest, onSubmit });
+    const wrapper = createWrapper({ addResource, addResourcesOpen: true, onSubmit });
     wrapper.setState({ formValue: 'asdf' });
 
     wrapper.setState({ formValue: 'http://example.com/iiif' });
 
     wrapper.find('form').simulate('submit', { preventDefault: () => {} });
-    expect(fetchManifest).toHaveBeenCalledWith('http://example.com/iiif');
+    expect(addResource).toHaveBeenCalledWith('http://example.com/iiif');
     expect(onSubmit).toHaveBeenCalled();
     expect(wrapper.state().formValue).toBe('');
   });

--- a/__tests__/src/components/WorkspaceAdd.test.js
+++ b/__tests__/src/components/WorkspaceAdd.test.js
@@ -6,7 +6,6 @@ import Fab from '@material-ui/core/Fab';
 import Typography from '@material-ui/core/Typography';
 import { WorkspaceAdd } from '../../../src/components/WorkspaceAdd';
 import ManifestListItem from '../../../src/containers/ManifestListItem';
-import fixture from '../../fixtures/version-2/002.json';
 import ManifestForm from '../../../src/containers/ManifestForm';
 
 /** create wrapper */
@@ -14,10 +13,10 @@ function createWrapper(props) {
   return shallow(
     <WorkspaceAdd
       setWorkspaceAddVisibility={() => {}}
-      manifests={{
-        bar: fixture,
-        foo: fixture,
-      }}
+      catalog={[
+        { manifestId: 'bar' },
+        { manifestId: 'foo' },
+      ]}
       classes={{}}
       t={str => str}
       {...props}
@@ -32,7 +31,7 @@ describe('WorkspaceAdd', () => {
   });
 
   it('without manifests, renders an empty message', () => {
-    const wrapper = createWrapper({ manifests: {} });
+    const wrapper = createWrapper({ catalog: [] });
     expect(wrapper.find(ManifestListItem).length).toEqual(0);
     expect(wrapper.find(Typography).first().children().text()).toEqual('emptyResourceList');
   });

--- a/__tests__/src/reducers/catalog.test.js
+++ b/__tests__/src/reducers/catalog.test.js
@@ -1,0 +1,85 @@
+import { catalogReducer } from '../../../src/state/reducers/catalog';
+import ActionTypes from '../../../src/state/actions/action-types';
+
+describe('catalog reducer', () => {
+  describe('ADD_MANIFEST', () => {
+    it('adds new manifests to the state', () => {
+      expect(catalogReducer([], {
+        manifestId: '1',
+        type: ActionTypes.ADD_RESOURCE,
+      })).toEqual([
+        { manifestId: '1' },
+      ]);
+    });
+    it('adds new manifests to the top of state', () => {
+      expect(catalogReducer([{ manifestId: '2' }], {
+        manifestId: '1',
+        type: ActionTypes.ADD_RESOURCE,
+      })).toEqual([
+        { manifestId: '1' },
+        { manifestId: '2' },
+      ]);
+    });
+    it('deduplicate manifests', () => {
+      expect(catalogReducer([{ manifestId: '1' }], {
+        manifestId: '1',
+        type: ActionTypes.ADD_RESOURCE,
+      })).toEqual([
+        { manifestId: '1' },
+      ]);
+    });
+  });
+
+  describe('REQUEST_MANIFEST', () => {
+    it('adds new manifests to the state', () => {
+      expect(catalogReducer([], {
+        manifestId: '1',
+        type: ActionTypes.REQUEST_MANIFEST,
+      })).toEqual([
+        { manifestId: '1' },
+      ]);
+    });
+    it('adds new manifests to the top of state', () => {
+      expect(catalogReducer([{ manifestId: '2' }], {
+        manifestId: '1',
+        type: ActionTypes.REQUEST_MANIFEST,
+      })).toEqual([
+        { manifestId: '1' },
+        { manifestId: '2' },
+      ]);
+    });
+    it('deduplicate manifests', () => {
+      expect(catalogReducer([{ manifestId: '1' }], {
+        manifestId: '1',
+        type: ActionTypes.REQUEST_MANIFEST,
+      })).toEqual([
+        { manifestId: '1' },
+      ]);
+    });
+  });
+
+  it('should handle REMOVE_RESOURCE', () => {
+    expect(catalogReducer([{ manifestId: '1' }], {
+      manifestId: '1',
+      type: ActionTypes.REMOVE_RESOURCE,
+    })).toEqual([]);
+  });
+
+  it('should handle IMPORT_MIRADOR_STATE', () => {
+    expect(catalogReducer([], {
+      state: { catalog: [{ manifestId: '1' }] },
+      type: ActionTypes.IMPORT_MIRADOR_STATE,
+    })).toEqual([
+      { manifestId: '1' },
+    ]);
+  });
+
+  it('should handle IMPORT_CONFIG', () => {
+    expect(catalogReducer([], {
+      config: { catalog: [{ manifestId: '1' }] },
+      type: ActionTypes.IMPORT_CONFIG,
+    })).toEqual([
+      { manifestId: '1' },
+    ]);
+  });
+});

--- a/src/components/ManifestForm.js
+++ b/src/components/ManifestForm.js
@@ -53,11 +53,11 @@ export class ManifestForm extends Component {
    * @private
    */
   formSubmit(event) {
-    const { fetchManifest, onSubmit } = this.props;
+    const { addResource, onSubmit } = this.props;
     const { formValue } = this.state;
     event.preventDefault();
     onSubmit();
-    fetchManifest(formValue);
+    addResource(formValue);
     this.setState({ formValue: '' });
   }
 
@@ -134,9 +134,9 @@ export class ManifestForm extends Component {
 }
 
 ManifestForm.propTypes = {
+  addResource: PropTypes.func.isRequired,
   addResourcesOpen: PropTypes.bool.isRequired,
   classes: PropTypes.objectOf(PropTypes.string),
-  fetchManifest: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
   onSubmit: PropTypes.func,
   t: PropTypes.func,

--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -43,21 +43,22 @@ export class WorkspaceAdd extends React.Component {
    */
   render() {
     const {
-      manifests, setWorkspaceAddVisibility, t, classes,
+      catalog, setWorkspaceAddVisibility, t, classes,
     } = this.props;
     const { addResourcesOpen } = this.state;
 
-    const manifestList = Object.keys(manifests).map(manifest => (
+    const manifestList = catalog.map(resource => (
       <ManifestListItem
-        key={manifest}
-        manifestId={manifest}
+        key={resource.manifestId}
+        manifestId={resource.manifestId}
+        provider={resource.provider}
         handleClose={() => setWorkspaceAddVisibility(false)}
       />
     ));
 
     return (
       <div className={classNames(ns('workspace-add'), classes.workspaceAdd)}>
-        {(Object.keys(manifests).length < 1) ? (
+        {catalog.length < 1 ? (
           <Grid
             alignItems="center"
             container
@@ -141,13 +142,14 @@ export class WorkspaceAdd extends React.Component {
 }
 
 WorkspaceAdd.propTypes = {
+  catalog: PropTypes.arrayOf(PropTypes.object),
   classes: PropTypes.objectOf(PropTypes.string),
-  manifests: PropTypes.instanceOf(Object).isRequired,
   setWorkspaceAddVisibility: PropTypes.func.isRequired,
   t: PropTypes.func,
 };
 
 WorkspaceAdd.defaultProps = {
+  catalog: [],
   classes: {},
   t: key => key,
 };

--- a/src/containers/ManifestForm.js
+++ b/src/containers/ManifestForm.js
@@ -11,7 +11,7 @@ import { ManifestForm } from '../components/ManifestForm';
  * @memberof ManifestForm
  * @private
  */
-const mapDispatchToProps = { fetchManifest: actions.fetchManifest };
+const mapDispatchToProps = { addResource: actions.addResource };
 /**
  *
  * @param theme

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -12,18 +12,21 @@ import * as actions from '../state/actions';
 import { ManifestListItem } from '../components/ManifestListItem';
 
 /** */
-const mapStateToProps = (state, { manifestId }) => ({
-  active: getWindowManifests(state).includes(manifestId),
-  error: getManifest(state, { manifestId }).error,
-  isFetching: getManifest(state, { manifestId }).isFetching,
-  manifestLogo: getManifestLogo(state, { manifestId }),
-  provider: getManifest(state, { manifestId }).provider
-    || getManifestProvider(state, { manifestId }),
-  ready: !!getManifest(state, { manifestId }).json,
-  size: getManifestCanvases(state, { manifestId }).length,
-  thumbnail: getManifestThumbnail(state, { manifestId }),
-  title: getManifestTitle(state, { manifestId }),
-});
+const mapStateToProps = (state, { manifestId, provider }) => {
+  const manifest = getManifest(state, { manifestId }) || {};
+  return {
+    active: getWindowManifests(state).includes(manifestId),
+    error: manifest.error,
+    isFetching: manifest.isFetching,
+    manifestLogo: getManifestLogo(state, { manifestId }),
+    provider: provider
+      || getManifestProvider(state, { manifestId }),
+    ready: !!manifest.json,
+    size: getManifestCanvases(state, { manifestId }).length,
+    thumbnail: getManifestThumbnail(state, { manifestId }),
+    title: getManifestTitle(state, { manifestId }),
+  };
+};
 
 /**
  * mapDispatchToProps - used to hook up connect to action creators

--- a/src/containers/ManifestListItemError.js
+++ b/src/containers/ManifestListItemError.js
@@ -3,12 +3,12 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
-import { fetchManifest, removeManifest } from '../state/actions/manifest';
+import { fetchManifest, removeResource } from '../state/actions';
 import { ManifestListItemError } from '../components/ManifestListItemError';
 
 /** */
 const mapDispatchToProps = {
-  onDismissClick: removeManifest,
+  onDismissClick: removeResource,
   onTryAgainClick: fetchManifest,
 };
 

--- a/src/containers/WorkspaceAdd.js
+++ b/src/containers/WorkspaceAdd.js
@@ -11,7 +11,7 @@ import { WorkspaceAdd } from '../components/WorkspaceAdd';
  * @memberof Workspace
  * @private
  */
-const mapStateToProps = state => ({ manifests: state.manifests });
+const mapStateToProps = state => ({ catalog: state.catalog });
 
 /**
  * mapDispatchToProps - used to hook up connect to action creators

--- a/src/state/actions/action-types.js
+++ b/src/state/actions/action-types.js
@@ -67,6 +67,8 @@ const ActionTypes = {
   SELECT_CONTENT_SEARCH_ANNOTATION: 'mirador/SELECT_CONTENT_SEARCH_ANNOTATION',
 
   UPDATE_LAYERS: 'mirador/UPDATE_LAYERS',
+  ADD_RESOURCE: 'mirador/ADD_RESOURCE',
+  REMOVE_RESOURCE: 'mirador/REMOVE_RESOURCE',
 };
 
 export default ActionTypes;

--- a/src/state/actions/catalog.js
+++ b/src/state/actions/catalog.js
@@ -1,0 +1,21 @@
+import ActionTypes from './action-types';
+import { fetchManifest } from './manifest';
+
+/**
+ * add a manifest to the resource catalog
+ * @param {string} manifestId
+ */
+export function addResource(manifestId) {
+  return ((dispatch, getState) => {
+    dispatch({ manifestId, type: ActionTypes.ADD_RESOURCE });
+    dispatch(fetchManifest(manifestId));
+  });
+}
+
+/** remove a manifest from the resource catalog */
+export function removeResource(manifestId) {
+  return {
+    manifestId,
+    type: ActionTypes.REMOVE_RESOURCE,
+  };
+}

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -15,3 +15,4 @@ export * from './auth';
 export * from './elasticLayout';
 export * from './search';
 export * from './layers';
+export * from './catalog';

--- a/src/state/reducers/catalog.js
+++ b/src/state/reducers/catalog.js
@@ -1,0 +1,25 @@
+import ActionTypes from '../actions/action-types';
+
+/**
+ * catalogReducer
+ */
+export const catalogReducer = (state = [], action) => {
+  switch (action.type) {
+    case ActionTypes.REQUEST_MANIFEST: // falls through, for now at least.
+    case ActionTypes.ADD_RESOURCE:
+      if (state.some(m => m.manifestId === action.manifestId)) return state;
+
+      return [
+        { manifestId: action.manifestId },
+        ...state,
+      ];
+    case ActionTypes.REMOVE_RESOURCE:
+      return state.filter(r => r.manifestId !== action.manifestId);
+    case ActionTypes.IMPORT_CONFIG:
+      return action.config.catalog || [];
+    case ActionTypes.IMPORT_MIRADOR_STATE:
+      return action.state.catalog || [];
+    default:
+      return state;
+  }
+};

--- a/src/state/reducers/index.js
+++ b/src/state/reducers/index.js
@@ -12,3 +12,4 @@ export * from './auth';
 export * from './elasticLayout';
 export * from './search';
 export * from './layers';
+export * from './catalog';

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -14,6 +14,7 @@ import {
   annotationsReducer,
   searchesReducer,
   layersReducer,
+  catalogReducer,
 } from '.';
 
 /**
@@ -26,6 +27,7 @@ export default function createRootReducer(pluginReducers) {
     accessTokens: accessTokensReducer,
     annotations: annotationsReducer,
     auth: authReducer,
+    catalog: catalogReducer,
     companionWindows: companionWindowsReducer,
     config: configReducer,
     elasticLayout: elasticLayoutReducer,


### PR DESCRIPTION
This is the start of a series of refactoring to try to pry apart/clarify some issues around manifest loading. The PR creates a seam so the workspace catalog can list entries (in `catalog`) separate from the HTTP mechanics of state in `manifests`, with the added benefit of (finally) making sure newly added manifests consistently appear at the top of the page.


