### PR TITLE
annotations: Make search annotations prettier

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -186,7 +186,7 @@ export class OpenSeadragonViewer extends Component {
   /**
    * annotationsToContext - converts anontations to a canvas context
    */
-  annotationsToContext(annotations, color = 'yellow', selected = false) {
+  annotationsToContext(annotations, color = 'yellow', selected = false, isSearch = false) {
     const { canvasWorld } = this.props;
     const context = this.osdCanvasOverlay.context2d;
     const zoomRatio = this.viewer.viewport.getZoom(true) / this.viewer.viewport.getMaxZoom();
@@ -195,7 +195,7 @@ export class OpenSeadragonViewer extends Component {
         if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
         const offset = canvasWorld.offsetByCanvas(resource.targetId);
         const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
-          color, offset, resource, selected, zoomRatio,
+          color, isSearch, offset, resource, selected, zoomRatio,
         });
         canvasAnnotationDisplay.toContext(context);
       });
@@ -355,11 +355,11 @@ export class OpenSeadragonViewer extends Component {
       palette,
     } = this.props;
 
-    this.annotationsToContext(searchAnnotations, palette.highlights.secondary);
+    this.annotationsToContext(searchAnnotations, palette.highlights.secondary, false, true);
     this.annotationsToContext(
       selectedContentSearchAnnotations,
       palette.highlights.primary,
-      true,
+      true, true,
     );
 
     this.annotationsToContext(highlightedAnnotations, palette.highlights.secondary);

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -1,3 +1,6 @@
+/** Opacity of the search annotations */
+const SEARCH_ANNOTATION_ALPHA = 0.3;
+
 /**
  * CanvasAnnotationDisplay - class used to display a SVG and fragment based
  * annotations.
@@ -5,13 +8,14 @@
 export default class CanvasAnnotationDisplay {
   /** */
   constructor({
-    resource, color, zoomRatio, offset, selected,
+    resource, color, zoomRatio, offset, selected, isSearch,
   }) {
     this.resource = resource;
     this.color = color;
     this.zoomRatio = zoomRatio;
     this.offset = offset;
     this.selected = selected;
+    this.isSearch = isSearch;
   }
 
   /** */
@@ -75,6 +79,10 @@ export default class CanvasAnnotationDisplay {
           this.context.globalAlpha = element.attributes['fill-opacity'].nodeValue;
         }
         this.context.fill(p);
+      } else if (this.isSearch) {
+        this.context.fillStyle = this.color;
+        this.context.globalAlpha = SEARCH_ANNOTATION_ALPHA;
+        this.context.fill(p);
       }
       this.context.restore();
     });
@@ -85,9 +93,16 @@ export default class CanvasAnnotationDisplay {
     const fragment = this.resource.fragmentSelector;
     fragment[0] += this.offset.x;
     fragment[1] += this.offset.y;
-    this.context.strokeStyle = this.color;
-    this.context.lineWidth = 1 / this.zoomRatio;
-    this.context.strokeRect(...fragment);
+    if (this.isSearch) {
+      this.context.fillStyle = this.color;
+      this.context.globalAlpha = SEARCH_ANNOTATION_ALPHA;
+      this.context.fillRect(...fragment);
+      this.context.restore();
+    } else {
+      this.context.strokeStyle = this.color;
+      this.context.lineWidth = 1 / this.zoomRatio;
+      this.context.strokeRect(...fragment);
+    }
   }
 
   /** */


### PR DESCRIPTION
This switches the visualization of search annotations from the standard outline-only display to a translucent filled rectangle that is more in line with how highlighted text is usually rendered on images in digital library search engines.

For this, we introduce a new `isSearch` option to the `CanvasAnnotationDisplay` class that enables this way of rendering.

Comparison of old (i.e. general annotation rendering) visualization and new:

![searchhl_old](https://user-images.githubusercontent.com/608610/82684607-2f6b4800-9c53-11ea-90ad-b832e3da8249.png)
![searchhl_new](https://user-images.githubusercontent.com/608610/82684618-32fecf00-9c53-11ea-8f44-247fb517b243.png)

Currently the alpha-value of the annotation rectangles is hardcoded to `0.3` with a constant, but if you can give me some pointers on how to use the configuration API to make this user-configurable, I can switch that out.

I also did not include unit tests, since I couldn't find any existing tests with assertions on the actual canvas pixels. If tests are desired, for this I can try to find a way,  but it'll probably be significantly more code than the actual changeset.