### PR TITLE
Refactor reducer plugins out of the PluginContext and into MiradorViewer

### DIFF
--- a/__tests__/src/extend/pluginPreprocessing.test.js
+++ b/__tests__/src/extend/pluginPreprocessing.test.js
@@ -27,16 +27,16 @@ describe('filterValidPlugins', () => {
         target: 'Window',
       },
       {
+        mode: 'wrap',
         name: 'invalid Plugin 1',
       },
       {
         name: 'invalid Plugin 2',
+        target: 'missing-mode',
       },
     ];
     const result = filterValidPlugins(plugins);
-    expect(result.length).toBe(2);
-    expect(result[0].name).toBe('valid plugin 1');
-    expect(result[1].name).toBe('valid plugin 2');
+    expect(result.map(r => r.name)).toEqual(['valid plugin 1', 'valid plugin 2']);
   });
 });
 

--- a/__tests__/src/extend/pluginValidation.test.js
+++ b/__tests__/src/extend/pluginValidation.test.js
@@ -22,7 +22,7 @@ describe('validatePlugin', () => {
   });
 
   it('plugin must be a object', () => {
-    const plugin = [];
+    const plugin = 'some string';
     expect(validatePlugin(plugin)).toBe(false);
   });
 
@@ -36,17 +36,17 @@ describe('validatePlugin', () => {
   });
 
   it('target must be string', () => {
-    let plugin = createPlugin({ target: undefined });
+    let plugin = createPlugin({ mode: 'add', target: undefined });
     expect(validatePlugin(plugin)).toBe(false);
-    plugin = createPlugin({ target: 'test' });
+    plugin = createPlugin({ mode: 'add', target: 'test' });
     expect(validatePlugin(plugin)).toBe(true);
-    plugin = createPlugin({ target: [] });
+    plugin = createPlugin({ mode: 'add', target: [] });
     expect(validatePlugin(plugin)).toBe(false);
   });
 
-  it('mode must be "add" or "wrap"', () => {
-    let plugin = createPlugin({ mode: undefined });
-    expect(validatePlugin(plugin)).toBe(false);
+  it('mode must be missing, "add" or "wrap"', () => {
+    let plugin = createPlugin({ mode: undefined, target: undefined });
+    expect(validatePlugin(plugin)).toBe(true);
     plugin = createPlugin({ mode: 'somethink' });
     expect(validatePlugin(plugin)).toBe(false);
     plugin = createPlugin({ mode: 'add' });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,6 @@
 import React, { Component, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import PluginProvider from '../extend/PluginProvider';
-import createRootReducer from '../state/reducers/rootReducer';
 import AppProviders from '../containers/AppProviders';
 import AuthenticationSender from '../containers/AuthenticationSender';
 import AccessTokenSender from '../containers/AccessTokenSender';
@@ -21,7 +20,7 @@ export class App extends Component {
     const { plugins } = this.props;
 
     return (
-      <PluginProvider plugins={plugins} createRootReducer={createRootReducer}>
+      <PluginProvider plugins={plugins}>
         <AppProviders>
           <AuthenticationSender />
           <AccessTokenSender />

--- a/src/extend/PluginProvider.js
+++ b/src/extend/PluginProvider.js
@@ -1,10 +1,7 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { ReactReduxContext } from 'react-redux';
 import PluginContext from './PluginContext';
 import {
-  filterValidPlugins,
-  addPluginReducersToStore,
   connectPluginsToStore,
   createTargetToPluginMapping,
   addPluginsToCompanionWindowsRegistry,
@@ -12,14 +9,11 @@ import {
 
 /**  */
 export default function PluginProvider(props) {
-  const { store } = useContext(ReactReduxContext);
-  const { plugins, createRootReducer, children } = props;
+  const { plugins, children } = props;
   const [pluginMap, setPluginMap] = useState({});
 
   useEffect(() => {
-    const validPlugins = filterValidPlugins(plugins);
-    const connectedPlugins = connectPluginsToStore(validPlugins);
-    createRootReducer && addPluginReducersToStore(store, createRootReducer, validPlugins);
+    const connectedPlugins = connectPluginsToStore(plugins);
     addPluginsToCompanionWindowsRegistry(connectedPlugins);
     setPluginMap(createTargetToPluginMapping(connectedPlugins));
   }, []);
@@ -33,12 +27,10 @@ export default function PluginProvider(props) {
 
 PluginProvider.propTypes = {
   children: PropTypes.node,
-  createRootReducer: PropTypes.func,
   plugins: PropTypes.array, // eslint-disable-line react/forbid-prop-types
 };
 
 PluginProvider.defaultProps = {
   children: null,
-  createRootReducer: null,
   plugins: [],
 };

--- a/src/extend/pluginPreprocessing.js
+++ b/src/extend/pluginPreprocessing.js
@@ -76,6 +76,6 @@ function connectPluginComponent(plugin) {
 }
 
 /**  */
-function getReducersFromPlugins(plugins) {
+export function getReducersFromPlugins(plugins) {
   return plugins && plugins.reduce((acc, plugin) => ({ ...acc, ...plugin.reducers }), {});
 }

--- a/src/extend/pluginValidation.js
+++ b/src/extend/pluginValidation.js
@@ -27,14 +27,16 @@ const checkName = (plugin) => {
 
 /** */
 const checkTarget = (plugin) => {
-  const { target } = plugin;
+  const { mode, target } = plugin;
+  if (isUndefined(mode)) return isUndefined(target);
+
   return isString(target);
 };
 
 /** */
 const checkMode = (plugin) => {
   const { mode } = plugin;
-  return ['add', 'wrap'].some(s => s === mode);
+  return isUndefined(mode) || ['add', 'wrap'].some(s => s === mode);
 };
 
 /** */

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -5,6 +5,10 @@ import { v4 as uuid } from 'uuid';
 import { App } from '../components/App';
 import createStore from '../state/createStore';
 import * as actions from '../state/actions';
+import {
+  filterValidPlugins,
+  getReducersFromPlugins,
+} from '../extend/pluginPreprocessing';
 import { getCompanionWindowIdsForPosition, getManifestSearchService } from '../state/selectors';
 
 /**
@@ -15,8 +19,9 @@ class MiradorViewer {
    */
   constructor(config, viewerConfig = {}) {
     this.config = config;
-    this.plugins = viewerConfig.plugins || [];
-    this.store = viewerConfig.store || createStore();
+    this.plugins = filterValidPlugins(viewerConfig.plugins || []);
+    this.store = viewerConfig.store
+      || createStore(getReducersFromPlugins(this.plugins));
     this.processConfig();
 
     const viewer = {


### PR DESCRIPTION
I was surprised to see we create the root reducer twice (once on initialization, once in the plugins).   

This also opens up the possibility of reducer-only plugins

One thing this drops is the ability to inject an existing plugin-less store.. we can easily re-add that, although it seems like the caller should just as easily add them in the first place.