### PR TITLE
Slightly darken/lighten the workspace background

### DIFF
--- a/src/containers/WorkspaceArea.js
+++ b/src/containers/WorkspaceArea.js
@@ -1,7 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, lighten, darken } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { WorkspaceArea } from '../components/WorkspaceArea';
 
@@ -23,17 +23,21 @@ const mapStateToProps = state => (
  * @param theme
  * @returns {{background: {background: string}}}
  */
-const styles = theme => ({
-  viewer: {
-    background: theme.palette.shades.light,
-    bottom: 0,
-    left: 0,
-    overflow: 'hidden',
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
-});
+const styles = (theme) => {
+  const getBackgroundColor = theme.palette.type === 'light' ? darken : lighten;
+
+  return {
+    viewer: {
+      background: getBackgroundColor(theme.palette.shades.light, 0.1),
+      bottom: 0,
+      left: 0,
+      overflow: 'hidden',
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    },
+  };
+};
 
 const enhance = compose(
   withTranslation(),


### PR DESCRIPTION
I noticed the design mocks used a slightly darker background here. I'm not sure if using the current color was an intentional thing, or just happened to happen.

![Screen Shot 2020-05-27 at 18 53 14](https://user-images.githubusercontent.com/111218/83089533-5bb80780-a04b-11ea-91ce-3646922e5c39.png)
