### PR TITLE
WIP: Only replace root reducers if necessary

### DIFF
--- a/src/extend/pluginPreprocessing.js
+++ b/src/extend/pluginPreprocessing.js
@@ -1,5 +1,6 @@
 import update from 'lodash/update';
 import { connect } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
 import { validatePlugin } from './pluginValidation';
 import CompanionWindowRegistry from '../lib/CompanionWindowRegistry';
 
@@ -40,7 +41,7 @@ export function connectPluginsToStore(plugins) {
 /** */
 export function addPluginReducersToStore(store, createRootReducer, plugins) {
   const pluginReducers = getReducersFromPlugins(plugins);
-  if (pluginReducers && pluginReducers.length > 0) {
+  if (!isEmpty(pluginReducers)) {
     store.replaceReducer(createRootReducer(pluginReducers));
   }
 }

--- a/src/extend/pluginPreprocessing.js
+++ b/src/extend/pluginPreprocessing.js
@@ -40,7 +40,9 @@ export function connectPluginsToStore(plugins) {
 /** */
 export function addPluginReducersToStore(store, createRootReducer, plugins) {
   const pluginReducers = getReducersFromPlugins(plugins);
-  store.replaceReducer(createRootReducer(pluginReducers));
+  if (pluginReducers && pluginReducers.length > 0) {
+    store.replaceReducer(createRootReducer(pluginReducers));
+  }
 }
 
 /** */


### PR DESCRIPTION
Currently, the [`App`](https://github.com/ProjectMirador/mirador/blob/35d8459b068f8c6e1b119356fbb244662e062ac5/src/components/App.js) component can't be used by react-redux applications that use Mirador as a React component because the plugin preprocessing will always replace the redux store's root reducers even if there are no plugins with their own reducers. By replacing the root reducers, the containing application's root reducers will not be available any more.

A solution could be to only replace the root reducers if there is at least one plugin with a reducer:
* If Mirador is used as standalone application (or at least not inside a redux application), everything will work as before, with or without any plugins.
* If Mirador is used inside a react-redux application, the containing application has to set up the store with its own reducers, the Mirador reducers and any M3 plugin reducers, if necessary.

