### PR TITLE
Revert "Pass through the annotation as a prop so that a plugin can us…

### DIFF
--- a/__tests__/src/components/CanvasAnnotations.test.js
+++ b/__tests__/src/components/CanvasAnnotations.test.js
@@ -70,11 +70,6 @@ describe('CanvasAnnotations', () => {
     expect(wrapper.find(Chip).length).toEqual(2);
   });
 
-  it('pass through the annotation to make plugins life easier', () => {
-    wrapper = createWrapper({ annotations });
-    expect(wrapper.find(ListItem).first().dive().props().annotation.id).toEqual('abc123');
-  });
-
   it('renders nothing when there are no annotations', () => {
     wrapper = createWrapper();
     expect(wrapper.find(Typography).length).toBe(0);

--- a/src/components/CanvasAnnotations.js
+++ b/src/components/CanvasAnnotations.js
@@ -76,7 +76,6 @@ export class CanvasAnnotations extends Component {
                 component={listContainerComponent}
                 className={classes.annotationListItem}
                 key={annotation.id}
-                annotation={annotation}
                 annotationid={annotation.id}
                 selected={selectedAnnotationIds.includes(annotation.id)}
                 onClick={e => this.handleClick(e, annotation)}


### PR DESCRIPTION
…e this in a much easier way"

This reverts commit 9f04fba8f8681cb6e473c57cae28c885d7659351.

I'm not sure that we will need this, and removing this will hopefully reduce rerender chances.