### PR TITLE
Refactor resourceHeaders setting to provide functionality for all mirador IIIF requests

### DIFF
--- a/__tests__/integration/mirador/v3.html
+++ b/__tests__/integration/mirador/v3.html
@@ -16,9 +16,11 @@
        windows: [{
          manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json',
        }],
-       resourceHeaders: {
-         Accept: 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"',
-       },
+       requestPipeline: [
+         (url, options) => ({  ...options, headers: {
+           Accept: 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"',
+         }})
+       ],
        window: {
          hideSearchPanel: false,
        }

--- a/__tests__/src/sagas/iiif.test.js
+++ b/__tests__/src/sagas/iiif.test.js
@@ -13,6 +13,7 @@ import {
   getManifests,
   selectInfoResponse,
   getAccessTokens,
+  getRequestsConfig,
 } from '../../../src/state/selectors';
 
 describe('IIIF sagas', () => {
@@ -46,6 +47,28 @@ describe('IIIF sagas', () => {
           [select(getConfig), {}],
         ])
         .put.actionType('mirador/RECEIVE_MANIFEST_FAILURE')
+        .run();
+    });
+
+    it('supports request configuration preprocessors', () => {
+      fetch.once(req => Promise.resolve(JSON.stringify({ data: req.headers.get('customheader') })));
+      const action = {
+        manifestId: 'manifestId',
+      };
+
+      return expectSaga(fetchManifest, action)
+        .provide([
+          [select(getRequestsConfig), {
+            preprocessors: [
+              (url, options) => ({ ...options, headers: { CustomHeader: 'config injected' } }),
+            ],
+          }],
+        ])
+        .put({
+          manifestId: 'manifestId',
+          manifestJson: { data: 'config injected' },
+          type: 'mirador/RECEIVE_MANIFEST',
+        })
         .run();
     });
   });

--- a/__tests__/src/selectors/config.test.js
+++ b/__tests__/src/selectors/config.test.js
@@ -6,6 +6,7 @@ import {
   getContainerId,
   getThemeDirection,
   getConfig,
+  getRequestsConfig,
 } from '../../../src/state/selectors';
 
 describe('getConfig', () => {
@@ -113,5 +114,12 @@ describe('getThemeDirection', () => {
   it('returns ltr as default', () => {
     const state = { config: { theme: { } } };
     expect(getThemeDirection(state)).toBe('ltr');
+  });
+});
+
+describe('getRequestsConfig', () => {
+  it('returns the requests configration', () => {
+    const state = { config: { requests: 'whatever' } };
+    expect(getRequestsConfig(state)).toEqual('whatever');
   });
 });

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "glob": "^7.1.4",
     "http-server": "^0.11.1",
     "jest": "^24.8.0",
-    "jest-fetch-mock": "^2.1.2",
+    "jest-fetch-mock": "^3.0.0",
     "jest-puppeteer": "^4.1.1",
     "jsdom": "15.1.1",
     "puppeteer": "^1.18.1",

--- a/setupJest.js
+++ b/setupJest.js
@@ -13,7 +13,7 @@ jest.setTimeout(10000);
 
 window.HTMLCanvasElement.prototype.getContext = () => {};
 jest.setMock('isomorphic-unfetch', fetch);
-global.fetch = require('jest-fetch-mock'); // eslint-disable-line import/no-extraneous-dependencies
+require('jest-fetch-mock').enableMocks(); // eslint-disable-line import/no-extraneous-dependencies
 
 global.window = window;
 global.navigator = {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -221,7 +221,11 @@ export default {
   },
   classPrefix: 'mirador',
   displayAllAnnotations: false, // Configure if annotations to be displayed on the canvas by default when fetched
-  resourceHeaders: {}, // Headers to send with IIIF Presentation API resource requests
+  requests: {
+    preprocessors: [ // Functions that receive HTTP requests and manipulate them (e.g. to add headers)
+      // (url, options) => (url.match('info.json') && { ...options, myCustomThing: 'blah' })
+    ],
+  },
   translations: { // Translations can be added to inject new languages or override existing labels
   },
   window: {

--- a/src/state/selectors/config.js
+++ b/src/state/selectors/config.js
@@ -3,7 +3,7 @@ import deepmerge from 'deepmerge';
 
 /** */
 export function getConfig(state) {
-  return state.config || {};
+  return (state && state.config) || {};
 }
 
 /**
@@ -60,4 +60,9 @@ export const getViewConfigs = createSelector(
 export const getThemeDirection = createSelector(
   [getConfig],
   ({ theme }) => theme.direction || 'ltr',
+);
+
+export const getRequestsConfig = createSelector(
+  [getConfig],
+  ({ requests }) => requests || {},
 );


### PR DESCRIPTION
The requests preprocessors configuration are run before making any IIIF requests (info.json, IIIF presentation manifests, annotations, etc).

Preprocessors are given 1) the url; 2) the fetch init data (see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) and
return a new set of init data or a false-y value. E.g.:

```ruby
  requests: {
    preprocessors: [ // Functions that receive HTTP requests and manipulate them (e.g. to add headers)
      // rewrite all info.json requests to add the text/json request header
      (url, options) => (url.match('info.json') && { ...options, headers: { ...options.headers, Accept: 'text/json' }})
    ],
  },
```