### PR TITLE
Enable post processing of requests before they hit the store

### DIFF
--- a/__tests__/src/sagas/iiif.test.js
+++ b/__tests__/src/sagas/iiif.test.js
@@ -71,6 +71,30 @@ describe('IIIF sagas', () => {
         })
         .run();
     });
+
+    it('supports response postprocessors', () => {
+      fetch.once(req => Promise.resolve(JSON.stringify({ data: req.headers.get('customheader') })));
+      const action = {
+        manifestId: 'manifestId',
+      };
+
+      return expectSaga(fetchManifest, action)
+        .provide([
+          [select(getRequestsConfig), {
+            postprocessors: [
+              (url, responseAction) => {
+                responseAction.manifestJson = { foo: 'modified!' }; // eslint-disable-line no-param-reassign
+              },
+            ],
+          }],
+        ])
+        .put({
+          manifestId: 'manifestId',
+          manifestJson: { foo: 'modified!' },
+          type: 'mirador/RECEIVE_MANIFEST',
+        })
+        .run();
+    });
   });
 
   describe('fetchInfoResponse', () => {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -225,6 +225,14 @@ export default {
     preprocessors: [ // Functions that receive HTTP requests and manipulate them (e.g. to add headers)
       // (url, options) => (url.match('info.json') && { ...options, myCustomThing: 'blah' })
     ],
+    postprocessors: [ // Functions that receive HTTP responses and manipulates them before adding to store
+      // An example of manipulating the response for an annotation request
+      // (url, action) => {
+      //   if (action.annotationId) {
+      //     action.annotationJson = {};
+      //   }
+      // }
+    ]
   },
   translations: { // Translations can be added to inject new languages or override existing labels
   },

--- a/src/state/sagas/iiif.js
+++ b/src/state/sagas/iiif.js
@@ -215,6 +215,5 @@ export default function* iiifSaga() {
     takeEvery(ActionTypes.REQUEST_ANNOTATION, fetchAnnotation),
     takeEvery(ActionTypes.RECEIVE_ACCESS_TOKEN, refetchInfoResponses),
     takeEvery(ActionTypes.ADD_RESOURCE, fetchResourceManifest),
-    // takeEvery(ActionTypes.RECEIVE_ANNOTATION, processReceiveAnno),
   ]);
 }


### PR DESCRIPTION
Related to https://github.com/ProjectMirador/mirador/issues/2971#issuecomment-631479528 by @rwd and discussions with @jbaiter. This PR enables Mirador adopters to post process actions (HTTP requests) made so that they can be manipulated before they hit the store.

An example would be throwing away annotation data you do not want to display for some reason (or enhancing it).

