### PR TITLE
Fixes #3098 and handles the case for OpenAnnotations id to be in the resource

### DIFF
--- a/__tests__/src/lib/AnnotationResource.test.js
+++ b/__tests__/src/lib/AnnotationResource.test.js
@@ -10,6 +10,9 @@ describe('AnnotationResource', () => {
       const expected = annoResource.id;
       expect(annoResource.id).toEqual(expected);
     });
+    it('handles the case where an id is only present in the resource', () => {
+      expect(new AnnotationResource({ resource: [{ '@id': 'bar' }] }).id).toEqual('bar');
+    });
   });
 
   describe('isOnlyTag', () => {

--- a/src/lib/AnnotationResource.js
+++ b/src/lib/AnnotationResource.js
@@ -16,7 +16,10 @@ export default class AnnotationResource {
 
   /** */
   get id() {
-    this._id = this._id || this.resource['@id'] || uuid(); // eslint-disable-line no-underscore-dangle
+    this._id = this._id
+      || this.resource['@id']
+      || (this.resources[0] && this.resources[0]['@id'])
+      || uuid();
     return this._id; // eslint-disable-line no-underscore-dangle
   }
 


### PR DESCRIPTION
For some IIIF v2 content, the OpenAnnotation `@id` is present not in the object but in the resource itself.

See https://fromthepage.com/iiif/33728/manifest

and in https://fromthepage.com/iiif/1143781/list/transcription

While this seems odd to me, the pattern is repeated in the spec several times, so I think we should support it.

