### PR TITLE
Extract AnnotationsOverlay component

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.js
+++ b/__tests__/src/components/AnnotationsOverlay.test.js
@@ -1,0 +1,340 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+import OpenSeadragon from 'openseadragon';
+import { Utils } from 'manifesto.js/dist-esmodule/Utils';
+import { AnnotationsOverlay } from '../../../src/components/AnnotationsOverlay';
+import OpenSeadragonCanvasOverlay from '../../../src/lib/OpenSeadragonCanvasOverlay';
+import AnnotationList from '../../../src/lib/AnnotationList';
+import CanvasWorld from '../../../src/lib/CanvasWorld';
+import fixture from '../../fixtures/version-2/019.json';
+
+const canvases = Utils.parseManifest(fixture).getSequences()[0].getCanvases();
+
+jest.mock('react-dom');
+jest.mock('openseadragon');
+jest.mock('../../../src/lib/OpenSeadragonCanvasOverlay');
+
+
+describe('AnnotationsOverlay', () => {
+  let wrapper;
+  let viewer;
+  let updateViewport;
+  beforeEach(() => {
+    OpenSeadragon.mockClear();
+    OpenSeadragonCanvasOverlay.mockClear();
+
+    updateViewport = jest.fn();
+    viewer = { addHandler: () => {}, forceRedraw: () => {} };
+
+    wrapper = shallow(
+      <AnnotationsOverlay
+        annotations={[]}
+        viewer={viewer}
+        classes={{}}
+        searchAnnotations={[]}
+        windowId="base"
+        config={{}}
+        updateViewport={updateViewport}
+        t={k => k}
+        canvasWorld={new CanvasWorld(canvases)}
+      />,
+    );
+  });
+
+  describe('annotationsMatch', () => {
+    it('is false if the annotations are a different size', () => {
+      const currentAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
+      const previousAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }, { id: 2, resources: [{ id: 'rid2' }] }];
+
+      expect(
+        AnnotationsOverlay.annotationsMatch(currentAnnotations, previousAnnotations),
+      ).toBe(false);
+    });
+
+    it('is true if the previous annotation\'s resource IDs all match', () => {
+      const currentAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
+      const previousAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
+
+      expect(
+        AnnotationsOverlay.annotationsMatch(currentAnnotations, previousAnnotations),
+      ).toBe(true);
+    });
+
+    it('is true if both are empty', () => {
+      expect(AnnotationsOverlay.annotationsMatch([], [])).toBe(true);
+    });
+
+    it('is false if the previous annotation\'s resource IDs do not match', () => {
+      const currentAnnotations = [{ id: 1, resources: [{ id: 'rid1' }] }];
+      const previousAnnotations = [{ id: 1, resources: [{ id: 'rid2' }] }];
+
+      expect(
+        AnnotationsOverlay.annotationsMatch(currentAnnotations, previousAnnotations),
+      ).toBe(false);
+    });
+
+    it('returns true if the annotation resources IDs are empty (to prevent unecessary rerender)', () => {
+      const currentAnnotations = [{ id: 1, resources: [] }];
+      const previousAnnotations = [{ id: 1, resources: [] }];
+
+      expect(
+        AnnotationsOverlay.annotationsMatch(currentAnnotations, previousAnnotations),
+      ).toBe(true);
+    });
+  });
+
+  describe('componentDidUpdate', () => {
+    it('sets up a OpenSeadragonCanvasOverlay', () => {
+      wrapper.instance().componentDidUpdate({});
+      expect(OpenSeadragonCanvasOverlay).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets up a listener on update-viewport', () => {
+      wrapper.instance().osdCanvasOverlay = null;
+      const addHandler = jest.fn();
+      viewer.addHandler = addHandler;
+      wrapper.instance().componentDidUpdate({});
+      expect(addHandler).toHaveBeenCalledWith('update-viewport', expect.anything());
+    });
+
+    it('sets up canvasUpdate to add annotations to the canvas and forces a redraw', () => {
+      const clear = jest.fn();
+      const resize = jest.fn();
+      const canvasUpdate = jest.fn();
+      const forceRedraw = jest.fn();
+
+      wrapper.instance().osdCanvasOverlay = {
+        canvasUpdate,
+        clear,
+        resize,
+      };
+
+      viewer.forceRedraw = forceRedraw;
+
+      wrapper.setProps(
+        {
+          annotations: [
+            new AnnotationList(
+              { '@id': 'foo', resources: [{ foo: 'bar' }] },
+            ),
+          ],
+        },
+      );
+      wrapper.setProps(
+        {
+          annotations: [
+            new AnnotationList(
+              { '@id': 'foo', resources: [{ foo: 'bar' }] },
+            ),
+          ],
+        },
+      );
+      wrapper.setProps(
+        {
+          annotations: [
+            new AnnotationList(
+              { '@id': 'bar', resources: [{ foo: 'bar' }] },
+            ),
+          ],
+        },
+      );
+      wrapper.instance().updateCanvas();
+      expect(clear).toHaveBeenCalledTimes(1);
+      expect(resize).toHaveBeenCalledTimes(1);
+      expect(canvasUpdate).toHaveBeenCalledTimes(1);
+      expect(forceRedraw).toHaveBeenCalled();
+    });
+  });
+
+  describe('onUpdateViewport', () => {
+    it('fires updateCanvas', () => {
+      const updateCanvas = jest.fn();
+      wrapper.instance().updateCanvas = updateCanvas;
+      wrapper.instance().onUpdateViewport();
+      expect(updateCanvas).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('annotationsToContext', () => {
+    it('converts the annotations to canvas and checks that the canvas is displayed', () => {
+      const strokeRect = jest.fn();
+      wrapper.instance().osdCanvasOverlay = {
+        context2d: {
+          restore: () => {},
+          save: () => {},
+          strokeRect,
+        },
+      };
+      viewer.viewport = {
+        getMaxZoom: () => (1),
+        getZoom: () => (0.05),
+      };
+
+      const annotations = [
+        new AnnotationList(
+          { '@id': 'foo', resources: [{ on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=10,10,100,200' }] },
+        ),
+      ];
+
+      const palette = {
+        default: { strokeStyle: 'yellow' },
+      };
+
+      wrapper.instance().annotationsToContext(annotations, palette);
+      const context = wrapper.instance().osdCanvasOverlay.context2d;
+      expect(context.strokeStyle).toEqual('yellow');
+      expect(context.lineWidth).toEqual(20);
+      expect(strokeRect).toHaveBeenCalledWith(10, 10, 100, 200);
+    });
+  });
+
+  describe('onCanvasClick', () => {
+    it('triggers a selectAnnotation for the clicked-on annotation', () => {
+      const selectAnnotation = jest.fn();
+
+      wrapper.setProps(
+        {
+          annotations: [
+            new AnnotationList(
+              {
+                '@id': 'foo',
+                resources: [{
+                  '@id': 'http://example.org/identifier/annotation/anno-line',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+                }],
+              },
+            ),
+          ],
+          selectAnnotation,
+        },
+      );
+
+      wrapper.instance().onCanvasClick({
+        eventSource: { viewport: { pointFromPixel: point => ({ x: 101, y: 101 }) } },
+        position: { x: 0, y: 0 },
+      });
+
+      expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
+    });
+
+    it('triggers a deselectAnnotation for an already-selected annotation', () => {
+      const deselectAnnotation = jest.fn();
+
+      wrapper.setProps(
+        {
+          annotations: [
+            new AnnotationList(
+              {
+                '@id': 'foo',
+                resources: [{
+                  '@id': 'http://example.org/identifier/annotation/anno-line',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+                }],
+              },
+            ),
+          ],
+          deselectAnnotation,
+          selectedAnnotationId: 'http://example.org/identifier/annotation/anno-line',
+        },
+      );
+
+      wrapper.instance().onCanvasClick({
+        eventSource: { viewport: { pointFromPixel: point => ({ x: 101, y: 101 }) } },
+        position: { x: 0, y: 0 },
+      });
+
+      expect(deselectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
+    });
+
+    it('selects the closest annotation', () => {
+      const selectAnnotation = jest.fn();
+
+      wrapper.setProps(
+        {
+          annotations: [
+            new AnnotationList(
+              {
+                '@id': 'foo',
+                resources: [{
+                  '@id': 'http://example.org/identifier/annotation/anno-line',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+                }, {
+                  '@id': 'http://example.org/identifier/annotation/larger-box',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=0,0,250,250',
+                }, {
+                  '@id': 'http://example.org/identifier/annotation/on-another-canvas',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/some-other-canvas#xywh=101,101,3,3',
+                }],
+              },
+            ),
+          ],
+          selectAnnotation,
+        },
+      );
+
+      wrapper.instance().onCanvasClick({
+        eventSource: { viewport: { pointFromPixel: point => ({ x: 101, y: 101 }) } },
+        position: { x: 0, y: 0 },
+      });
+
+      expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
+    });
+  });
+
+  describe('onCanvasMouseMove', () => {
+    it('triggers the hover event for every annotation at that point', () => {
+      const hoverAnnotation = jest.fn();
+      const forceRedraw = jest.fn();
+
+      viewer.forceRedraw = forceRedraw;
+      viewer.viewport = { pointFromPixel: point => ({ x: 101, y: 101 }) };
+
+      wrapper.setProps(
+        {
+          annotations: [
+            new AnnotationList(
+              {
+                '@id': 'foo',
+                resources: [{
+                  '@id': 'foo',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+                }, {
+                  '@id': 'bar',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=0,0,250,250',
+                }, {
+                  '@id': 'irrelevant-box',
+                  '@type': 'oa:Annotation',
+                  motivation: 'sc:painting',
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=0,0,50,50',
+                }],
+              },
+            ),
+          ],
+          hoverAnnotation,
+        },
+      );
+
+      wrapper.instance().onCanvasMouseMove({
+        position: { x: 0, y: 0 },
+      });
+      wrapper.instance().onCanvasMouseMove.flush();
+
+      expect(hoverAnnotation).toHaveBeenCalledWith('base', ['foo', 'bar']);
+    });
+  });
+});

--- a/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
+++ b/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
@@ -5,11 +5,13 @@ jest.mock('openseadragon');
 
 describe('OpenSeadragonCanvasOverlay', () => {
   let canvasOverlay;
+  const ref = { current: undefined };
   beforeEach(() => {
-    document.body.innerHTML = '<div id="canvas"></div>';
+    document.body.innerHTML = '<div id="canvas"><canvas></div>';
+    ref.current = document.getElementById('canvas');
     OpenSeadragon.mockClear();
     OpenSeadragon.mockImplementation(() => ({
-      canvas: document.getElementById('canvas'),
+      canvas: ref,
       container: {
         clientHeight: 100,
         clientWidth: 200,
@@ -35,22 +37,21 @@ describe('OpenSeadragonCanvasOverlay', () => {
         })),
       },
     }));
-    canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon());
+    canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon(), ref);
   });
   describe('constructor', () => {
     it('sets up initial values and canvas', () => {
       expect(canvasOverlay.containerHeight).toEqual(0);
       expect(canvasOverlay.containerWidth).toEqual(0);
-      expect(canvasOverlay.canvasDiv.outerHTML).toEqual(
-        '<div style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"><canvas></canvas></div>',
-      );
     });
   });
   describe('context2d', () => {
     it('calls getContext on canvas', () => {
       const contextMock = jest.fn();
-      canvasOverlay.canvas = {
-        getContext: contextMock,
+      ref.current = {
+        firstElementChild: {
+          getContext: contextMock,
+        },
       };
       canvasOverlay.context2d; // eslint-disable-line no-unused-expressions
       expect(contextMock).toHaveBeenCalledTimes(1);
@@ -62,8 +63,10 @@ describe('OpenSeadragonCanvasOverlay', () => {
       const contextMock = jest.fn(() => ({
         clearRect,
       }));
-      canvasOverlay.canvas = {
-        getContext: contextMock,
+      ref.current = {
+        firstElementChild: {
+          getContext: contextMock,
+        },
       };
       canvasOverlay.clear();
       expect(contextMock).toHaveBeenCalledTimes(1);
@@ -92,7 +95,7 @@ describe('OpenSeadragonCanvasOverlay', () => {
           getItemAt: jest.fn(),
         },
       }));
-      canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon());
+      canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon(), ref);
       canvasOverlay.resize();
       expect(canvasOverlay.imgHeight).toEqual(undefined);
       expect(canvasOverlay.imgWidth).toEqual(undefined);
@@ -109,8 +112,11 @@ describe('OpenSeadragonCanvasOverlay', () => {
         setTransform,
         translate,
       }));
-      canvasOverlay.canvas = {
-        getContext: contextMock,
+      ref.current = {
+        firstElementChild: {
+          getContext: contextMock,
+          setAttribute,
+        },
         setAttribute,
       };
       const update = jest.fn();

--- a/src/components/AnnotationsOverlay.js
+++ b/src/components/AnnotationsOverlay.js
@@ -1,0 +1,447 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+import debounce from 'lodash/debounce';
+import flatten from 'lodash/flatten';
+import sortBy from 'lodash/sortBy';
+import xor from 'lodash/xor';
+import OpenSeadragonCanvasOverlay from '../lib/OpenSeadragonCanvasOverlay';
+import CanvasWorld from '../lib/CanvasWorld';
+import CanvasAnnotationDisplay from '../lib/CanvasAnnotationDisplay';
+
+/**
+ * Represents a OpenSeadragonViewer in the mirador workspace. Responsible for mounting
+ * and rendering OSD.
+ */
+export class AnnotationsOverlay extends Component {
+  /**
+   * annotationsMatch - compares previous annotations to current to determine
+   * whether to add a new updateCanvas method to draw annotations
+   * @param  {Array} currentAnnotations
+   * @param  {Array} prevAnnotations
+   * @return {Boolean}
+   */
+  static annotationsMatch(currentAnnotations, prevAnnotations) {
+    if (!currentAnnotations && !prevAnnotations) return true;
+    if (
+      (currentAnnotations && !prevAnnotations)
+      || (!currentAnnotations && prevAnnotations)
+    ) return false;
+
+    if (currentAnnotations.length === 0 && prevAnnotations.length === 0) return true;
+    if (currentAnnotations.length !== prevAnnotations.length) return false;
+    return currentAnnotations.every((annotation, index) => {
+      const newIds = annotation.resources.map(r => r.id);
+      const prevIds = prevAnnotations[index].resources.map(r => r.id);
+      if (newIds.length === 0 && prevIds.length === 0) return true;
+      if (newIds.length !== prevIds.length) return false;
+
+      if ((annotation.id === prevAnnotations[index].id) && (isEqual(newIds, prevIds))) {
+        return true;
+      }
+      return false;
+    });
+  }
+
+  /**
+   * @param {Object} props
+   */
+  constructor(props) {
+    super(props);
+
+    this.ref = React.createRef();
+    this.osdCanvasOverlay = null;
+    // An initial value for the updateCanvas method
+    this.updateCanvas = () => {};
+    this.onUpdateViewport = this.onUpdateViewport.bind(this);
+    this.onCanvasClick = this.onCanvasClick.bind(this);
+    this.onCanvasMouseMove = debounce(this.onCanvasMouseMove.bind(this), 10);
+    this.onCanvasExit = this.onCanvasExit.bind(this);
+  }
+
+  /**
+   * React lifecycle event
+   */
+  componentDidMount() {
+    this.initializeViewer();
+  }
+
+  /**
+   * When the tileSources change, make sure to close the OSD viewer.
+   * When the annotations change, reset the updateCanvas method to make sure
+   * they are added.
+   * When the viewport state changes, pan or zoom the OSD viewer as appropriate
+   */
+  componentDidUpdate(prevProps) {
+    const {
+      drawAnnotations,
+      drawSearchAnnotations,
+      annotations, searchAnnotations,
+      hoveredAnnotationIds, selectedAnnotationId,
+      highlightAllAnnotations,
+      viewer,
+    } = this.props;
+
+    this.initializeViewer();
+
+    const annotationsUpdated = !AnnotationsOverlay.annotationsMatch(
+      annotations, prevProps.annotations,
+    );
+    const searchAnnotationsUpdated = !AnnotationsOverlay.annotationsMatch(
+      searchAnnotations, prevProps.searchAnnotations,
+    );
+
+    const hoveredAnnotationsUpdated = (
+      xor(hoveredAnnotationIds, prevProps.hoveredAnnotationIds).length > 0
+    );
+
+    if (this.osdCanvasOverlay && hoveredAnnotationsUpdated) {
+      if (hoveredAnnotationIds.length > 0) {
+        this.osdCanvasOverlay.canvasDiv.style.cursor = 'pointer';
+      } else {
+        this.osdCanvasOverlay.canvasDiv.style.cursor = '';
+      }
+    }
+
+    const selectedAnnotationsUpdated = selectedAnnotationId !== prevProps.selectedAnnotationId;
+
+    const redrawAnnotations = drawAnnotations !== prevProps.drawAnnotations
+      || drawSearchAnnotations !== prevProps.drawSearchAnnotations
+      || highlightAllAnnotations !== prevProps.highlightAllAnnotations;
+
+    if (
+      searchAnnotationsUpdated
+      || annotationsUpdated
+      || selectedAnnotationsUpdated
+      || hoveredAnnotationsUpdated
+      || redrawAnnotations
+    ) {
+      this.updateCanvas = this.canvasUpdateCallback();
+      viewer.forceRedraw();
+    }
+  }
+
+  /**
+   */
+  componentWillUnmount() {
+    const { viewer } = this.props;
+
+    viewer.removeHandler('canvas-click', this.onCanvasClick);
+    viewer.removeHandler('canvas-exit', this.onCanvasExit);
+    viewer.removeHandler('update-viewport', this.onUpdateViewport);
+
+    if (viewer.innerTracker
+      && viewer.innerTracker.moveHandler === this.onCanvasMouseMove) {
+      viewer.innerTracker.moveHandler = null;
+    }
+  }
+
+  /** */
+  onCanvasClick(event) {
+    const {
+      canvasWorld,
+    } = this.props;
+
+    const { position: webPosition, eventSource: { viewport } } = event;
+    const point = viewport.pointFromPixel(webPosition);
+
+    const canvas = canvasWorld.canvasAtPoint(point);
+    if (!canvas) return;
+    const [
+      _canvasX, _canvasY, canvasWidth, canvasHeight, // eslint-disable-line no-unused-vars
+    ] = canvasWorld.canvasToWorldCoordinates(canvas.id);
+
+    // get all the annotations that contain the click
+    const annos = this.annotationsAtPoint(canvas, point);
+
+    if (annos.length > 0) {
+      event.preventDefaultAction = true; // eslint-disable-line no-param-reassign
+    }
+
+    if (annos.length === 1) {
+      this.toggleAnnotation(annos[0].id);
+    } else if (annos.length > 0) {
+      /**
+       * Try to find the "right" annotation to select after a click.
+       *
+       * This is perhaps a naive method, but seems to deal with rectangles and SVG shapes:
+       *
+       * - figure out how many points around a circle are inside the annotation shape
+       * - if there's a shape with the fewest interior points, it's probably the one
+       *       with the closest boundary?
+       * - if there's a tie, make the circle bigger and try again.
+       */
+      const annosWithClickScore = (radius) => {
+        const degreesToRadians = Math.PI / 180;
+
+        return (anno) => {
+          let score = 0;
+          for (let degrees = 0; degrees < 360; degrees += 1) {
+            const x = Math.cos(degrees * degreesToRadians) * radius + point.x;
+            const y = Math.sin(degrees * degreesToRadians) * radius + point.y;
+
+            if (this.isAnnotationAtPoint(anno, canvas, { x, y })) score += 1;
+          }
+
+          return { anno, score };
+        };
+      };
+
+      let annosWithScore = [];
+      let radius = 1;
+      annosWithScore = sortBy(annos.map(annosWithClickScore(radius)), 'score');
+
+      while (radius < Math.max(canvasWidth, canvasHeight)
+        && annosWithScore[0].score === annosWithScore[1].score) {
+        radius *= 2;
+        annosWithScore = sortBy(annos.map(annosWithClickScore(radius)), 'score');
+      }
+
+      this.toggleAnnotation(annosWithScore[0].anno.id);
+    }
+  }
+
+  /** */
+  onCanvasMouseMove(event) {
+    const {
+      annotations,
+      canvasWorld,
+      hoverAnnotation,
+      hoveredAnnotationIds,
+      searchAnnotations,
+      viewer,
+      windowId,
+    } = this.props;
+
+    if (annotations.length === 0 && searchAnnotations.length === 0) return;
+
+    const { position: webPosition } = event;
+    const point = viewer.viewport.pointFromPixel(webPosition);
+
+    const canvas = canvasWorld.canvasAtPoint(point);
+    if (!canvas) {
+      hoverAnnotation(windowId, []);
+      return;
+    }
+
+    const annos = this.annotationsAtPoint(canvas, point);
+
+    if (xor(hoveredAnnotationIds, annos.map(a => a.id)).length > 0) {
+      hoverAnnotation(windowId, annos.map(a => a.id));
+    }
+  }
+
+  /** If the cursor leaves the canvas, wipe out highlights */
+  onCanvasExit(event) {
+    const {
+      hoverAnnotation,
+      windowId,
+    } = this.props;
+
+    // a move event may be queued up by the debouncer
+    this.onCanvasMouseMove.cancel();
+    hoverAnnotation(windowId, []);
+  }
+
+  /**
+   * onUpdateViewport - fires during OpenSeadragon render method.
+   */
+  onUpdateViewport(event) {
+    this.updateCanvas();
+  }
+
+  /** @private */
+  initializeViewer() {
+    const { viewer } = this.props;
+
+    if (!viewer) return;
+    if (this.osdCanvasOverlay) return;
+
+    this.osdCanvasOverlay = new OpenSeadragonCanvasOverlay(viewer, this.ref);
+
+    viewer.addHandler('canvas-click', this.onCanvasClick);
+    viewer.addHandler('canvas-exit', this.onCanvasExit);
+    viewer.addHandler('update-viewport', this.onUpdateViewport);
+
+    if (viewer.innerTracker) {
+      viewer.innerTracker.moveHandler = this.onCanvasMouseMove;
+    }
+
+    this.updateCanvas = this.canvasUpdateCallback();
+  }
+
+  /** */
+  canvasUpdateCallback() {
+    return () => {
+      this.osdCanvasOverlay.clear();
+      this.osdCanvasOverlay.resize();
+      this.osdCanvasOverlay.canvasUpdate(this.renderAnnotations.bind(this));
+    };
+  }
+
+  /** @private */
+  isAnnotationAtPoint(resource, canvas, point) {
+    const {
+      canvasWorld,
+    } = this.props;
+
+    const [canvasX, canvasY] = canvasWorld.canvasToWorldCoordinates(canvas.id);
+    const relativeX = point.x - canvasX;
+    const relativeY = point.y - canvasY;
+
+    if (resource.svgSelector) {
+      const context = this.osdCanvasOverlay.context2d;
+      const { svgPaths } = new CanvasAnnotationDisplay({ resource });
+      return [...svgPaths].some(path => (
+        context.isPointInPath(new Path2D(path.attributes.d.nodeValue), relativeX, relativeY)
+      ));
+    }
+
+    if (resource.fragmentSelector) {
+      const [x, y, w, h] = resource.fragmentSelector;
+      return x <= relativeX && relativeX <= (x + w)
+        && y <= relativeY && relativeY <= (y + h);
+    }
+    return false;
+  }
+
+  /** @private */
+  annotationsAtPoint(canvas, point) {
+    const {
+      annotations, searchAnnotations,
+    } = this.props;
+
+    const lists = [...annotations, ...searchAnnotations];
+    const annos = flatten(lists.map(l => l.resources)).filter((resource) => {
+      if (canvas.id !== resource.targetId) return false;
+
+      return this.isAnnotationAtPoint(resource, canvas, point);
+    });
+
+    return annos;
+  }
+
+  /** */
+  toggleAnnotation(id) {
+    const {
+      selectedAnnotationId,
+      selectAnnotation,
+      deselectAnnotation,
+      windowId,
+    } = this.props;
+
+    if (selectedAnnotationId === id) {
+      deselectAnnotation(windowId, id);
+    } else {
+      selectAnnotation(windowId, id);
+    }
+  }
+
+  /**
+   * annotationsToContext - converts anontations to a canvas context
+   */
+  annotationsToContext(annotations, palette) {
+    const {
+      highlightAllAnnotations, hoveredAnnotationIds, selectedAnnotationId, canvasWorld,
+      viewer,
+    } = this.props;
+    const context = this.osdCanvasOverlay.context2d;
+    const zoomRatio = viewer.viewport.getZoom(true) / viewer.viewport.getMaxZoom();
+    annotations.forEach((annotation) => {
+      annotation.resources.forEach((resource) => {
+        if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
+        const offset = canvasWorld.offsetByCanvas(resource.targetId);
+        const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
+          hovered: hoveredAnnotationIds.includes(resource.id),
+          offset,
+          palette: {
+            ...palette,
+            default: {
+              ...palette.default,
+              ...(!highlightAllAnnotations && palette.hidden),
+            },
+          },
+          resource,
+          selected: selectedAnnotationId === resource.id,
+          zoomRatio,
+        });
+        canvasAnnotationDisplay.toContext(context);
+      });
+    });
+  }
+
+  /** */
+  renderAnnotations() {
+    const {
+      annotations,
+      drawAnnotations,
+      drawSearchAnnotations,
+      searchAnnotations,
+      palette,
+    } = this.props;
+
+    if (drawSearchAnnotations) {
+      this.annotationsToContext(searchAnnotations, palette.search);
+    }
+
+    if (drawAnnotations) {
+      this.annotationsToContext(annotations, palette.annotations);
+    }
+  }
+
+  /**
+   * Renders things
+   */
+  render() {
+    const { viewer } = this.props;
+
+    if (!viewer) return <></>;
+
+    return ReactDOM.createPortal(
+      (
+        <div
+          ref={this.ref}
+          style={{
+            height: '100%', left: 0, position: 'absolute', top: 0, width: '100%',
+          }}
+        >
+          <canvas />
+        </div>
+      ),
+      viewer.canvas,
+    );
+  }
+}
+
+AnnotationsOverlay.defaultProps = {
+  annotations: [],
+  deselectAnnotation: () => {},
+  drawAnnotations: true,
+  drawSearchAnnotations: true,
+  highlightAllAnnotations: false,
+  hoverAnnotation: () => {},
+  hoveredAnnotationIds: [],
+  palette: {},
+  searchAnnotations: [],
+  selectAnnotation: () => {},
+  selectedAnnotationId: undefined,
+  viewer: null,
+};
+
+AnnotationsOverlay.propTypes = {
+  annotations: PropTypes.arrayOf(PropTypes.object),
+  canvasWorld: PropTypes.instanceOf(CanvasWorld).isRequired,
+  deselectAnnotation: PropTypes.func,
+  drawAnnotations: PropTypes.bool,
+  drawSearchAnnotations: PropTypes.bool,
+  highlightAllAnnotations: PropTypes.bool,
+  hoverAnnotation: PropTypes.func,
+  hoveredAnnotationIds: PropTypes.arrayOf(PropTypes.string),
+  palette: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  searchAnnotations: PropTypes.arrayOf(PropTypes.object),
+  selectAnnotation: PropTypes.func,
+  selectedAnnotationId: PropTypes.string,
+  viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  windowId: PropTypes.string.isRequired,
+};

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -7,6 +7,7 @@ import ns from '../config/css-ns';
 import AnnotationsOverlay from '../containers/AnnotationsOverlay';
 import CanvasWorld from '../lib/CanvasWorld';
 import { PluginHook } from './PluginHook';
+import { OSDReferences } from '../plugins/OSDReferences';
 
 /**
  * Represents a OpenSeadragonViewer in the mirador workspace. Responsible for mounting
@@ -21,6 +22,8 @@ export class OpenSeadragonViewer extends Component {
 
     this.state = { viewer: undefined };
     this.ref = React.createRef();
+    this.apiRef = React.createRef();
+    OSDReferences.set(props.windowId, this.apiRef);
     this.onViewportChange = this.onViewportChange.bind(this);
     this.zoomToWorld = this.zoomToWorld.bind(this);
     this.osdUpdating = false;
@@ -39,6 +42,7 @@ export class OpenSeadragonViewer extends Component {
       id: this.ref.current.id,
       ...osdConfig,
     });
+    this.apiRef.current = viewer;
 
     this.setState({ viewer });
 
@@ -64,6 +68,7 @@ export class OpenSeadragonViewer extends Component {
       canvasWorld,
     } = this.props;
     const { viewer } = this.state;
+    this.apiRef.current = viewer;
 
     if (prevState.viewer === undefined) {
       if (viewerConfig) {
@@ -104,6 +109,7 @@ export class OpenSeadragonViewer extends Component {
     const { viewer } = this.state;
 
     viewer.removeAllHandlers();
+    this.apiRef.current = undefined;
   }
 
   /**

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import ns from '../config/css-ns';
 import AnnotationsOverlay from '../containers/AnnotationsOverlay';
 import CanvasWorld from '../lib/CanvasWorld';
+import { PluginHook } from './PluginHook';
 
 /**
  * Represents a OpenSeadragonViewer in the mirador workspace. Responsible for mounting
@@ -298,6 +299,7 @@ export class OpenSeadragonViewer extends Component {
           { drawAnnotations
             && <AnnotationsOverlay viewer={viewer} windowId={windowId} /> }
           { enhancedChildren }
+          <PluginHook viewer={viewer} windowId={windowId} />
         </section>
       </>
     );

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -1,16 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import debounce from 'lodash/debounce';
-import flatten from 'lodash/flatten';
-import sortBy from 'lodash/sortBy';
-import xor from 'lodash/xor';
 import OpenSeadragon from 'openseadragon';
 import classNames from 'classnames';
 import ns from '../config/css-ns';
-import OpenSeadragonCanvasOverlay from '../lib/OpenSeadragonCanvasOverlay';
+import AnnotationsOverlay from '../containers/AnnotationsOverlay';
 import CanvasWorld from '../lib/CanvasWorld';
-import CanvasAnnotationDisplay from '../lib/CanvasAnnotationDisplay';
 
 /**
  * Represents a OpenSeadragonViewer in the mirador workspace. Responsible for mounting
@@ -18,44 +13,14 @@ import CanvasAnnotationDisplay from '../lib/CanvasAnnotationDisplay';
  */
 export class OpenSeadragonViewer extends Component {
   /**
-   * annotationsMatch - compares previous annotations to current to determine
-   * whether to add a new updateCanvas method to draw annotations
-   * @param  {Array} currentAnnotations
-   * @param  {Array} prevAnnotations
-   * @return {Boolean}
-   */
-  static annotationsMatch(currentAnnotations, prevAnnotations) {
-    if (currentAnnotations.length === 0 && prevAnnotations.length === 0) return true;
-    if (currentAnnotations.length !== prevAnnotations.length) return false;
-    return currentAnnotations.every((annotation, index) => {
-      const newIds = annotation.resources.map(r => r.id);
-      const prevIds = prevAnnotations[index].resources.map(r => r.id);
-      if (newIds.length === 0 && prevIds.length === 0) return true;
-      if (newIds.length !== prevIds.length) return false;
-
-      if ((annotation.id === prevAnnotations[index].id) && (isEqual(newIds, prevIds))) {
-        return true;
-      }
-      return false;
-    });
-  }
-
-  /**
    * @param {Object} props
    */
   constructor(props) {
     super(props);
 
-    this.viewer = null;
-    this.osdCanvasOverlay = null;
-    // An initial value for the updateCanvas method
-    this.updateCanvas = () => {};
+    this.state = { viewer: undefined };
     this.ref = React.createRef();
-    this.onUpdateViewport = this.onUpdateViewport.bind(this);
     this.onViewportChange = this.onViewportChange.bind(this);
-    this.onCanvasClick = this.onCanvasClick.bind(this);
-    this.onCanvasMouseMove = debounce(this.onCanvasMouseMove.bind(this), 10);
-    this.onCanvasExit = this.onCanvasExit.bind(this);
     this.zoomToWorld = this.zoomToWorld.bind(this);
     this.osdUpdating = false;
   }
@@ -64,41 +29,26 @@ export class OpenSeadragonViewer extends Component {
    * React lifecycle event
    */
   componentDidMount() {
-    const { osdConfig, viewer } = this.props;
+    const { osdConfig } = this.props;
     if (!this.ref.current) {
       return;
     }
 
-    this.viewer = new OpenSeadragon({
+    const viewer = new OpenSeadragon({
       id: this.ref.current.id,
       ...osdConfig,
     });
 
-    this.osdCanvasOverlay = new OpenSeadragonCanvasOverlay(this.viewer);
-    this.viewer.addHandler('update-viewport', this.onUpdateViewport);
+    this.setState({ viewer });
+
     // Set a flag when OSD starts animating (so that viewer updates are not used)
-    this.viewer.addHandler('animation-start', () => {
+    viewer.addHandler('animation-start', () => {
       this.osdUpdating = true;
     });
-    this.viewer.addHandler('animation-finish', this.onViewportChange);
-    this.viewer.addHandler('animation-finish', () => {
+    viewer.addHandler('animation-finish', this.onViewportChange);
+    viewer.addHandler('animation-finish', () => {
       this.osdUpdating = false;
     });
-
-    this.viewer.addHandler('canvas-click', this.onCanvasClick);
-    this.viewer.addHandler('canvas-exit', this.onCanvasExit);
-
-    if (this.viewer.innerTracker) {
-      this.viewer.innerTracker.moveHandler = this.onCanvasMouseMove;
-    }
-
-    this.updateCanvas = this.canvasUpdateCallback();
-
-    if (viewer) {
-      this.viewer.viewport.panTo(viewer, true);
-      this.viewer.viewport.zoomTo(viewer.zoom, viewer, true);
-    }
-    this.addAllImageSources(!(viewer));
   }
 
   /**
@@ -107,71 +57,42 @@ export class OpenSeadragonViewer extends Component {
    * they are added.
    * When the viewport state changes, pan or zoom the OSD viewer as appropriate
    */
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const {
-      viewer,
+      viewerConfig,
       canvasWorld,
-      drawAnnotations,
-      drawSearchAnnotations,
-      annotations, searchAnnotations,
-      hoveredAnnotationIds, selectedAnnotationId,
-      highlightAllAnnotations,
     } = this.props;
+    const { viewer } = this.state;
 
-    const annotationsUpdated = !OpenSeadragonViewer.annotationsMatch(
-      annotations, prevProps.annotations,
-    );
-    const searchAnnotationsUpdated = !OpenSeadragonViewer.annotationsMatch(
-      searchAnnotations, prevProps.searchAnnotations,
-    );
-
-    const hoveredAnnotationsUpdated = (
-      xor(hoveredAnnotationIds, prevProps.hoveredAnnotationIds).length > 0
-    );
-
-    if (hoveredAnnotationsUpdated) {
-      if (hoveredAnnotationIds.length > 0) {
-        this.ref.current.style.cursor = 'pointer';
-      } else {
-        this.ref.current.style.cursor = '';
+    if (prevState.viewer === undefined) {
+      if (viewerConfig) {
+        viewer.viewport.panTo(viewerConfig, true);
+        viewer.viewport.zoomTo(viewerConfig.zoom, viewerConfig, true);
       }
-    }
 
-    const selectedAnnotationsUpdated = selectedAnnotationId !== prevProps.selectedAnnotationId;
+      this.addAllImageSources(!(viewerConfig));
 
-    const redrawAnnotations = drawAnnotations !== prevProps.drawAnnotations
-      || drawSearchAnnotations !== prevProps.drawSearchAnnotations
-      || highlightAllAnnotations !== prevProps.highlightAllAnnotations;
-
-    if (
-      searchAnnotationsUpdated
-      || annotationsUpdated
-      || selectedAnnotationsUpdated
-      || hoveredAnnotationsUpdated
-      || redrawAnnotations
-    ) {
-      this.updateCanvas = this.canvasUpdateCallback();
-      this.viewer.forceRedraw();
+      return;
     }
 
     if (!this.infoResponsesMatch(prevProps.infoResponses)
       || !this.nonTiledImagedMatch(prevProps.nonTiledImages)
     ) {
-      this.viewer.close();
+      viewer.close();
       const canvasesChanged = !(isEqual(canvasWorld.canvasIds, prevProps.canvasWorld.canvasIds));
-      this.addAllImageSources((canvasesChanged || !viewer));
+      this.addAllImageSources((canvasesChanged || !viewerConfig));
     } else if (!isEqual(canvasWorld.layers, prevProps.canvasWorld.layers)) {
       this.refreshTileProperties();
-    } else if (viewer && !this.osdUpdating) {
-      const { viewport } = this.viewer;
+    } else if (viewerConfig && !this.osdUpdating) {
+      const { viewport } = viewer;
 
-      if (viewer.x !== viewport.centerSpringX.target.value
-        || viewer.y !== viewport.centerSpringY.target.value) {
-        this.viewer.viewport.panTo(viewer, false);
+      if (viewerConfig.x !== viewport.centerSpringX.target.value
+        || viewerConfig.y !== viewport.centerSpringY.target.value) {
+        viewer.viewport.panTo(viewerConfig, false);
       }
 
-      if (viewer.zoom !== viewport.zoomSpring.target.value) {
-        this.viewer.viewport.zoomTo(viewer.zoom, viewer, false);
+      if (viewerConfig.zoom !== viewport.zoomSpring.target.value) {
+        viewer.viewport.zoomTo(viewerConfig.zoom, viewerConfig, false);
       }
     }
   }
@@ -179,120 +100,9 @@ export class OpenSeadragonViewer extends Component {
   /**
    */
   componentWillUnmount() {
-    this.viewer.removeAllHandlers();
-  }
+    const { viewer } = this.state;
 
-  /** */
-  onCanvasClick(event) {
-    const {
-      canvasWorld,
-    } = this.props;
-
-    const { position: webPosition, eventSource: { viewport } } = event;
-    const point = viewport.pointFromPixel(webPosition);
-
-    const canvas = canvasWorld.canvasAtPoint(point);
-    if (!canvas) return;
-    const [
-      _canvasX, _canvasY, canvasWidth, canvasHeight, // eslint-disable-line no-unused-vars
-    ] = canvasWorld.canvasToWorldCoordinates(canvas.id);
-
-    // get all the annotations that contain the click
-    const annos = this.annotationsAtPoint(canvas, point);
-
-    if (annos.length > 0) {
-      event.preventDefaultAction = true; // eslint-disable-line no-param-reassign
-    }
-
-    if (annos.length === 1) {
-      this.toggleAnnotation(annos[0].id);
-    } else if (annos.length > 0) {
-      /**
-       * Try to find the "right" annotation to select after a click.
-       *
-       * This is perhaps a naive method, but seems to deal with rectangles and SVG shapes:
-       *
-       * - figure out how many points around a circle are inside the annotation shape
-       * - if there's a shape with the fewest interior points, it's probably the one
-       *       with the closest boundary?
-       * - if there's a tie, make the circle bigger and try again.
-       */
-      const annosWithClickScore = (radius) => {
-        const degreesToRadians = Math.PI / 180;
-
-        return (anno) => {
-          let score = 0;
-          for (let degrees = 0; degrees < 360; degrees += 1) {
-            const x = Math.cos(degrees * degreesToRadians) * radius + point.x;
-            const y = Math.sin(degrees * degreesToRadians) * radius + point.y;
-
-            if (this.isAnnotationAtPoint(anno, canvas, { x, y })) score += 1;
-          }
-
-          return { anno, score };
-        };
-      };
-
-      let annosWithScore = [];
-      let radius = 1;
-      annosWithScore = sortBy(annos.map(annosWithClickScore(radius)), 'score');
-
-      while (radius < Math.max(canvasWidth, canvasHeight)
-        && annosWithScore[0].score === annosWithScore[1].score) {
-        radius *= 2;
-        annosWithScore = sortBy(annos.map(annosWithClickScore(radius)), 'score');
-      }
-
-      this.toggleAnnotation(annosWithScore[0].anno.id);
-    }
-  }
-
-  /** */
-  onCanvasMouseMove(event) {
-    const {
-      annotations,
-      canvasWorld,
-      hoverAnnotation,
-      hoveredAnnotationIds,
-      searchAnnotations,
-      windowId,
-    } = this.props;
-
-    if (annotations.length === 0 && searchAnnotations.length === 0) return;
-
-    const { position: webPosition } = event;
-    const point = this.viewer.viewport.pointFromPixel(webPosition);
-
-    const canvas = canvasWorld.canvasAtPoint(point);
-    if (!canvas) {
-      hoverAnnotation(windowId, []);
-      return;
-    }
-
-    const annos = this.annotationsAtPoint(canvas, point);
-
-    if (xor(hoveredAnnotationIds, annos.map(a => a.id)).length > 0) {
-      hoverAnnotation(windowId, annos.map(a => a.id));
-    }
-  }
-
-  /** If the cursor leaves the canvas, wipe out highlights */
-  onCanvasExit(event) {
-    const {
-      hoverAnnotation,
-      windowId,
-    } = this.props;
-
-    // a move event may be queued up by the debouncer
-    this.onCanvasMouseMove.cancel();
-    hoverAnnotation(windowId, []);
-  }
-
-  /**
-   * onUpdateViewport - fires during OpenSeadragon render method.
-   */
-  onUpdateViewport(event) {
-    this.updateCanvas();
+    viewer.removeAllHandlers();
   }
 
   /**
@@ -307,105 +117,6 @@ export class OpenSeadragonViewer extends Component {
       x: Math.round(viewport.centerSpringX.target.value),
       y: Math.round(viewport.centerSpringY.target.value),
       zoom: viewport.zoomSpring.target.value,
-    });
-  }
-
-  /** */
-  canvasUpdateCallback() {
-    return () => {
-      this.osdCanvasOverlay.clear();
-      this.osdCanvasOverlay.resize();
-      this.osdCanvasOverlay.canvasUpdate(this.renderAnnotations.bind(this));
-    };
-  }
-
-  /** @private */
-  isAnnotationAtPoint(resource, canvas, point) {
-    const {
-      canvasWorld,
-    } = this.props;
-
-    const [canvasX, canvasY] = canvasWorld.canvasToWorldCoordinates(canvas.id);
-    const relativeX = point.x - canvasX;
-    const relativeY = point.y - canvasY;
-
-    if (resource.svgSelector) {
-      const context = this.osdCanvasOverlay.context2d;
-      const { svgPaths } = new CanvasAnnotationDisplay({ resource });
-      return [...svgPaths].some(path => (
-        context.isPointInPath(new Path2D(path.attributes.d.nodeValue), relativeX, relativeY)
-      ));
-    }
-
-    if (resource.fragmentSelector) {
-      const [x, y, w, h] = resource.fragmentSelector;
-      return x <= relativeX && relativeX <= (x + w)
-        && y <= relativeY && relativeY <= (y + h);
-    }
-    return false;
-  }
-
-  /** @private */
-  annotationsAtPoint(canvas, point) {
-    const {
-      annotations, searchAnnotations,
-    } = this.props;
-
-    const lists = [...annotations, ...searchAnnotations];
-    const annos = flatten(lists.map(l => l.resources)).filter((resource) => {
-      if (canvas.id !== resource.targetId) return false;
-
-      return this.isAnnotationAtPoint(resource, canvas, point);
-    });
-
-    return annos;
-  }
-
-  /** */
-  toggleAnnotation(id) {
-    const {
-      selectedAnnotationId,
-      selectAnnotation,
-      deselectAnnotation,
-      windowId,
-    } = this.props;
-
-    if (selectedAnnotationId === id) {
-      deselectAnnotation(windowId, id);
-    } else {
-      selectAnnotation(windowId, id);
-    }
-  }
-
-  /**
-   * annotationsToContext - converts anontations to a canvas context
-   */
-  annotationsToContext(annotations, palette) {
-    const {
-      highlightAllAnnotations, hoveredAnnotationIds, selectedAnnotationId, canvasWorld,
-    } = this.props;
-    const context = this.osdCanvasOverlay.context2d;
-    const zoomRatio = this.viewer.viewport.getZoom(true) / this.viewer.viewport.getMaxZoom();
-    annotations.forEach((annotation) => {
-      annotation.resources.forEach((resource) => {
-        if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
-        const offset = canvasWorld.offsetByCanvas(resource.targetId);
-        const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
-          hovered: hoveredAnnotationIds.includes(resource.id),
-          offset,
-          palette: {
-            ...palette,
-            default: {
-              ...palette.default,
-              ...(!highlightAllAnnotations && palette.hidden),
-            },
-          },
-          resource,
-          selected: selectedAnnotationId === resource.id,
-          zoomRatio,
-        });
-        canvasAnnotationDisplay.toContext(context);
-      });
     });
   }
 
@@ -426,11 +137,12 @@ export class OpenSeadragonViewer extends Component {
   /** */
   addNonTiledImage(contentResource) {
     const { canvasWorld } = this.props;
+    const { viewer } = this.state;
     return new Promise((resolve, reject) => {
-      if (!this.viewer) {
+      if (!viewer) {
         return;
       }
-      this.viewer.addSimpleImage({
+      viewer.addSimpleImage({
         error: event => reject(event),
         fitBounds: new OpenSeadragon.Rect(
           ...canvasWorld.contentResourceToWorldCoordinates(contentResource),
@@ -447,8 +159,9 @@ export class OpenSeadragonViewer extends Component {
    */
   addTileSource(infoResponse) {
     const { canvasWorld } = this.props;
+    const { viewer } = this.state;
     return new Promise((resolve, reject) => {
-      if (!this.viewer) {
+      if (!viewer) {
         return;
       }
 
@@ -457,7 +170,7 @@ export class OpenSeadragonViewer extends Component {
 
       if (!contentResource) return;
 
-      this.viewer.addTiledImage({
+      viewer.addTiledImage({
         error: event => reject(event),
         fitBounds: new OpenSeadragon.Rect(
           ...canvasWorld.contentResourceToWorldCoordinates(contentResource),
@@ -473,7 +186,7 @@ export class OpenSeadragonViewer extends Component {
   /** */
   refreshTileProperties() {
     const { canvasWorld } = this.props;
-    const { world } = this.viewer;
+    const { viewer: { world } } = this.state;
 
     const items = [];
     for (let i = 0; i < world.getItemCount(); i += 1) {
@@ -492,7 +205,9 @@ export class OpenSeadragonViewer extends Component {
   /**
    */
   fitBounds(x, y, w, h, immediately = true) {
-    this.viewer.viewport.fitBounds(
+    const { viewer } = this.state;
+
+    viewer.viewport.fitBounds(
       new OpenSeadragon.Rect(x, y, w, h),
       immediately,
     );
@@ -553,32 +268,15 @@ export class OpenSeadragonViewer extends Component {
     this.fitBounds(...canvasWorld.worldBounds(), immediately);
   }
 
-  /** */
-  renderAnnotations() {
-    const {
-      annotations,
-      drawAnnotations,
-      drawSearchAnnotations,
-      searchAnnotations,
-      palette,
-    } = this.props;
-
-    if (drawSearchAnnotations) {
-      this.annotationsToContext(searchAnnotations, palette.search);
-    }
-
-    if (drawAnnotations) {
-      this.annotationsToContext(annotations, palette.annotations);
-    }
-  }
-
   /**
    * Renders things
    */
   render() {
     const {
       children, classes, label, t, windowId,
+      drawAnnotations,
     } = this.props;
+    const { viewer } = this.state;
 
     const enhancedChildren = React.Children.map(children, child => (
       React.cloneElement(
@@ -597,6 +295,8 @@ export class OpenSeadragonViewer extends Component {
           ref={this.ref}
           aria-label={t('item', { label })}
         >
+          { drawAnnotations
+            && <AnnotationsOverlay viewer={viewer} windowId={windowId} /> }
           { enhancedChildren }
         </section>
       </>
@@ -605,46 +305,26 @@ export class OpenSeadragonViewer extends Component {
 }
 
 OpenSeadragonViewer.defaultProps = {
-  annotations: [],
   children: null,
-  deselectAnnotation: () => {},
-  drawAnnotations: true,
-  drawSearchAnnotations: true,
-  highlightAllAnnotations: false,
-  hoverAnnotation: () => {},
-  hoveredAnnotationIds: [],
+  drawAnnotations: false,
   infoResponses: [],
   label: null,
   nonTiledImages: [],
   osdConfig: {},
-  palette: {},
-  searchAnnotations: [],
-  selectAnnotation: () => {},
-  selectedAnnotationId: undefined,
-  viewer: null,
+  viewerConfig: null,
 };
 
 OpenSeadragonViewer.propTypes = {
-  annotations: PropTypes.arrayOf(PropTypes.object),
   canvasWorld: PropTypes.instanceOf(CanvasWorld).isRequired,
   children: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
-  deselectAnnotation: PropTypes.func,
   drawAnnotations: PropTypes.bool,
-  drawSearchAnnotations: PropTypes.bool,
-  highlightAllAnnotations: PropTypes.bool,
-  hoverAnnotation: PropTypes.func,
-  hoveredAnnotationIds: PropTypes.arrayOf(PropTypes.string),
   infoResponses: PropTypes.arrayOf(PropTypes.object),
   label: PropTypes.string,
   nonTiledImages: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   osdConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  palette: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  searchAnnotations: PropTypes.arrayOf(PropTypes.object),
-  selectAnnotation: PropTypes.func,
-  selectedAnnotationId: PropTypes.string,
   t: PropTypes.func.isRequired,
   updateViewport: PropTypes.func.isRequired,
-  viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  viewerConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   windowId: PropTypes.string.isRequired,
 };

--- a/src/containers/AnnotationsOverlay.js
+++ b/src/containers/AnnotationsOverlay.js
@@ -1,0 +1,63 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import { withPlugins } from '../extend/withPlugins';
+import { AnnotationsOverlay } from '../components/AnnotationsOverlay';
+import * as actions from '../state/actions';
+import CanvasWorld from '../lib/CanvasWorld';
+import {
+  getWindow,
+  getSequenceViewingDirection,
+  getLayersForVisibleCanvases,
+  getVisibleCanvases,
+  getSearchAnnotationsForWindow,
+  getCompanionWindowsForContent,
+  getTheme,
+  getConfig,
+  getPresentAnnotationsOnSelectedCanvases,
+  getSelectedAnnotationId,
+} from '../state/selectors';
+
+/**
+ * mapStateToProps - used to hook up connect to action creators
+ * @memberof Window
+ * @private
+ */
+const mapStateToProps = (state, { windowId }) => ({
+  annotations: getPresentAnnotationsOnSelectedCanvases(state, { windowId }),
+  canvasWorld: new CanvasWorld(
+    getVisibleCanvases(state, { windowId }),
+    getLayersForVisibleCanvases(state, { windowId }),
+    getSequenceViewingDirection(state, { windowId }),
+  ),
+  drawAnnotations: getConfig(state).window.forceDrawAnnotations || getCompanionWindowsForContent(state, { content: 'annotations', windowId }).length > 0,
+  drawSearchAnnotations: getConfig(state).window.forceDrawAnnotations || getCompanionWindowsForContent(state, { content: 'search', windowId }).length > 0,
+  highlightAllAnnotations: getWindow(state, { windowId }).highlightAllAnnotations,
+  hoveredAnnotationIds: getWindow(state, { windowId }).hoveredAnnotationIds,
+  palette: getTheme(state).palette,
+  searchAnnotations: getSearchAnnotationsForWindow(
+    state,
+    { windowId },
+  ),
+  selectedAnnotationId: getSelectedAnnotationId(state, { windowId }),
+});
+
+/**
+ * mapDispatchToProps - used to hook up connect to action creators
+ * @memberof ManifestListItem
+ * @private
+ */
+const mapDispatchToProps = {
+  deselectAnnotation: actions.deselectAnnotation,
+  hoverAnnotation: actions.hoverAnnotation,
+  selectAnnotation: actions.selectAnnotation,
+};
+
+const enhance = compose(
+  withTranslation(),
+  connect(mapStateToProps, mapDispatchToProps),
+  withPlugins('AnnotationsOverlay'),
+);
+
+
+export default enhance(AnnotationsOverlay);

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -7,7 +7,6 @@ import { OpenSeadragonViewer } from '../components/OpenSeadragonViewer';
 import * as actions from '../state/actions';
 import CanvasWorld from '../lib/CanvasWorld';
 import {
-  getWindow,
   getVisibleCanvasNonTiledResources,
   getCurrentCanvas,
   getCanvasLabel,
@@ -15,12 +14,8 @@ import {
   getLayersForVisibleCanvases,
   getVisibleCanvases,
   getViewer,
-  getSearchAnnotationsForWindow,
-  getCompanionWindowsForContent,
-  getTheme,
   getConfig,
-  getPresentAnnotationsOnSelectedCanvases,
-  getSelectedAnnotationId,
+  getCompanionWindowsForContent,
 } from '../state/selectors';
 
 /**
@@ -29,29 +24,21 @@ import {
  * @private
  */
 const mapStateToProps = (state, { windowId }) => ({
-  annotations: getPresentAnnotationsOnSelectedCanvases(state, { windowId }),
   canvasWorld: new CanvasWorld(
     getVisibleCanvases(state, { windowId }),
     getLayersForVisibleCanvases(state, { windowId }),
     getSequenceViewingDirection(state, { windowId }),
   ),
-  drawAnnotations: getConfig(state).window.forceDrawAnnotations || getCompanionWindowsForContent(state, { content: 'annotations', windowId }).length > 0,
-  drawSearchAnnotations: getConfig(state).window.forceDrawAnnotations || getCompanionWindowsForContent(state, { content: 'search', windowId }).length > 0,
-  highlightAllAnnotations: getWindow(state, { windowId }).highlightAllAnnotations,
-  hoveredAnnotationIds: getWindow(state, { windowId }).hoveredAnnotationIds,
+  drawAnnotations: getConfig(state).window.forceDrawAnnotations
+    || getCompanionWindowsForContent(state, { content: 'annotations', windowId }).length > 0
+    || getCompanionWindowsForContent(state, { content: 'search', windowId }).length > 0,
   label: getCanvasLabel(state, {
     canvasId: (getCurrentCanvas(state, { windowId }) || {}).id,
     windowId,
   }),
   nonTiledImages: getVisibleCanvasNonTiledResources(state, { windowId }),
   osdConfig: state.config.osdConfig,
-  palette: getTheme(state).palette,
-  searchAnnotations: getSearchAnnotationsForWindow(
-    state,
-    { windowId },
-  ),
-  selectedAnnotationId: getSelectedAnnotationId(state, { windowId }),
-  viewer: getViewer(state, { windowId }),
+  viewerConfig: getViewer(state, { windowId }),
 });
 
 /**
@@ -60,9 +47,6 @@ const mapStateToProps = (state, { windowId }) => ({
  * @private
  */
 const mapDispatchToProps = {
-  deselectAnnotation: actions.deselectAnnotation,
-  hoverAnnotation: actions.hoverAnnotation,
-  selectAnnotation: actions.selectAnnotation,
   updateViewport: actions.updateViewport,
 };
 

--- a/src/lib/OpenSeadragonCanvasOverlay.js
+++ b/src/lib/OpenSeadragonCanvasOverlay.js
@@ -12,23 +12,23 @@ export default class OpenSeadragonCanvasOverlay {
   /**
    * constructor - sets up the Canvas overlay container
    */
-  constructor(viewer) {
+  constructor(viewer, ref) {
     this.viewer = viewer;
+    this.ref = ref;
 
     this.containerWidth = 0;
     this.containerHeight = 0;
-
-    this.canvasDiv = document.createElement('div');
-    this.canvasDiv.style.position = 'absolute';
-    this.canvasDiv.style.left = 0;
-    this.canvasDiv.style.top = 0;
-    this.canvasDiv.style.width = '100%';
-    this.canvasDiv.style.height = '100%';
-    this.viewer.canvas.appendChild(this.canvasDiv);
-
-    this.canvas = document.createElement('canvas');
-    this.canvasDiv.appendChild(this.canvas);
     this.imgAspectRatio = 1;
+  }
+
+  /** */
+  get canvas() {
+    return this.canvasDiv.firstElementChild;
+  }
+
+  /** */
+  get canvasDiv() {
+    return this.ref.current;
   }
 
   /** */
@@ -38,7 +38,7 @@ export default class OpenSeadragonCanvasOverlay {
 
   /** */
   clear() {
-    this.canvas.getContext('2d').clearRect(0, 0, this.containerWidth, this.containerHeight);
+    this.context2d.clearRect(0, 0, this.containerWidth, this.containerHeight);
   }
 
   /**
@@ -90,11 +90,11 @@ export default class OpenSeadragonCanvasOverlay {
     ) * this.containerHeight;
 
     if (this.clearBeforeRedraw) this.clear();
-    this.canvas.getContext('2d').translate(x, y);
-    this.canvas.getContext('2d').scale(zoom, zoom);
+    this.context2d.translate(x, y);
+    this.context2d.scale(zoom, zoom);
 
     update();
 
-    this.canvas.getContext('2d').setTransform(1, 0, 0, 1, 0, 0);
+    this.context2d.setTransform(1, 0, 0, 1, 0, 0);
   }
 }

--- a/src/plugins/OSDReferences.js
+++ b/src/plugins/OSDReferences.js
@@ -1,6 +1,3 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-
 export const OSDReferences = {
   /** */
   get(windowId) {
@@ -11,33 +8,4 @@ export const OSDReferences = {
   set(windowId, ref) {
     this.refs[windowId] = ref;
   },
-};
-
-/** */
-class OSDReferenceComponent extends React.Component {
-  /** */
-  constructor(props) {
-    super(props);
-    const { windowId } = props.targetProps;
-    this.osdRef = React.createRef();
-    OSDReferences.set(windowId, this.osdRef);
-  }
-
-  /** */
-  render() {
-    const { targetProps } = this.props;
-
-    return <this.props.TargetComponent {...targetProps} ref={this.osdRef} />;
-  }
-}
-
-OSDReferenceComponent.propTypes = {
-  targetProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-};
-
-export default {
-  component: OSDReferenceComponent,
-  mode: 'wrap',
-  name: 'OSD Reference',
-  target: 'OpenSeadragonViewer',
 };


### PR DESCRIPTION
This disentangles (slightly...) the OpenSeadragonViewer's canvas display from the annotations overlay by extracting the annotations rendering and interactions into an `AnnotationsOverlay` component.

While I was at it, I also added an explicit `PluginHook` for OSDViewer to inject similar behavior externally.

