### PR TITLE
Make the workspace export configurable

### DIFF
--- a/__tests__/src/components/WorkspaceExport.test.js
+++ b/__tests__/src/components/WorkspaceExport.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Dialog from '@material-ui/core/Dialog';
 import Button from '@material-ui/core/Button';
-import IconButton from '@material-ui/core/IconButton';
 import Snackbar from '@material-ui/core/Snackbar';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { WorkspaceExport } from '../../../src/components/WorkspaceExport';

--- a/__tests__/src/components/WorkspaceExport.test.js
+++ b/__tests__/src/components/WorkspaceExport.test.js
@@ -27,7 +27,7 @@ describe('WorkspaceExport', () => {
       <WorkspaceExport
         open
         handleClose={handleClose}
-        state={mockState}
+        exportableState={mockState}
       />,
     );
   });

--- a/__tests__/src/reducers/manifests.test.js
+++ b/__tests__/src/reducers/manifests.test.js
@@ -89,9 +89,9 @@ describe('manifests reducer', () => {
     });
   });
   it('should handle IMPORT_MIRADOR_STATE setting to clean state', () => {
-    expect(manifestsReducer({}, {
+    expect(manifestsReducer({ old: 'stuff' }, {
       state: { manifests: { new: 'stuff' } },
       type: ActionTypes.IMPORT_MIRADOR_STATE,
-    })).toEqual({});
+    })).toEqual({ new: 'stuff' });
   });
 });

--- a/__tests__/src/selectors/config.test.js
+++ b/__tests__/src/selectors/config.test.js
@@ -7,12 +7,30 @@ import {
   getThemeDirection,
   getConfig,
   getRequestsConfig,
+  getExportableState,
 } from '../../../src/state/selectors';
 
 describe('getConfig', () => {
   it('returns the whole config', () => {
     const state = { config: { x: {} } };
     expect(getConfig(state)).toEqual(state.config);
+  });
+});
+
+describe('getExportableState', () => {
+  it('returns whole stems', () => {
+    const a = { some: 'value' };
+    const b = [1, 2, 3];
+    const state = { a, b, config: { export: { a: true, b: true } } };
+    expect(getExportableState(state)).toEqual({ a, b });
+  });
+
+  it('filters out parts of stems', () => {
+    const f = {
+      a: 1, b: 2, c: 3, d: 4,
+    };
+    const state = { config: { export: { f: { filter: ([k, v]) => (v % 2) === 0 } } }, f };
+    expect(getExportableState(state)).toEqual({ f: { b: 2, d: 4 } });
   });
 });
 

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -38,25 +38,10 @@ export class WorkspaceExport extends Component {
   /**
    * @private
    */
-  exportableState() {
-    const { state } = this.props;
-    const {
-      companionWindows,
-      config,
-      elasticLayout,
-      viewers,
-      windows,
-      workspace,
-    } = state;
+  exportedState() {
+    const { exportableState } = this.props;
 
-    return JSON.stringify({
-      companionWindows,
-      config,
-      elasticLayout,
-      viewers,
-      windows,
-      workspace,
-    }, null, 2);
+    return JSON.stringify(exportableState, null, 2);
   }
 
 
@@ -69,8 +54,6 @@ export class WorkspaceExport extends Component {
       children, container, open, t,
     } = this.props;
     const { copied } = this.state;
-
-    const exportableState = this.exportableState();
 
     if (copied) {
       return (
@@ -108,14 +91,14 @@ export class WorkspaceExport extends Component {
         <ScrollIndicatedDialogContent>
           {children}
           <pre>
-            {exportableState}
+            {this.exportedState()}
           </pre>
         </ScrollIndicatedDialogContent>
         <DialogActions>
           <Button onClick={this.handleClose}>{t('cancel')}</Button>
           <CopyToClipboard
             onCopy={this.onCopy}
-            text={exportableState}
+            text={this.exportedState()}
           >
             <Button variant="contained" color="primary">{t('copy')}</Button>
           </CopyToClipboard>
@@ -128,9 +111,9 @@ export class WorkspaceExport extends Component {
 WorkspaceExport.propTypes = {
   children: PropTypes.node,
   container: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  exportableState: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
-  state: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   t: PropTypes.func,
 };
 

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -319,5 +319,17 @@ export default {
     preserveImageSizeOnResize: true,
     preserveViewport: true,
     showNavigationControl: false,
+  },
+  export: {
+    state: [
+      'catalog',
+      'companionWindows',
+      'config',
+      'elasticLayout',
+      'layers',
+      'viewers',
+      'windows',
+      'workspace',
+    ]
   }
 };

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -321,15 +321,15 @@ export default {
     showNavigationControl: false,
   },
   export: {
-    state: [
-      'catalog',
-      'companionWindows',
-      'config',
-      'elasticLayout',
-      'layers',
-      'viewers',
-      'windows',
-      'workspace',
-    ]
+    catalog: true,
+    companionWindows: true,
+    config: true,
+    elasticLayout: true,
+    layers: true,
+    // filter out anything re-retrievable:
+    manifests: { filter: ([id, value]) => !id.startsWith('http') },
+    viewers: true,
+    windows: true,
+    workspace: true,
   }
 };

--- a/src/containers/WorkspaceExport.js
+++ b/src/containers/WorkspaceExport.js
@@ -9,7 +9,11 @@ import { WorkspaceExport } from '../components/WorkspaceExport';
  * @memberof Workspace
  * @private
  */
-const mapStateToProps = state => ({ state });
+const mapStateToProps = state => ({
+  exportableState: state.config.export.state.reduce(
+    (acc, stem) => { acc[stem] = state[stem]; return acc; }, {},
+  ),
+});
 
 const enhance = compose(
   withTranslation(),

--- a/src/containers/WorkspaceExport.js
+++ b/src/containers/WorkspaceExport.js
@@ -3,6 +3,9 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import { WorkspaceExport } from '../components/WorkspaceExport';
+import {
+  getExportableState,
+} from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -10,9 +13,7 @@ import { WorkspaceExport } from '../components/WorkspaceExport';
  * @private
  */
 const mapStateToProps = state => ({
-  exportableState: state.config.export.state.reduce(
-    (acc, stem) => { acc[stem] = state[stem]; return acc; }, {},
-  ),
+  exportableState: getExportableState(state),
 });
 
 const enhance = compose(

--- a/src/state/reducers/manifests.js
+++ b/src/state/reducers/manifests.js
@@ -44,7 +44,7 @@ export const manifestsReducer = (state = {}, action) => {
         return object;
       }, {});
     case ActionTypes.IMPORT_MIRADOR_STATE:
-      return {};
+      return action.state.manifests || {};
     default: return state;
   }
 };

--- a/src/state/selectors/config.js
+++ b/src/state/selectors/config.js
@@ -7,6 +7,33 @@ export function getConfig(state) {
 }
 
 /**
+ * Extract an exportable version of state using the configuration from the config.
+ */
+export function getExportableState(state) {
+  const exportConfig = getConfig(state).export;
+
+  return Object.entries(exportConfig).reduce(
+    (acc, [stem, value]) => {
+      if (value === true) {
+        acc[stem] = state[stem];
+      } else if (value.filter) {
+        acc[stem] = Object.entries(state[stem])
+          .filter(value.filter)
+          .reduce(
+            (stemAcc, [k, v]) => {
+              stemAcc[k] = v; // eslint-disable-line no-param-reassign
+              return stemAcc;
+            },
+            {},
+          );
+      }
+      return acc;
+    },
+    {},
+  );
+}
+
+/**
 * Return languages from config (in state) and indicate which is currently set
 * @param {object} state
 * @return {Array} [ {locale: 'de', label: 'Deutsch', current: true}, ... ]


### PR DESCRIPTION
Fixes #3137 ?

Previously, our exported state was hard-coded in the component. This PR lifts up to a selector that uses the configuration to identify the stems to export.

This PR  also adds exporting/importing manifests (say, created as part of #3094); by default, we only handle non-resolvable manifests to keep the export size down.
