### PR TITLE
Allow plugin system to accept arrays of plugins and validate them as a batch

### DIFF
--- a/__tests__/integration/mirador/plugins/add.html
+++ b/__tests__/integration/mirador/plugins/add.html
@@ -85,7 +85,7 @@
         component: AddPluginComponentE,
       };
 
-      const miradorInstance = Mirador.viewer(config, [addPluginA, addPluginB, addPluginC, wrapPluginD, addPluginE]);
+      const miradorInstance = Mirador.viewer(config, [[addPluginA, addPluginB], addPluginC, wrapPluginD, addPluginE]);
 
      </script>
   </body>

--- a/__tests__/integration/mirador/plugins/validate.html
+++ b/__tests__/integration/mirador/plugins/validate.html
@@ -86,13 +86,12 @@
 
       const miradorInstance = Mirador.viewer(config, [
         validPluginA,
-        validPluginB,
         invalidPluginA,
         invalidPluginB,
         invalidPluginC,
         invalidPluginD,
         invalidPluginE,
-        invalidPluginF,
+        [validPluginB, invalidPluginF],
       ]);
 
      </script>

--- a/__tests__/integration/mirador/plugins/validate.test.js
+++ b/__tests__/integration/mirador/plugins/validate.test.js
@@ -7,7 +7,6 @@ describe('pass valid and invalid plugins to <WorkspaceControlPanelButtons>', () 
 
   it('valid plugins will be applied <WorkspaceControlPanelButtons>', async () => {
     await expect(page).toMatchElement('#valid-plugin-a');
-    await expect(page).toMatchElement('#valid-plugin-b');
   });
 
   it('invalid plugins will not be applied <WorkspaceControlPanelButtons>', async () => {

--- a/__tests__/src/extend/pluginPreprocessing.test.js
+++ b/__tests__/src/extend/pluginPreprocessing.test.js
@@ -26,10 +26,18 @@ describe('filterValidPlugins', () => {
         mode: 'wrap',
         name: 'invalid Plugin 1',
       },
-      {
-        name: 'invalid Plugin 2',
-        target: 'missing-mode',
-      },
+      [
+        {
+          name: 'invalid Plugin 2',
+          target: 'missing-mode',
+        },
+        {
+          component: props => null,
+          mode: 'wrap',
+          name: 'valid plugin, grouped with an invalid one',
+          target: 'WindowTopBar',
+        },
+      ],
     ];
     const result = filterValidPlugins(plugins);
     expect(result.map(r => r.name)).toEqual(['valid plugin 1', 'valid plugin 2']);

--- a/src/extend/pluginPreprocessing.js
+++ b/src/extend/pluginPreprocessing.js
@@ -15,13 +15,20 @@ export function addPluginReducersToStore(store, createRootReducer, plugins) {
 
 /** */
 function splitPluginsByValidation(plugins) {
-  const splittedPlugins = { invalidPlugins: [], validPlugins: [] };
-  plugins.forEach(plugin => (
-    validatePlugin(plugin)
-      ? splittedPlugins.validPlugins.push(plugin)
-      : splittedPlugins.invalidPlugins.push(plugin)
-  ));
-  return splittedPlugins;
+  const invalidPlugins = [];
+  const validPlugins = [];
+  plugins.forEach(plugin => {
+    if (Array.isArray(plugin)) {
+      const allValid = plugin.every(p => validatePlugin(p));
+
+      allValid ? validPlugins.push(...plugin) : invalidPlugins.push(...plugin);
+    } else {
+      validatePlugin(plugin)
+        ? validPlugins.push(plugin)
+        : invalidPlugins.push(plugin);
+    }
+  });
+  return { invalidPlugins, validPlugins };
 }
 
 /** */


### PR DESCRIPTION
This codifies a pattern we've been using in some projects that want to inject multiple Mirador plugins into the application (currently just using the `...` operator).
