### PR TITLE
Allow empty pluginSagas

### DIFF
--- a/src/state/sagas/index.js
+++ b/src/state/sagas/index.js
@@ -20,7 +20,7 @@ function* launchSaga(saga) {
 }
 
 /** */
-function getRootSaga(pluginSagas) {
+function getRootSaga(pluginSagas = []) {
   return function* rootSaga() {
     const sagas = [
       annotations,


### PR DESCRIPTION
This is just an low-level API nicety for apps that want to use our sagas but don't need/want any plugins.