### PR TITLE
Show isWorkspaceAddVisible in settings for adopter visibility

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -297,6 +297,7 @@ export default {
     draggingEnabled: true,
     allowNewWindows: true,
     id: uuid(),
+    isWorkspaceAddVisible: false, // Catalog/Workspace add window feature visible by default
     exposeModeOn: false, // unused?
     height: 5000, // height of the elastic mode's virtual canvas
     showZoomControls: false, // Configure if zoom controls should be displayed by default


### PR DESCRIPTION
This was asked about in the IIIF slack. Elevating this in the settings for user visibility.

Also, should we rename? If so.. to what?