### PR TITLE
Fix for canvases with no annotations

### DIFF
--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -221,6 +221,28 @@ describe('window-level sagas', () => {
         .then(({ allEffects }) => allEffects.length === 0);
     });
 
+    it('does nothing when there are no annotations targeting the current canvas', () => {
+      const action = {
+        type: ActionTypes.SET_CANVAS,
+        visibleCanvases: ['a', 'b'],
+        windowId: 'abc123',
+      };
+
+      return expectSaga(setCurrentAnnotationsOnCurrentCanvas, action)
+        .provide([
+          [select(getSearchForWindow,
+            { windowId: 'abc123' }), { cwid: { } }],
+          [select(getAnnotationsBySearch, { canvasIds: ['a', 'b'], companionWindowIds: ['cwid'], windowId: 'abc123' }),
+            { }],
+        ])
+        .run()
+        // Assert that nothing did happen, see https://github.com/jfairbank/redux-saga-test-plan/issues/137
+        .then(({ effects }) => {
+          expect(effects.select.length).toEqual(2);
+          expect(effects.put).toBeUndefined();
+        });
+    });
+
     it('selects content search annotations for the current searches', () => {
       const action = {
         type: ActionTypes.SET_CANVAS,

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -129,8 +129,10 @@ export function* setCurrentAnnotationsOnCurrentCanvas({
         )))),
   );
 
-  // if the currently selected annotation isn't on this canvas, do a thing.
-  yield put(selectAnnotation(windowId, Object.values(annotationBySearch)[0][0]));
+  if (Object.values(annotationBySearch).length > 0) {
+    // if the currently selected annotation isn't on this canvas, do a thing.
+    yield put(selectAnnotation(windowId, Object.values(annotationBySearch)[0][0]));
+  }
 }
 
 /** @private */


### PR DESCRIPTION
When using the Search feature, switching to a canvas without a search hit (i.e. no annotations targeting it), Mirador would run into a `TypeError` in the `setCurrentAnnotationsOnCurrentCanvas` Saga.
The underlying cause was that the code would try to select the first annotation for the current canvas, if the currently selected annotation was not targeting it. This, of course, failed when there were no
annotations targeting the current canvas. This is why `rc.3` has pretty much broken content search for us, since for most searches there's only ever going to be a handful of canvases with hits.

This PR fixes this by adding a check for the presence of annotations for the current canvas before dispatching the `selectAnnotation` action.

To reproduce the bug with the current `master` build of Mirador, use the "Wunder der Vererbung" manifest, search for `kugelpaare` and switch pages, the viewport should be empty now and the console should show a stack trace from the saga middleware.