### PR TITLE
Remove unused plugin preprocessing addPluginReducersToStore

### DIFF
--- a/__tests__/src/extend/pluginPreprocessing.test.js
+++ b/__tests__/src/extend/pluginPreprocessing.test.js
@@ -1,6 +1,5 @@
 import {
   filterValidPlugins,
-  addPluginReducersToStore,
 } from '../../../src/extend/pluginPreprocessing';
 
 describe('filterValidPlugins', () => {
@@ -41,42 +40,5 @@ describe('filterValidPlugins', () => {
     ];
     const result = filterValidPlugins(plugins);
     expect(result.map(r => r.name)).toEqual(['valid plugin 1', 'valid plugin 2']);
-  });
-});
-
-describe('addPluginReducersToStore', () => {
-  const store = { replaceReducer: jest.fn() };
-  const createRootReducer = jest.fn(pluginReducers => pluginReducers);
-
-  /** */ const fooReducer = x => x;
-  /** */ const barReducer = x => x;
-  /** */ const bazReducer = x => x;
-
-  const plugins = [
-    {
-      component: props => null,
-      mode: 'add',
-      reducers: {
-        bar: barReducer,
-        foo: fooReducer,
-      },
-      target: 'Window',
-    },
-    {
-      component: props => null,
-      mode: 'add',
-      reducers: {
-        baz: bazReducer,
-      },
-      target: 'Window',
-    },
-  ];
-
-  addPluginReducersToStore(store, createRootReducer, plugins);
-  expect(store.replaceReducer.mock.calls.length).toBe(1);
-  expect(store.replaceReducer.mock.calls[0][0]).toEqual({
-    bar: barReducer,
-    baz: bazReducer,
-    foo: fooReducer,
   });
 });

--- a/src/extend/pluginPreprocessing.js
+++ b/src/extend/pluginPreprocessing.js
@@ -8,12 +8,6 @@ export function filterValidPlugins(plugins) {
 }
 
 /** */
-export function addPluginReducersToStore(store, createRootReducer, plugins) {
-  const pluginReducers = getReducersFromPlugins(plugins);
-  store.replaceReducer(createRootReducer(pluginReducers));
-}
-
-/** */
 function splitPluginsByValidation(plugins) {
   const invalidPlugins = [];
   const validPlugins = [];


### PR DESCRIPTION
Added here: https://github.com/ProjectMirador/mirador/commit/91e4e337a6c6acd9d69da7e485633ab3e4d08937

I couldn't find this being used.