### PR TITLE
Enable plugins to provide their own configs that can get merged into …

### DIFF
--- a/__tests__/integration/mirador/plugins/add.html
+++ b/__tests__/integration/mirador/plugins/add.html
@@ -58,6 +58,9 @@
       const addPluginA = {
         target: 'WorkspaceControlPanelButtons',
         mode: 'add',
+        config: {
+          foo: 'bar',
+        },
         component: AddPluginComponentA,
       };
 

--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -64,5 +64,43 @@ describe('MiradorViewer', () => {
 
       expect(config.foo).toBe('bar');
     });
+    it('merges translation configs from multiple plugins', () => {
+      instance = new MiradorViewer({
+        id: 'mirador',
+      },
+      {
+        plugins: [
+          {
+            config: {
+              translations: {
+                en: {
+                  foo: 'bar',
+                },
+              },
+            },
+            mode: 'add',
+            target: 'WindowTopBarPluginArea',
+          },
+          {
+            config: {
+              translations: {
+                en: {
+                  bat: 'bar',
+                },
+              },
+            },
+            mode: 'wrap',
+            target: 'Window',
+          },
+        ],
+      });
+
+      const { config } = instance.store.getState();
+
+      expect(config.translations.en).toEqual(expect.objectContaining({
+        bat: 'bar',
+        foo: 'bar',
+      }));
+    });
   });
 });

--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -37,9 +37,18 @@ describe('MiradorViewer', () => {
             view: 'book',
           },
         ],
+      },
+      {
+        plugins: [{
+          config: {
+            foo: 'bar',
+          },
+          mode: 'add',
+          target: 'WindowTopBarPluginArea',
+        }],
       });
 
-      const { windows, catalog } = instance.store.getState();
+      const { windows, catalog, config } = instance.store.getState();
       const windowIds = Object.keys(windows);
       expect(Object.keys(windowIds).length).toBe(2);
       expect(windows[windowIds[0]].canvasId).toBe('https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892');
@@ -52,6 +61,8 @@ describe('MiradorViewer', () => {
       expect(catalog.length).toBe(1);
       expect(catalog[0].manifestId).toBe('http://media.nga.gov/public/manifests/nga_highlights.json');
       expect(catalog[0].provider).toBe('National Gallery of Art');
+
+      expect(config.foo).toBe('bar');
     });
   });
 });

--- a/src/extend/pluginPreprocessing.js
+++ b/src/extend/pluginPreprocessing.js
@@ -1,3 +1,4 @@
+import deepmerge from 'deepmerge';
 import { validatePlugin } from './pluginValidation';
 
 /** */
@@ -39,7 +40,7 @@ export function getReducersFromPlugins(plugins) {
 
 /**  */
 export function getConfigFromPlugins(plugins) {
-  return plugins && plugins.reduce((acc, plugin) => ({ ...acc, ...plugin.config }), {});
+  return plugins && plugins.reduce((acc, plugin) => (deepmerge(acc, plugin.config || {})), {});
 }
 
 /**  */

--- a/src/extend/pluginPreprocessing.js
+++ b/src/extend/pluginPreprocessing.js
@@ -38,6 +38,11 @@ export function getReducersFromPlugins(plugins) {
 }
 
 /**  */
+export function getConfigFromPlugins(plugins) {
+  return plugins && plugins.reduce((acc, plugin) => ({ ...acc, ...plugin.config }), {});
+}
+
+/**  */
 export function getSagasFromPlugins(plugins) {
   return plugins && plugins.filter(plugin => plugin.saga).map(plugin => plugin.saga);
 }

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -45,7 +45,7 @@ class MiradorViewer {
   processConfig() {
     this.store.dispatch(
       importConfig(
-        deepmerge(getConfigFromPlugins(this.plugins), this.config),
+        deepmerge(this.config, getConfigFromPlugins(this.plugins)),
       ),
     );
   }

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -45,7 +45,7 @@ class MiradorViewer {
   processConfig() {
     this.store.dispatch(
       importConfig(
-        deepmerge(this.config, getConfigFromPlugins(this.plugins)),
+        deepmerge(getConfigFromPlugins(this.plugins), this.config),
       ),
     );
   }

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import deepmerge from 'deepmerge';
 import HotApp from '../components/App';
 import createStore from '../state/createStore';
 import { importConfig } from '../state/actions/config';
 import {
   filterValidPlugins,
+  getConfigFromPlugins,
   getReducersFromPlugins,
   getSagasFromPlugins,
 } from '../extend/pluginPreprocessing';
@@ -38,10 +40,14 @@ class MiradorViewer {
   }
 
   /**
-   * Process config into actions
+   * Process config with plugin configs into actions
    */
   processConfig() {
-    this.store.dispatch(importConfig(this.config));
+    this.store.dispatch(
+      importConfig(
+        deepmerge(getConfigFromPlugins(this.plugins), this.config),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
…the main redux config

Fixes #3020  and allows for plugins to inject their own translations see: https://github.com/ProjectMirador/mirador-image-tools/pull/21