### PR TITLE
Update landmarks for Mirador workspace

### DIFF
--- a/__tests__/src/components/MosaicRenderPreview.test.js
+++ b/__tests__/src/components/MosaicRenderPreview.test.js
@@ -17,5 +17,6 @@ describe('MosaicRenderPreview', () => {
     expect(
       wrapper.find(MinimalWindow).prop('label'),
     ).toEqual('previewWindowTitle The Title Prop');
+    expect(wrapper.find(MinimalWindow).prop('ariaLabel')).toEqual(false);
   });
 });

--- a/__tests__/src/components/WorkspaceMosaic.test.js
+++ b/__tests__/src/components/WorkspaceMosaic.test.js
@@ -110,7 +110,7 @@ describe('WorkspaceMosaic', () => {
       }));
 
       expect(shallow(shallow(renderedTile).props().renderPreview({ windowId: 1 })).matchesElement(
-        <div className="mosaic-preview">
+        <div className="mosaic-preview" aria-hidden>
           <MosaicRenderPreview windowId={1} />
         </div>,
       )).toBe(true);

--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -57,6 +57,15 @@ export class CompanionArea extends Component {
 
     return (
       <div className={[classes.root, this.areaLayoutClass(), ns(`companion-area-${position}`)].join(' ')}>
+        <Slide in={companionAreaOpen} direction={this.slideDirection()}>
+          <div className={[ns('companion-windows'), companionWindowIds.length > 0 && classes[position], this.areaLayoutClass()].join(' ')} style={{ display: companionAreaOpen ? 'flex' : 'none' }}>
+            {
+              companionWindowIds.map(id => (
+                <CompanionWindowFactory id={id} key={id} windowId={windowId} />
+              ))
+            }
+          </div>
+        </Slide>
         {
           setCompanionAreaOpen && position === 'left' && sideBarOpen && companionWindowIds.length > 0
           && (
@@ -74,15 +83,6 @@ export class CompanionArea extends Component {
             </div>
           )
         }
-        <Slide in={companionAreaOpen} direction={this.slideDirection()}>
-          <div className={[ns('companion-windows'), companionWindowIds.length > 0 && classes[position], this.areaLayoutClass()].join(' ')} style={{ display: companionAreaOpen ? 'flex' : 'none' }}>
-            {
-              companionWindowIds.map(id => (
-                <CompanionWindowFactory id={id} key={id} windowId={windowId} />
-              ))
-            }
-          </div>
-        </Slide>
       </div>
     );
   }

--- a/src/components/MinimalWindow.js
+++ b/src/components/MinimalWindow.js
@@ -17,6 +17,7 @@ export class MinimalWindow extends Component {
     const {
       allowClose,
       allowWindowSideBar,
+      ariaLabel,
       children,
       classes,
       label,
@@ -33,7 +34,7 @@ export class MinimalWindow extends Component {
         className={
           cn(classes.window, ns('placeholder-window'))
         }
-        aria-label={t('window', { label })}
+        aria-label={label && ariaLabel ? t('window', { label }) : null}
       >
         <AppBar position="relative" color="default">
           <Toolbar
@@ -75,6 +76,7 @@ export class MinimalWindow extends Component {
 MinimalWindow.propTypes = {
   allowClose: PropTypes.bool,
   allowWindowSideBar: PropTypes.bool,
+  ariaLabel: PropTypes.bool,
   children: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.string),
   label: PropTypes.string,
@@ -86,6 +88,7 @@ MinimalWindow.propTypes = {
 MinimalWindow.defaultProps = {
   allowClose: true,
   allowWindowSideBar: true,
+  ariaLabel: true,
   children: null,
   classes: {},
   label: '',

--- a/src/components/MinimalWindow.js
+++ b/src/components/MinimalWindow.js
@@ -61,6 +61,9 @@ export class MinimalWindow extends Component {
                 aria-label={t('closeWindow')}
                 className={cn(classes.button, ns('window-close'))}
                 onClick={removeWindow}
+                TooltipProps={{
+                  tabIndex: ariaLabel ? '0' : '-1',
+                }}
               >
                 <CloseIcon />
               </MiradorMenuButton>

--- a/src/components/MosaicRenderPreview.js
+++ b/src/components/MosaicRenderPreview.js
@@ -11,7 +11,7 @@ export function MosaicRenderPreview(props) {
   } = props;
 
   return (
-    <MinimalWindow windowId={`${windowId}-preview`} label={t('previewWindowTitle', { title })} />
+    <MinimalWindow windowId={`${windowId}-preview`} label={t('previewWindowTitle', { title })} ariaLabel={false} />
   );
 }
 

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -49,7 +49,7 @@ export class OpenSeadragonViewer extends Component {
     if (canvas) {
       canvas.setAttribute('role', 'img');
       canvas.setAttribute('aria-label', t('digitizedView'));
-      canvas.setAttribute('aria-describedby', `osd-info-${windowId}`);
+      canvas.setAttribute('aria-describedby', `${windowId}-osd`);
     }
 
     this.apiRef.current = viewer;
@@ -331,7 +331,7 @@ export class OpenSeadragonViewer extends Component {
    */
   render() {
     const {
-      children, classes, windowId,
+      children, classes, label, t, windowId,
       drawAnnotations,
     } = this.props;
     const { viewer } = this.state;
@@ -351,7 +351,7 @@ export class OpenSeadragonViewer extends Component {
           className={classNames(ns('osd-container'), classes.osdContainer)}
           id={`${windowId}-osd`}
           ref={this.ref}
-          aria-labelledby={`osd-info-${windowId}`}
+          aria-label={t('item', { label })}
           aria-live="polite"
         >
           { drawAnnotations
@@ -368,6 +368,7 @@ OpenSeadragonViewer.defaultProps = {
   children: null,
   drawAnnotations: false,
   infoResponses: [],
+  label: null,
   nonTiledImages: [],
   osdConfig: {},
   viewerConfig: null,
@@ -379,6 +380,7 @@ OpenSeadragonViewer.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   drawAnnotations: PropTypes.bool,
   infoResponses: PropTypes.arrayOf(PropTypes.object),
+  label: PropTypes.string,
   nonTiledImages: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   osdConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   t: PropTypes.func.isRequired,

--- a/src/components/ViewerInfo.js
+++ b/src/components/ViewerInfo.js
@@ -16,14 +16,10 @@ export class ViewerInfo extends Component {
       canvasLabel,
       classes,
       t,
-      windowId,
     } = this.props;
 
     return (
-      <div
-        id={`osd-info-${windowId}`}
-        className={classNames(ns('osd-info'), classes.osdInfo)}
-      >
+      <div className={classNames(ns('osd-info'), classes.osdInfo)}>
         <Typography display="inline" variant="caption" className={ns('canvas-count')}>
           { t('pagination', { current: canvasIndex + 1, total: canvasCount }) }
         </Typography>
@@ -38,7 +34,6 @@ export class ViewerInfo extends Component {
 ViewerInfo.defaultProps = {
   canvasLabel: undefined,
   t: () => {},
-  windowId: PropTypes.string,
 };
 
 ViewerInfo.propTypes = {
@@ -47,5 +42,4 @@ ViewerInfo.propTypes = {
   canvasLabel: PropTypes.string,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   t: PropTypes.func,
-  windowId: PropTypes.string,
 };

--- a/src/components/WorkspaceMosaic.js
+++ b/src/components/WorkspaceMosaic.js
@@ -104,7 +104,7 @@ export class WorkspaceMosaic extends React.Component {
   /** */
   static renderPreview(mosaicProps) {
     return (
-      <div className="mosaic-preview">
+      <div className="mosaic-preview" aria-hidden>
         <MosaicRenderPreview windowId={mosaicProps.windowId} />
       </div>
     );

--- a/src/containers/MosaicRenderPreview.js
+++ b/src/containers/MosaicRenderPreview.js
@@ -16,7 +16,6 @@ const mapStateToProps = (state, { windowId }) => (
 /**
  *
  * @param theme
- * @returns {{ctrlBtn: {margin: (number|string)}}}
  */
 const styles = theme => ({
   preview: {

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -9,6 +9,8 @@ import * as actions from '../state/actions';
 import CanvasWorld from '../lib/CanvasWorld';
 import {
   getVisibleCanvasNonTiledResources,
+  getCurrentCanvas,
+  getCanvasLabel,
   getSequenceViewingDirection,
   getLayersForVisibleCanvases,
   getVisibleCanvases,
@@ -42,6 +44,10 @@ const mapStateToProps = (state, { windowId }) => {
       .filter(infoResponse => (infoResponse !== undefined
         && infoResponse.isFetching === false
         && infoResponse.error === undefined)),
+    label: getCanvasLabel(state, {
+      canvasId: (getCurrentCanvas(state, { windowId }) || {}).id,
+      windowId,
+    }),
     nonTiledImages: getVisibleCanvasNonTiledResources(state, { windowId }),
     osdConfig: getConfig(state).osdConfig,
     viewerConfig: getViewer(state, { windowId }),


### PR DESCRIPTION
This pull request makes the following accessibility changes:

 - Fixes #3223 by reverting back to using the "Item: {label}" approach instead of stuff from `ViewerInfo` which ended up not really working with screenreaders
 - Removes aria-label for mosiac previews and makes them aria-hidden
 - Removes an extra tab index element (mosaic preview close button)
 - Fixes #3115 by reversing the order of the sidebar collapse button and the slide component

Paired with @jvine on some of this.

Builds on previous work in https://github.com/ProjectMirador/mirador/commit/64442a2cb0c5609ca91ad203ad445442d2e3a022