### PR TITLE
Add target.source (without id) as valid target.

### DIFF
--- a/src/lib/AnnotationItem.js
+++ b/src/lib/AnnotationItem.js
@@ -29,7 +29,7 @@ export default class AnnotationItem {
       case 'string':
         return target.replace(/#?xywh=(.*)$/, '');
       case 'object':
-        return target.id || (target.source && target.source.id);
+        return (target.source && target.source.id) || target.source || target.id;
       default:
         return null;
     }


### PR DESCRIPTION
According to the WebAnno spec it is valid for `target.source` to be a uri.

Closes https://github.com/ProjectMirador/mirador-annotations/issues/25