### PR TITLE
Delete Mirador 2 issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/mirador-2.md
+++ b/.github/ISSUE_TEMPLATE/mirador-2.md
@@ -1,8 +1,0 @@
----
-name: Mirador 2
-about: Issues related to the latest stable build of Mirador 2.7
-title: ''
-labels: Mirador2
-assignees: ''
-
----


### PR DESCRIPTION
All major development effort has been directed towards Mirador 3. Implementers are free to fork Mirador 2.7 and apply patches to their local instances, but we haven't received any upstream Mirador 2 work in a long time.

Making more specific issue templates for Mirador 3 will be addressed in a later PR.