### PR TITLE
Provide empty class style props that are used in IIIFThumbnail

### DIFF
--- a/src/containers/IIIFThumbnail.js
+++ b/src/containers/IIIFThumbnail.js
@@ -12,6 +12,7 @@ const styles = theme => ({
     lineHeight: '1.5em',
     wordBreak: 'break-word',
   },
+  image: {},
   insideCaption: {
     color: '#ffffff',
     lineClamp: '1',
@@ -43,6 +44,7 @@ const styles = theme => ({
   },
   outsideLabel: {},
   outsideRoot: {},
+  root: {},
 });
 
 const enhance = compose(


### PR DESCRIPTION
These are used in `components/IIIFThumbnail`. Should we provide empty ones so that plugins can override? Or remove from component?