### PR TITLE
Fix canvas label display in ViewerInfo.

### DIFF
--- a/src/containers/ViewerInfo.js
+++ b/src/containers/ViewerInfo.js
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { ViewerInfo } from '../components/ViewerInfo';
 import {
-  getCanvasLabel, getCanvases, getCanvasIndex, getVisibleCanvasIds
+  getCanvasLabel, getCanvases, getCanvasIndex, getCurrentCanvas,
 } from '../state/selectors';
 
 /**
@@ -17,7 +17,7 @@ const mapStateToProps = (state, props) => {
   const { windowId } = props;
   const canvases = getCanvases(state, { windowId });
   const canvasIndex = getCanvasIndex(state, { windowId });
-  const canvasId = getVisibleCanvasIds(state, { windowId })[0];
+  const canvasId = (getCurrentCanvas(state, { windowId }) || {}).id;
 
   return {
     canvasCount: canvases.length,

--- a/src/containers/ViewerInfo.js
+++ b/src/containers/ViewerInfo.js
@@ -4,7 +4,9 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { ViewerInfo } from '../components/ViewerInfo';
-import { getCanvasLabel, getCanvases, getCanvasIndex } from '../state/selectors';
+import {
+  getCanvasLabel, getCanvases, getCanvasIndex, getVisibleCanvasIds
+} from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -15,12 +17,13 @@ const mapStateToProps = (state, props) => {
   const { windowId } = props;
   const canvases = getCanvases(state, { windowId });
   const canvasIndex = getCanvasIndex(state, { windowId });
+  const canvasId = getVisibleCanvasIds(state, { windowId })[0];
 
   return {
     canvasCount: canvases.length,
     canvasIndex,
     canvasLabel: getCanvasLabel(state, {
-      canvasIndex,
+      canvasId,
       windowId,
     }),
   };

--- a/src/containers/WindowCanvasNavigationControls.js
+++ b/src/containers/WindowCanvasNavigationControls.js
@@ -4,19 +4,11 @@ import { withSize } from 'react-sizeme';
 import { withStyles } from '@material-ui/core';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withPlugins } from '../extend/withPlugins';
-import {
-  getCurrentCanvas,
-  getCanvasLabel,
-  getWorkspace,
-} from '../state/selectors';
+import { getWorkspace } from '../state/selectors';
 import { WindowCanvasNavigationControls } from '../components/WindowCanvasNavigationControls';
 
 /** */
 const mapStateToProps = (state, { windowId }) => ({
-  canvasLabel: getCanvasLabel(state, {
-    canvasId: (getCurrentCanvas(state, { windowId }) || {}).id,
-    windowId,
-  }),
   visible: getWorkspace(state).focusedWindowId === windowId,
 });
 


### PR DESCRIPTION
The component would always get be passed an `undefined` prop for the label, since the selector in the container used the `canvasIdx` to select the label, but the selector expected the identifier.

This was missed in #2851 when the canvas identifier was passed to components that were missing it.

Additionally, this commit removes the `canvasLabel` prop from the `WindowCanvasNavigationControls` container, since the label is never used in the actual component. (#3258)

**Before:**
![image](https://user-images.githubusercontent.com/608610/94172745-2acdcf00-fe93-11ea-83a7-9b19b390dbae.png)

**After:**
![image](https://user-images.githubusercontent.com/608610/94172622-03770200-fe93-11ea-9d2f-c0dd9db41129.png)
