### PR TITLE
Get all of the metadata (instead of Manifestos first if it matches lo…

### DIFF
--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -290,7 +290,9 @@ export function getDestructuredMetadata(iiifResource) {
   return (iiifResource
     && iiifResource.getMetadata().map(labelValuePair => ({
       label: labelValuePair.getLabel(),
-      values: labelValuePair.getValues(),
+      values: labelValuePair.value
+        .filter(value => value.locale === labelValuePair.defaultLocale)
+        .map(value => value.value),
     }))
   );
 }


### PR DESCRIPTION
…cale)

@jbaiter perhaps this is a stop gap for us and provides us the flexibility without a new manifesto release?