### PR TITLE
Pass PluginComponents as targetProps to wrapped plugins

### DIFF
--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -33,7 +33,7 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
 
       return (
         <WrapPluginComponent
-          targetProps={passDownProps}
+          targetProps={{...passDownProps, PluginComponents }}
           {...passDownProps}
           PluginComponents={PluginComponents}
           TargetComponent={TargetComponent}


### PR DESCRIPTION
Fixes ProjectMirador/mirador#3281