### PR TITLE
Provide back an instance from initialization allowing adopters to safely unmount and remove all listeners

### DIFF
--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -9,6 +9,7 @@ describe('MiradorViewer', () => {
   let instance;
   beforeAll(() => {
     ReactDOM.render = jest.fn();
+    ReactDOM.unmountComponentAtNode = jest.fn();
     instance = new MiradorViewer({});
   });
   describe('constructor', () => {
@@ -101,6 +102,12 @@ describe('MiradorViewer', () => {
         bat: 'bar',
         foo: 'bar',
       }));
+    });
+  });
+  describe('unmount', () => {
+    it('unmounts via ReactDOM', () => {
+      instance.unmount();
+      expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -25,18 +25,12 @@ class MiradorViewer {
       || createStore(getReducersFromPlugins(this.plugins), getSagasFromPlugins(this.plugins));
     this.processConfig();
 
-    const viewer = {
-      store: this.store,
-    };
-
     ReactDOM.render(
       <Provider store={this.store}>
         <HotApp plugins={this.plugins} />
       </Provider>,
       document.getElementById(config.id),
     );
-
-    return viewer;
   }
 
   /**
@@ -48,6 +42,13 @@ class MiradorViewer {
         deepmerge(getConfigFromPlugins(this.plugins), this.config),
       ),
     );
+  }
+
+  /**
+   * Cleanup method to unmount Mirador from the dom
+   */
+  unmount() {
+    ReactDOM.unmountComponentAtNode(document.getElementById(this.config.id));
   }
 }
 


### PR DESCRIPTION
Fixes #3234
Fixes #3285

This will also cleanup injected styles from `withStyles` API from Material-UI. 