### PR TITLE
Constrain video height to window height

### DIFF
--- a/src/containers/VideoViewer.js
+++ b/src/containers/VideoViewer.js
@@ -22,6 +22,7 @@ const styles = () => ({
     width: '100%',
   },
   video: {
+    maxHeight: '100%',
     width: '100%',
   },
 });


### PR DESCRIPTION
Fixes #3295
Thanks @markmatney! Your suggestion was right on point.

## Before
<img width="1580" alt="wide video player with inaccessible controls" src="https://user-images.githubusercontent.com/5402927/96652948-d9c3c600-12ec-11eb-9957-5d2b02aabe9c.png">

## After
<img width="1189" alt="wide video player with controls visible" src="https://user-images.githubusercontent.com/5402927/96652965-e0ead400-12ec-11eb-8e17-f3437928ebef.png">

