### PR TITLE
Display multi seq on ui

### DIFF
--- a/__tests__/fixtures/version-2/multipleSequences.json
+++ b/__tests__/fixtures/version-2/multipleSequences.json
@@ -1,0 +1,1083 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/manifest.json",
+  "@type": "sc:Manifest",
+  "label": "Urn\u00e4sch, Gemeindearchiv Urn\u00e4sch, Fragment",
+  "metadata": [
+    {
+      "label": "Location",
+      "value": "Urn\u00e4sch"
+    },
+    {
+      "label": "Collection Name",
+      "value": "Gemeindearchiv Urn\u00e4sch"
+    },
+    {
+      "label": "Shelfmark",
+      "value": "Fragment"
+    },
+    {
+      "label": "Document Type",
+      "value": "Fragment"
+    },
+    {
+      "label": "DOI",
+      "value": "10.5076/e-codices-gau-Fragment"
+    },
+    {
+      "label": "Title (English)",
+      "value": "Psalterium iuxta Hebraeos (Fragment)"
+    },
+    {
+      "label": "Material",
+      "value": "Parchment"
+    },
+    {
+      "label": "Place of Origin (English)",
+      "value": "St. Gall"
+    },
+    {
+      "label": "Date of Origin (English)",
+      "value": "around 900 or 10th century"
+    },
+    {
+      "label": "Number of Pages",
+      "value": "2"
+    },
+    {
+      "label": "Dimensions",
+      "value": "21.6 x 37 cm (Fragm. 1), 21.7 x 20 cm (Fragm. 2)"
+    },
+    {
+      "label": "Online Since",
+      "value": "2015-10-08"
+    },
+    {
+      "label": "Summary (English)",
+      "value": "These are two well preserved fragments of a <i>Psalterium iuxta Hebraeos</i>, which were probably written in the 10th century at the monastery of St. Gall, following the model of <a href=\"http://www.e-codices.unifr.ch/en/list/one/csg/0019\">Cod. Sang. 19</a>. In 1963 both fragments were detached from a messenger bag; they are held in the town archive of Urn\u00e4sch (Appenzell Ausserrhoden)."
+    },
+    {
+      "label": "Century",
+      "value": "9th century"
+    },
+    {
+      "label": "Century",
+      "value": "10th century"
+    },
+    {
+      "label": "Liturgica christiana",
+      "value": "Bible"
+    },
+    {
+      "label": "Liturgica christiana",
+      "value": "Psalter"
+    },
+    {
+      "label": "Text Language",
+      "value": "Latin"
+    }
+  ],
+  "description": [
+    {
+      "@value": "These are two well preserved fragments of a Psalterium iuxta Hebraeos, which were probably written in the 10th century at the monastery of St. Gall, following the model of Cod. Sang. 19. In 1963 both fragments were detached from a messenger bag; they are held in the town archive of Urn\u00e4sch (Appenzell Ausserrhoden).",
+      "@language": "en"
+    }
+  ],
+  "license": "http://creativecommons.org/licenses/by-nc/4.0/",
+  "attribution": "e-codices - Virtual Manuscript Library of Switzerland",
+  "logo": "https://www.e-codices.ch/img/logo-for-iiif-manifest.png",
+  "service": [
+    {
+      "@context": "https://www.w3.org/ns/webmention",
+      "@id": "https://www.e-codices.unifr.ch/webmention/receive",
+      "profile": "https://www.w3.org/ns/webmention",
+      "label": "e-codices Webmention Service"
+    }
+  ],
+  "related": "https://www.e-codices.ch/en/list/one/gau/Fragment",
+  "within": "https://www.e-codices.ch/en/list/gau",
+  "seeAlso": [
+    {
+      "@id": "https://www.e-codices.unifr.ch/xml/tei_published/gau-Fragment_Solovey.xml",
+      "@format": "application/tei+xml"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/sequence/Sequence-1740.json",
+      "@type": "sc:Sequence",
+      "label": [
+        {
+          "@value": "Standard",
+          "@language": "de"
+        },
+        {
+          "@value": "Normal Sequence",
+          "@language": "en"
+        },
+        {
+          "@value": "S\u00e9quence normale",
+          "@language": "fr"
+        },
+        {
+          "@value": "Sequenza normale",
+          "@language": "it"
+        }
+      ],
+      "canvases": [
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001a.json",
+          "@type": "sc:Canvas",
+          "label": "fragm1a",
+          "height": 6132,
+          "width": 8176,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag001a.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001a.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001a.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 6132,
+                "width": 8176,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001a.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001b.json",
+          "@type": "sc:Canvas",
+          "label": "fragm1b",
+          "height": 6132,
+          "width": 8176,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag001b.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001b.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001b.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 6132,
+                "width": 8176,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001b.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002a.json",
+          "@type": "sc:Canvas",
+          "label": "fragm2a",
+          "height": 6132,
+          "width": 8176,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag002a.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002a.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002a.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 6132,
+                "width": 8176,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002a.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002b.json",
+          "@type": "sc:Canvas",
+          "label": "fragm2b",
+          "height": 6132,
+          "width": 8176,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag002b.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002b.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002b.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 6132,
+                "width": 8176,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002b.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat.json",
+          "@type": "sc:Canvas",
+          "label": "Casing",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat1.json",
+          "@type": "sc:Canvas",
+          "label": "Casing 1",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat1.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat1.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat1.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat1.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat2.json",
+          "@type": "sc:Canvas",
+          "label": "Casing 2",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat2.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat2.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat2.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat2.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat3.json",
+          "@type": "sc:Canvas",
+          "label": "Casing 3",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat3.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat3.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat3.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat3.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_MassSa.json",
+          "@type": "sc:Canvas",
+          "label": "Ruler on page",
+          "height": 6132,
+          "width": 8176,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_1_MassSa.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_MassSa.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_MassSa.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 6132,
+                "width": 8176,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_MassSa.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_ProfilSa.json",
+          "@type": "sc:Canvas",
+          "label": "QP card on page",
+          "height": 6132,
+          "width": 8176,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_1_ProfilSa.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_ProfilSa.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_ProfilSa.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 6132,
+                "width": 8176,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_ProfilSa.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_MassMat.json",
+          "@type": "sc:Canvas",
+          "label": "Ruler",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_MassMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_MassMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_MassMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_MassMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilMat.json",
+          "@type": "sc:Canvas",
+          "label": "Color profile",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_ProfilMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_ProfilMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilSG.json",
+          "@type": "sc:Canvas",
+          "label": "Digital Colorchecker",
+          "height": 6132,
+          "width": 8176,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_ProfilSG.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilSG.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilSG.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 6132,
+                "width": 8176,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilSG.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/sequence/Sequence-1741.json",
+      "@type": "sc:Sequence",
+      "label": [
+        {
+          "@value": "Lesefreundliche Sequenz",
+          "@language": "de"
+        },
+        {
+          "@value": "Reader-friendly Sequence",
+          "@language": "en"
+        },
+        {
+          "@value": "S\u00e9quence adapt\u00e9e pour la lecture",
+          "@language": "fr"
+        },
+        {
+          "@value": "Sequenza facilitata per la lettura",
+          "@language": "it"
+        }
+      ],
+      "canvases": [
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001a_1r.json",
+          "@type": "sc:Canvas",
+          "label": "fragm1a_1r",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag001a_1r.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001a_1r.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001a_1r.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001a_1r.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001b_1v.json",
+          "@type": "sc:Canvas",
+          "label": "fragm1b_1v",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag001b_1v.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001b_1v.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001b_1v.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001b_1v.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001b_2r.json",
+          "@type": "sc:Canvas",
+          "label": "fragm1b_2r",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag001b_2r.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001b_2r.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001b_2r.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001b_2r.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001a_2v.json",
+          "@type": "sc:Canvas",
+          "label": "fragm1a_2v",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag001a_2v.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag001a_2v.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001a_2v.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag001a_2v.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002a_1r.json",
+          "@type": "sc:Canvas",
+          "label": "fragm2a_1r",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag002a_1r.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002a_1r.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002a_1r.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002a_1r.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002b_1v.json",
+          "@type": "sc:Canvas",
+          "label": "fragm2b_1v",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag002b_1v.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002b_1v.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002b_1v.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002b_1v.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002b_2r.json",
+          "@type": "sc:Canvas",
+          "label": "fragm2b_2r",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag002b_2r.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002b_2r.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002b_2r.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002b_2r.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002a_2v.json",
+          "@type": "sc:Canvas",
+          "label": "fragm2a_2v",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_frag002a_2v.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_frag002a_2v.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002a_2v.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_frag002a_2v.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_MassS.json",
+          "@type": "sc:Canvas",
+          "label": "Ruler on page",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_1_MassS.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_MassS.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_MassS.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_MassS.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_ProfilS.json",
+          "@type": "sc:Canvas",
+          "label": "QP card on page",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_1_ProfilS.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_1_ProfilS.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_ProfilS.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_1_ProfilS.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_2_MassS.json",
+          "@type": "sc:Canvas",
+          "label": "Ruler on page a",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_2_MassS.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_2_MassS.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_2_MassS.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_2_MassS.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_2_ProfilS.json",
+          "@type": "sc:Canvas",
+          "label": "QP card on page a",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_2_ProfilS.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_2_ProfilS.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_2_ProfilS.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_2_ProfilS.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat.json",
+          "@type": "sc:Canvas",
+          "label": "Casing",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat1.json",
+          "@type": "sc:Canvas",
+          "label": "Casing 1",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat1.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat1.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_mat1.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_mat1.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_mat1.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_MassMat.json",
+          "@type": "sc:Canvas",
+          "label": "Ruler",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_MassMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_MassMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_MassMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_MassMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_MassMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilMat.json",
+          "@type": "sc:Canvas",
+          "label": "Color profile",
+          "height": 8176,
+          "width": 6132,
+          "images": [
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_ProfilMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            },
+            {
+              "@id": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/annotation/gau-Fragment_ProfilMat.json",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://www.e-codices.unifr.ch/metadata/iiif/gau-Fragment/canvas/gau-Fragment_ProfilMat.json",
+              "resource": {
+                "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2/full/full/0/default/jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 8176,
+                "width": 6132,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://www.e-codices.unifr.ch/loris/gau/gau-Fragment/gau-Fragment_ProfilMat.jp2",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": []
+}

--- a/__tests__/src/components/SidebarSequenceList.test.js
+++ b/__tests__/src/components/SidebarSequenceList.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Utils } from 'manifesto.js/dist-esmodule/Utils';
+import manifestJson from '../../fixtures/version-2/multipleSequences.json';
+import SidebarSequenceList from '../../../src/containers/SidebarSequenceList';
+
+/**
+ * Helper function to create a shallow wrapper around WindowSideBarCanvasPanel
+ */
+function createWrapper(props) {
+  const sequences = Utils.parseManifest(manifestJson).getSequences();
+
+  return shallow(
+    <SidebarSequenceList
+      id="asdf"
+      classes={{ listItem: 'x' }}
+      windowId="xyz"
+      sequences={sequences}
+      containerRef={{}}
+      {...props}
+    />,
+  );
+}
+
+describe('SidebarSequenceList', () => {
+  it('renders correct number of sequences on the sidebar', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.shallow().dive().find('div').length).toEqual(2);
+  });
+
+  it('renders the first sequence as open by default', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.shallow().dive().find('div').first()
+      .find('ExpandLessIcon')
+      .exists()).toBe(true);
+  });
+});

--- a/__tests__/src/components/WindowSideBarCanvasPanel.test.js
+++ b/__tests__/src/components/WindowSideBarCanvasPanel.test.js
@@ -4,6 +4,7 @@ import { Utils } from 'manifesto.js/dist-esmodule/Utils';
 import compact from 'lodash/compact';
 import { WindowSideBarCanvasPanel } from '../../../src/components/WindowSideBarCanvasPanel';
 import SidebarIndexList from '../../../src/containers/SidebarIndexList';
+import SidebarSequenceList from '../../../src/containers/SidebarSequenceList';
 import CompanionWindow from '../../../src/containers/CompanionWindow';
 import manifestJson from '../../fixtures/version-2/019.json';
 
@@ -12,6 +13,15 @@ import manifestJson from '../../fixtures/version-2/019.json';
  */
 function createWrapper(props) {
   const canvases = Utils.parseManifest(manifestJson).getSequences()[0].getCanvases();
+  const { multipleSequences } = props;
+  let sequences;
+
+  if (multipleSequences) {
+    sequences = [{ id: 'a', label: 'seq1' },
+      { id: 'b', label: 'seq2' }];
+  } else {
+    sequences = Utils.parseManifest(manifestJson).getSequences();
+  }
 
   return shallow(
     <WindowSideBarCanvasPanel
@@ -24,6 +34,7 @@ function createWrapper(props) {
       config={{ canvasNavigation: { height: 100 } }}
       updateVariant={() => {}}
       selectedCanvases={[canvases[1]]}
+      sequences={sequences}
       variant="item"
       {...props}
     />,
@@ -32,13 +43,13 @@ function createWrapper(props) {
 
 describe('WindowSideBarCanvasPanel', () => {
   it('renders SidebarIndexList', () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ multipleSequences: false });
     expect(wrapper.find(CompanionWindow).props().title).toBe('canvasIndex');
     expect(wrapper.find(SidebarIndexList).length).toBe(1);
   });
 
   it('without a treeStructure will not render the table of contents tab', () => {
-    const wrapper = createWrapper();
+    const wrapper = createWrapper({ multipleSequences: false });
     expect(
       compact(wrapper.find(CompanionWindow).props().titleControls.props.children)
         .length,
@@ -48,9 +59,21 @@ describe('WindowSideBarCanvasPanel', () => {
   describe('handleVariantChange', () => {
     it('updates the variant', () => {
       const updateVariant = jest.fn();
-      const wrapper = createWrapper({ updateVariant });
+      const wrapper = createWrapper({ multipleSequences: false, updateVariant });
       wrapper.instance().handleVariantChange({}, 'item');
       expect(updateVariant).toHaveBeenCalledWith('item');
+    });
+  });
+
+  describe('MultipleSequencesDisplay', () => {
+    it('renders canvases (SidebarIndexList) in sidebar when manifest contains one sequence', () => {
+      const wrapper = createWrapper({ multipleSequences: false });
+      expect(wrapper.exists(SidebarIndexList)).toBe(true);
+    });
+
+    it('renders sequence list in sidebar when manifest contains multiple sequences', () => {
+      const wrapper = createWrapper({ multipleSequences: true });
+      expect(wrapper.exists(SidebarSequenceList)).toBe(true);
     });
   });
 });

--- a/src/components/SidebarIndexList.js
+++ b/src/components/SidebarIndexList.js
@@ -9,6 +9,12 @@ import SidebarIndexThumbnail from '../containers/SidebarIndexThumbnail';
 
 /** */
 export class SidebarIndexList extends Component {
+  /** */
+  constructor(props) {
+    super(props);
+    this.state = { prevSequenceId: '' };
+  }
+
   /** @private */
   getIdAndLabelOfCanvases() {
     const { canvases } = this.props;
@@ -19,10 +25,20 @@ export class SidebarIndexList extends Component {
     }));
   }
 
+  /** @private */
+  updateCurrentSequence(sequenceId) {
+    const { updateSequence } = this.props;
+
+    updateSequence(sequenceId);
+    this.setState({ prevSequenceId: sequenceId });
+  }
+
   /** */
   render() {
     const {
       canvases,
+      sequence,
+      sequences,
       classes,
       containerRef,
       selectedCanvasIds,
@@ -30,6 +46,8 @@ export class SidebarIndexList extends Component {
       variant,
       windowId,
     } = this.props;
+
+    const { prevSequenceId } = this.state;
 
     const canvasesIdAndLabel = this.getIdAndLabelOfCanvases(canvases);
     let Item;
@@ -46,7 +64,12 @@ export class SidebarIndexList extends Component {
       <MenuList variant="selectedMenu">
         {
           canvasesIdAndLabel.map((canvas, canvasIndex) => {
-            const onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
+            let onClick;
+            if (sequences && sequences.length > 1 && prevSequenceId !== sequence.id) {
+              onClick = () => { this.updateCurrentSequence(sequence.id); setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
+            } else {
+              onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
+            }
 
             return (
               <MenuItem
@@ -78,9 +101,12 @@ export class SidebarIndexList extends Component {
 SidebarIndexList.propTypes = {
   canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
-  containerRef: PropTypes.oneOf([PropTypes.func, PropTypes.object]).isRequired,
+  containerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
   selectedCanvasIds: PropTypes.arrayOf(PropTypes.string),
+  sequence: PropTypes.shape({ id: PropTypes.string }).isRequired,
+  sequences: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   setCanvas: PropTypes.func.isRequired,
+  updateSequence: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(['item', 'thumbnail']),
   windowId: PropTypes.string.isRequired,
 };

--- a/src/components/SidebarSequenceItem.js
+++ b/src/components/SidebarSequenceItem.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import classNames from 'classnames';
+
+/** */
+export class SidebarSequenceItem extends Component {
+  /** */
+  render() {
+    const {
+      sequence,
+    } = this.props;
+
+    /** */
+    return (
+      <>
+        <Typography
+          className={classNames(sequence.label)}
+          variant="body1"
+        >
+          {sequence.label}
+        </Typography>
+      </>
+    );
+  }
+}
+
+SidebarSequenceItem.propTypes = {
+  sequence: PropTypes.objectOf(PropTypes.any).isRequired,
+};

--- a/src/components/SidebarSequenceList.js
+++ b/src/components/SidebarSequenceList.js
@@ -1,0 +1,126 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import MenuList from '@material-ui/core/MenuList';
+import MenuItem from '@material-ui/core/MenuItem';
+import ArrowDropDownCircle from '@material-ui/icons/ArrowDropDownCircle';
+import Divider from '@material-ui/core/Divider';
+import Collapse from '@material-ui/core/Collapse';
+import IconExpandLess from '@material-ui/icons/ExpandLess';
+import IconExpandMore from '@material-ui/icons/ExpandMore';
+import SidebarIndexList from '../containers/SidebarIndexList';
+import SidebarSequenceItem from '../containers/SidebarSequenceItem';
+
+/** */
+export class SidebarSequenceList extends Component {
+  /** */
+  constructor(props) {
+    super(props);
+
+    const open = {};
+    props.sequences.forEach((sequence, i) => {
+      if (i === 0) {
+        open[sequence.id] = true;
+      } else {
+        open[sequence.id] = false;
+      }
+    });
+
+    this.state = { open };
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  /** @private */
+  getIdAndLabelOfSequences() {
+    const { sequences } = this.props;
+
+    return sequences.map((sequence, index) => ({
+      id: sequence.id,
+      label: (sequence.getLabel
+        && sequence.getLabel().length > 0)
+        ? sequence.getLabel()[0].value
+        : sequence.id,
+    }));
+  }
+
+  /** @private */
+  handleClick(sequenceId) {
+    const { open } = this.state;
+    open[sequenceId] = !open[sequenceId];
+    Object.keys(open).forEach((sequence) => {
+      if (sequence !== sequenceId) {
+        open[sequence] = false;
+      }
+    });
+
+    this.setState({ open });
+  }
+
+  /** */
+  render() {
+    const {
+      containerRef,
+      sequences,
+      id,
+      t,
+      classes,
+      windowId,
+    } = this.props;
+
+    const { open } = this.state;
+
+    const sequencesIdAndLabel = this.getIdAndLabelOfSequences(sequences);
+    const Item = SidebarSequenceItem;
+
+    /** */
+    return (
+      <MenuList variant="selectedMenu" disablePadding>
+        {
+          sequencesIdAndLabel.map((sequence, sequenceIndex) => {
+            /** */
+            const onClick = () => this.handleClick(sequence.id);
+
+            /** */
+            return (
+              <div key={sequence.id}>
+                <MenuItem
+                  className={classes.listItem}
+                  righticon={<ArrowDropDownCircle />}
+                  alignItems="flex-start"
+                  onClick={onClick}
+                  button
+                  component="li"
+                >
+                  <Item sequence={sequence} otherSequence={sequences[sequenceIndex]} />
+                  {open[sequence.id] ? <IconExpandLess /> : <IconExpandMore />}
+                </MenuItem>
+                <Collapse in={open[sequence.id]} timeout="auto" unmountOnExit>
+                  <Divider />
+                  <SidebarIndexList
+                    id={id}
+                    t={t}
+                    sequence={sequences[sequenceIndex]}
+                    containerRef={containerRef}
+                    windowId={windowId}
+                  />
+                </Collapse>
+              </div>
+            );
+          })
+        }
+      </MenuList>
+    );
+  }
+}
+
+SidebarSequenceList.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  containerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
+  id: PropTypes.string.isRequired,
+  sequences: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  t: PropTypes.func,
+  windowId: PropTypes.string.isRequired,
+};
+
+SidebarSequenceList.defaultProps = {
+  t: () => {},
+};

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -13,16 +13,14 @@ import ArrowForwardIcon from '@material-ui/icons/ArrowForwardSharp';
 import CompanionWindow from '../containers/CompanionWindow';
 import SidebarIndexList from '../containers/SidebarIndexList';
 import SidebarIndexTableOfContents from '../containers/SidebarIndexTableOfContents';
+import SidebarSequenceList from '../containers/SidebarSequenceList';
 
-/**
- * a panel showing the canvases for a given manifest
- */
+/** */
 export class WindowSideBarCanvasPanel extends Component {
   /** */
   constructor(props) {
     super(props);
     this.handleVariantChange = this.handleVariantChange.bind(this);
-
     this.containerRef = React.createRef();
   }
 
@@ -53,12 +51,12 @@ export class WindowSideBarCanvasPanel extends Component {
       showMultipart,
       t,
       variant,
+      sequences,
       showToc,
       windowId,
     } = this.props;
 
     let listComponent;
-
     if (variant === 'tableOfContents') {
       listComponent = (
         <SidebarIndexTableOfContents
@@ -67,12 +65,25 @@ export class WindowSideBarCanvasPanel extends Component {
           windowId={windowId}
         />
       );
+    } else if (sequences && sequences.length > 1) {
+      listComponent = (
+        <SidebarSequenceList
+          id={id}
+          t={t}
+          containerRef={this.containerRef}
+          windowId={windowId}
+          variant={variant}
+          sequences={sequences}
+        />
+      );
     } else {
       listComponent = (
         <SidebarIndexList
           id={id}
+          t={t}
           containerRef={this.containerRef}
           windowId={windowId}
+          sequence={sequences[0]}
         />
       );
     }
@@ -94,13 +105,14 @@ export class WindowSideBarCanvasPanel extends Component {
               {showToc && (
                 <Tooltip title={t('tableOfContentsList')} value="tableOfContents"><Tab className={classes.variantTab} value="tableOfContents" aria-label={t('tableOfContentsList')} aria-controls={`tab-panel-${id}`} icon={<TocIcon style={{ transform: 'scale(-1, 1)' }} />} /></Tooltip>
               )}
+
               <Tooltip title={t('itemList')} value="item"><Tab className={classes.variantTab} value="item" aria-label={t('itemList')} aria-controls={`tab-panel-${id}`} icon={<ItemListIcon />} /></Tooltip>
               <Tooltip title={t('thumbnailList')} value="thumbnail"><Tab className={classes.variantTab} value="thumbnail" aria-label={t('thumbnailList')} aria-controls={`tab-panel-${id}`} icon={<ThumbnailListIcon />} /></Tooltip>
             </Tabs>
           )}
         >
           <div id={`tab-panel-${id}`}>
-            { collection && (
+            {collection && (
               <Button
                 fullWidth
                 onClick={showMultipart}
@@ -123,6 +135,7 @@ WindowSideBarCanvasPanel.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   collection: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   id: PropTypes.string.isRequired,
+  sequences: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   showMultipart: PropTypes.func.isRequired,
   showToc: PropTypes.bool,
   t: PropTypes.func.isRequired,

--- a/src/containers/SidebarIndexList.js
+++ b/src/containers/SidebarIndexList.js
@@ -6,7 +6,8 @@ import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
 import {
   getCompanionWindow,
-  getCanvases,
+  getSequences,
+  getSequenceCanvases,
   getVisibleCanvasIds,
 } from '../state/selectors';
 import { SidebarIndexList } from '../components/SidebarIndexList';
@@ -14,9 +15,10 @@ import { SidebarIndexList } from '../components/SidebarIndexList';
 /**
  * mapStateToProps - to hook up connect
  */
-const mapStateToProps = (state, { id, windowId }) => ({
-  canvases: getCanvases(state, { windowId }),
+const mapStateToProps = (state, { id, sequence, windowId }) => ({
+  canvases: getSequenceCanvases(state, { sequence, windowId }),
   selectedCanvasIds: getVisibleCanvasIds(state, { windowId }),
+  sequences: getSequences(state, { windowId }),
   variant: getCompanionWindow(state, { companionWindowId: id, windowId }).variant,
 });
 
@@ -27,6 +29,9 @@ const mapStateToProps = (state, { id, windowId }) => ({
  */
 const mapDispatchToProps = (dispatch, { id, windowId }) => ({
   setCanvas: (...args) => dispatch(actions.setCanvas(...args)),
+  updateSequence: (sequenceId) => dispatch(
+    actions.updateWindow(windowId, { sequenceId }),
+  ),
 });
 
 /**

--- a/src/containers/SidebarSequenceItem.js
+++ b/src/containers/SidebarSequenceItem.js
@@ -1,7 +1,6 @@
 import { compose } from 'redux';
-import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import withStyles from '@material-ui/core/styles/withStyles';
+import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { SidebarSequenceItem } from '../components/SidebarSequenceItem';
 
@@ -23,7 +22,6 @@ const styles = (theme) => ({
 const enhance = compose(
   withStyles(styles),
   withTranslation(),
-  connect(null, null),
   withPlugins('SidebarSequenceItem'),
 );
 

--- a/src/containers/SidebarSequenceItem.js
+++ b/src/containers/SidebarSequenceItem.js
@@ -1,0 +1,30 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import withStyles from '@material-ui/core/styles/withStyles';
+import { withPlugins } from '../extend/withPlugins';
+import { SidebarSequenceItem } from '../components/SidebarSequenceItem';
+
+/**
+ * mapStateToProps - used to hook up state to props
+ * @memberof SidebarSequenceItem
+ * @private
+ */
+
+/**
+ * Styles for withStyles HOC
+ */
+const styles = (theme) => ({
+  label: {
+    paddingLeft: theme.spacing(1),
+  },
+});
+
+const enhance = compose(
+  withStyles(styles),
+  withTranslation(),
+  connect(null, null),
+  withPlugins('SidebarSequenceItem'),
+);
+
+export default enhance(SidebarSequenceItem);

--- a/src/containers/SidebarSequenceList.js
+++ b/src/containers/SidebarSequenceList.js
@@ -1,7 +1,6 @@
 import { compose } from 'redux';
-import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import withStyles from '@material-ui/core/styles/withStyles';
+import { withStyles } from '@material-ui/core/styles';
 import { withPlugins } from '../extend/withPlugins';
 import { SidebarSequenceList } from '../components/SidebarSequenceList';
 
@@ -28,7 +27,6 @@ const styles = (theme) => ({
 const enhance = compose(
   withStyles(styles),
   withTranslation(),
-  connect(null, null),
   withPlugins('SidebarSequenceList'),
 );
 

--- a/src/containers/SidebarSequenceList.js
+++ b/src/containers/SidebarSequenceList.js
@@ -1,0 +1,35 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslation } from 'react-i18next';
+import withStyles from '@material-ui/core/styles/withStyles';
+import { withPlugins } from '../extend/withPlugins';
+import { SidebarSequenceList } from '../components/SidebarSequenceList';
+
+/**
+ * mapStateToProps - used to hook up state to props
+ * @memberof SidebarSequenceList
+ * @private
+ */
+
+/**
+ * Styles for withStyles HOC
+ */
+const styles = (theme) => ({
+  label: {
+    paddingLeft: theme.spacing(1),
+  },
+  listItem: {
+    borderBottom: `0.5px solid ${theme.palette.divider}`,
+    paddingRight: theme.spacing(1),
+    width: '100%',
+  },
+});
+
+const enhance = compose(
+  withStyles(styles),
+  withTranslation(),
+  connect(null, null),
+  withPlugins('SidebarSequenceList'),
+);
+
+export default enhance(SidebarSequenceList);

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -9,6 +9,7 @@ import {
   getCompanionWindow,
   getDefaultSidebarVariant,
   getSequenceTreeStructure,
+  getSequences,
   getWindow,
   getManifestoInstance,
 } from '../state/selectors';
@@ -23,9 +24,12 @@ const mapStateToProps = (state, { id, windowId }) => {
   const companionWindow = getCompanionWindow(state, { companionWindowId: id });
   const collectionPath = window.collectionPath || [];
   const collectionId = collectionPath && collectionPath[collectionPath.length - 1];
+  const sequences = getSequences(state, { windowId });
+
   return {
     collection: collectionId && getManifestoInstance(state, { manifestId: collectionId }),
     config,
+    sequences,
     showToc: treeStructure && treeStructure.nodes && treeStructure.nodes.length > 0,
     variant: companionWindow.variant
       || getDefaultSidebarVariant(state, { windowId }),

--- a/src/state/selectors/sequences.js
+++ b/src/state/selectors/sequences.js
@@ -50,6 +50,13 @@ export const getSequence = createSelector(
   },
 );
 
+export const getSequenceCanvases = createSelector(
+  [
+    (state, { sequence }) => sequence,
+  ],
+  sequence => (sequence && sequence.getCanvases()) || [],
+);
+
 /** Return the canvas index for a certain window.
 * @param {object} state
 * @param {String} windowId


### PR DESCRIPTION
Adds multi seq UI display for https://github.com/ProjectMirador/mirador/issues/2949
  - Shows sequences as collapsible buttons in sidebar
Updates sequences selector in master by adding getSequenceCanvases selector

Before

<img width="1440" alt="Before" src="https://user-images.githubusercontent.com/12305084/96768809-4651ca00-13ac-11eb-8e33-b272846d55e8.png">

After UI update

<img width="1440" alt="After_1" src="https://user-images.githubusercontent.com/12305084/96768866-579ad680-13ac-11eb-97f0-98c269cb2702.png">
<img width="1440" alt="After_2" src="https://user-images.githubusercontent.com/12305084/96768871-58cc0380-13ac-11eb-9718-5aec1162623f.png">
<img width="1440" alt="After_3" src="https://user-images.githubusercontent.com/12305084/96768873-59649a00-13ac-11eb-915a-0ac8e3082f3a.png">
