### PR TITLE
Remove topranges from multi sequence selection fixes #3335

### DIFF
--- a/__tests__/src/selectors/sequences.test.js
+++ b/__tests__/src/selectors/sequences.test.js
@@ -34,8 +34,8 @@ describe('getSequences', () => {
     };
     const state = { manifests: { x: { json: manifest } } };
     const sequences = getSequences(state, { manifestId: 'x' });
-    expect(sequences.length).toEqual(3);
-    expect(sequences.map(s => s.id)).toEqual(['https://iiif.bodleian.ox.ac.uk/iiif/sequence/9cca8fdd-4a61-4429-8ac1-f648764b4d6d_default.json', 'a', 'b']);
+    expect(sequences.length).toEqual(1);
+    expect(sequences.map(s => s.id)).toEqual(['https://iiif.bodleian.ox.ac.uk/iiif/sequence/9cca8fdd-4a61-4429-8ac1-f648764b4d6d_default.json']);
   });
   describe('with a v3 manifest', () => {
     const manifest = {

--- a/src/containers/WindowSideBarCanvasPanel.js
+++ b/src/containers/WindowSideBarCanvasPanel.js
@@ -25,10 +25,11 @@ const mapStateToProps = (state, { id, windowId }) => {
   const companionWindow = getCompanionWindow(state, { companionWindowId: id });
   const collectionPath = window.collectionPath || [];
   const collectionId = collectionPath && collectionPath[collectionPath.length - 1];
+  const sequence = getSequence(state, { windowId });
   return {
     collection: collectionId && getManifestoInstance(state, { manifestId: collectionId }),
     config,
-    sequenceId: getSequence(state, { windowId }).id,
+    sequenceId: sequence && sequence.id,
     sequences: getSequences(state, { windowId }),
     showToc: treeStructure && treeStructure.nodes && treeStructure.nodes.length > 0,
     variant: companionWindow.variant || getDefaultSidebarVariant(state, { windowId }),

--- a/src/state/selectors/sequences.js
+++ b/src/state/selectors/sequences.js
@@ -21,8 +21,6 @@ export const getSequences = createSelector(
     const sequences = [].concat(
       // v2: multi-sequence manifests, or v3: items
       manifest.getSequences(),
-      // v2: top ranges
-      v2TopRanges,
       // v3: all top-level ranges with behavior=sequence
       v3RangeSequences,
     );


### PR DESCRIPTION
While we could add back support in the future, removing topranges to resolve issues w/ display of things like https://iiif.bodleian.ox.ac.uk/iiif/manifest/390fd0e8-9eae-475d-9564-ed916ab9035c.json