### PR TITLE
Adds setting to remove ThumbnailNavigation from WindowTopMenu

### DIFF
--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -27,7 +27,8 @@ export class WindowTopMenu extends Component {
    */
   render() {
     const {
-      containerId, handleClose, anchorEl, toggleDraggingEnabled, windowId,
+      containerId, handleClose, anchorEl, showThumbnailNavigationSettings,
+      toggleDraggingEnabled, windowId,
     } = this.props;
 
     return (
@@ -51,7 +52,8 @@ export class WindowTopMenu extends Component {
         orientation="horizontal"
       >
         <WindowViewSettings windowId={windowId} handleClose={handleClose} />
-        <WindowThumbnailSettings windowId={windowId} handleClose={handleClose} />
+        {showThumbnailNavigationSettings
+          && <WindowThumbnailSettings windowId={windowId} handleClose={handleClose} />}
         <PluginHookWithHeader {...this.props} />
       </Menu>
     );
@@ -62,10 +64,12 @@ WindowTopMenu.propTypes = {
   anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   containerId: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
+  showThumbnailNavigationSettings: PropTypes.bool,
   toggleDraggingEnabled: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
 };
 
 WindowTopMenu.defaultProps = {
   anchorEl: null,
+  showThumbnailNavigationSettings: true,
 };

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -297,6 +297,7 @@ export default {
   ],
   thumbnailNavigation: {
     defaultPosition: 'off', // Which position for the thumbnail navigation to be be displayed. Other possible values are "far-bottom" or "far-right"
+    displaySettings: true, // Display the settings for this in WindowTopMenu
     height: 130, // height of entire ThumbnailNavigation area when position is "far-bottom"
     width: 100, // width of one canvas (doubled for book view) in ThumbnailNavigation area when position is "far-right"
   },

--- a/src/containers/WindowTopMenu.js
+++ b/src/containers/WindowTopMenu.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
 import { WindowTopMenu } from '../components/WindowTopMenu';
-import { getContainerId } from '../state/selectors';
+import { getConfig, getContainerId } from '../state/selectors';
 
 /**
  * mapStateToProps - to hook up connect
@@ -13,6 +13,7 @@ import { getContainerId } from '../state/selectors';
  */
 const mapStateToProps = state => ({
   containerId: getContainerId(state),
+  showThumbnailNavigationSettings: getConfig(state).thumbnailNavigation.displaySettings,
 });
 
 /**


### PR DESCRIPTION
fixes #3312
![Screen Shot 2020-11-06 at 1 07 12 PM](https://user-images.githubusercontent.com/1656824/98410060-2fa8a580-2031-11eb-853c-20df8cdb0ec3.png)
