### PR TITLE
Fix clearing of search input

### DIFF
--- a/src/components/SearchPanelControls.js
+++ b/src/components/SearchPanelControls.js
@@ -41,12 +41,12 @@ export class SearchPanelControls extends Component {
 
   /** */
   handleChange(event, value, reason) {
-    if (value) {
-      this.setState({
-        search: value,
-        suggestions: [],
-      });
+    this.setState({
+      search: value,
+      suggestions: [],
+    });
 
+    if (value) {
       this.fetchAutocomplete(value);
     }
   }


### PR DESCRIPTION
At the moment, it's not possible to clear the search input:
![Bildschirmfoto_2020-11-13_13-52-05](https://user-images.githubusercontent.com/19190936/99074138-7eb58400-25b7-11eb-85da-4329fd12daa8.png)
This misbehaviour is related to this commit: https://github.com/ProjectMirador/mirador/commit/f4cb8dbaf29db1032ab29b47d5f5d6212245f21d - an empty string is always evaluated as `false`.