### PR TITLE
More safely navigate deep destructuring of config.auth

### DIFF
--- a/src/state/sagas/auth.js
+++ b/src/state/sagas/auth.js
@@ -73,7 +73,7 @@ export function* refetchInfoResponses({ serviceId }) {
 /** try to start any non-interactive auth flows */
 export function* doAuthWorkflow({ infoJson, windowId }) {
   const auths = yield select(getAuth);
-  const { auth: { serviceProfiles } } = yield select(getConfig);
+  const { auth: { serviceProfiles = [] } = {} } = yield select(getConfig);
   const nonInteractiveAuthFlowProfiles = serviceProfiles.filter(p => p.external || p.kiosk);
 
   // try to get an untried, non-interactive auth service

--- a/src/state/selectors/auth.js
+++ b/src/state/selectors/auth.js
@@ -10,7 +10,7 @@ export const getAuthProfiles = createSelector(
   [
     getConfig,
   ],
-  ({ auth: { serviceProfiles = [] } }) => serviceProfiles,
+  ({ auth: { serviceProfiles = [] } = {} }) => serviceProfiles,
 );
 
 /** */


### PR DESCRIPTION
Fixes an issue where an import might fail if `auth` part of config is not present. 

```javascript
const t1 = { auth: { serviceProfiles: [1, 2, 3]}}
const t2 = { auth: {}}
const t3 = {}

var { auth: { serviceProfiles = [] } = {}} = t1;
console.log(serviceProfiles);
var { auth: { serviceProfiles = [] } = {}} = t3;
console.log(serviceProfiles);
var { auth: { serviceProfiles = [] } = {}} = t3;
console.log(serviceProfiles);
```

I **think** this is how to do it 🤷 