### PR TITLE
Fixes for Content Search panel

### DIFF
--- a/src/components/SearchPanelControls.js
+++ b/src/components/SearchPanelControls.js
@@ -2,12 +2,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import deburr from 'lodash/deburr';
 import debounce from 'lodash/debounce';
+import isObject from 'lodash/isObject';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import TextField from '@material-ui/core/TextField';
 import SearchIcon from '@material-ui/icons/SearchSharp';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 import SearchPanelNavigation from '../containers/SearchPanelNavigation';
+
+/** Sometimes an autocomplete match can be a simple string, other times an object
+    with a `match` property, this function abstracts that away */
+const getMatch = (option) => (isObject(option) ? option.match : option);
 
 /** */
 export class SearchPanelControls extends Component {
@@ -25,8 +30,7 @@ export class SearchPanelControls extends Component {
   }
 
   /**
-   * Set the component's local search state
-   * to blank when the query has been cleared
+   * Update the query in the component state if the query has changed in the redux store
    */
   componentDidUpdate(prevProps) {
     const { query } = this.props;
@@ -98,8 +102,8 @@ export class SearchPanelControls extends Component {
 
   /** */
   selectItem(_event, selectedItem, _reason) {
-    if (selectedItem && selectedItem.match) {
-      this.setState({ search: selectedItem.match }, this.submitSearch);
+    if (selectedItem && getMatch(selectedItem)) {
+      this.setState({ search: getMatch(selectedItem) }, this.submitSearch);
     }
   }
 
@@ -118,15 +122,15 @@ export class SearchPanelControls extends Component {
             id={id}
             inputValue={search}
             options={suggestions}
-            getOptionLabel={option => option.match}
+            getOptionLabel={getMatch}
             getOptionSelected={(option, value) => (
-              deburr(option.match.trim()).toLowerCase()
-                === deburr(value.match.trim()).toLowerCase()
+              deburr(getMatch(option).trim()).toLowerCase()
+                === deburr(getMatch(value).trim()).toLowerCase()
             )}
             noOptionsText=""
             onChange={this.selectItem}
             onInputChange={this.handleChange}
-            freeSolo={true}
+            freeSolo
             renderInput={params => (
               <TextField
                 {...params}

--- a/src/components/SearchPanelControls.js
+++ b/src/components/SearchPanelControls.js
@@ -41,6 +41,11 @@ export class SearchPanelControls extends Component {
 
   /** */
   handleChange(event, value, reason) {
+    // For some reason the value gets reset to an empty value from the
+    // useAutocomplete hook sometimes, we just ignore these cases
+    if (reason === 'reset' && !value) {
+      return;
+    }
     this.setState({
       search: value,
       suggestions: [],
@@ -121,6 +126,7 @@ export class SearchPanelControls extends Component {
             noOptionsText=""
             onChange={this.selectItem}
             onInputChange={this.handleChange}
+            freeSolo={true}
             renderInput={params => (
               <TextField
                 {...params}


### PR DESCRIPTION
## Fix undesired resets of content search query
Previously, this would happen anytime the input was blurred (fixed by setting the `freeSolo` prop) and for some reason after a re-render, triggered by the `useAutocomplete` hook in MUI (fixed by ignoring
updates with an empty value and a 'reset' reason).

<details>
<summary>Before</summary>

![contentsearch_before](https://user-images.githubusercontent.com/608610/100354616-b4fbf600-2ff0-11eb-90d4-d12b5b18d6f8.gif)
</details>

<details>
<summary>After</summary>

![contentsearch_after](https://user-images.githubusercontent.com/608610/100354635-baf1d700-2ff0-11eb-9248-5bfd3d155696.gif)
</details>

## Fix crashes in content search autocomplete code

I noticed during debugging that autocomplete occassionally crashed when hitting `Enter` in the search input box without selecting an autocomplete option. The reason for this were several functions that expected an object with a `match` property, but would receive a simple `string` in these cases.
I worked around this with a new `getMatch` utility function that handles these cases.