### PR TITLE
Draft: Fix fragment rendering on scaled canvases in bookview

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.js
+++ b/__tests__/src/components/AnnotationsOverlay.test.js
@@ -183,7 +183,10 @@ describe('AnnotationsOverlay', () => {
       const context = wrapper.instance().osdCanvasOverlay.context2d;
       expect(context.strokeStyle).toEqual('yellow');
       expect(context.lineWidth).toEqual(20);
-      expect(strokeRect).toHaveBeenCalledWith(10, 10, 100, 200);
+      expect(strokeRect.mock.calls[0][0]).toBeCloseTo(24.561);
+      expect(strokeRect.mock.calls[0][1]).toBeCloseTo(24.561);
+      expect(strokeRect.mock.calls[0][2]).toBeCloseTo(245.61);
+      expect(strokeRect.mock.calls[0][3]).toBeCloseTo(491.22);
     });
   });
 

--- a/src/components/AnnotationsOverlay.js
+++ b/src/components/AnnotationsOverlay.js
@@ -345,6 +345,7 @@ export class AnnotationsOverlay extends Component {
       annotation.resources.forEach((resource) => {
         if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
         const offset = canvasWorld.offsetByCanvas(resource.targetId);
+        const scaleFactor = canvasWorld.scaleByCanvas(resource.targetId);
         const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
           hovered: hoveredAnnotationIds.includes(resource.id),
           offset,
@@ -356,6 +357,7 @@ export class AnnotationsOverlay extends Component {
             },
           },
           resource,
+          scaleFactor,
           selected: selectedAnnotationId === resource.id,
           zoomRatio,
         });

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -5,7 +5,7 @@
 export default class CanvasAnnotationDisplay {
   /** */
   constructor({
-    resource, palette, zoomRatio, offset, selected, hovered,
+    resource, palette, zoomRatio, offset, selected, hovered, scaleFactor,
   }) {
     this.resource = resource;
     this.palette = palette;
@@ -13,6 +13,7 @@ export default class CanvasAnnotationDisplay {
     this.offset = offset;
     this.selected = selected;
     this.hovered = hovered;
+    this.scaleFactor = scaleFactor;
   }
 
   /** */
@@ -104,9 +105,12 @@ export default class CanvasAnnotationDisplay {
 
   /** */
   fragmentContext() {
-    const fragment = this.resource.fragmentSelector;
+    let fragment = this.resource.fragmentSelector;
     fragment[0] += this.offset.x;
     fragment[1] += this.offset.y;
+    if (this.scaleFactor && this.scaleFactor !== 1) {
+      fragment = fragment.map(x => x * this.scaleFactor);
+    }
 
     let currentPalette;
     if (this.selected) {

--- a/src/lib/CanvasWorld.js
+++ b/src/lib/CanvasWorld.js
@@ -28,9 +28,15 @@ export default class CanvasWorld {
     }
 
     const [dirX, dirY] = this.canvasDirection;
+    // Smallest dimension in the given direction
     const scale = dirY === 0
       ? Math.min(...this.canvases.map(c => c.getHeight()))
       : Math.min(...this.canvases.map(c => c.getWidth()));
+    // Largest dimension in the given direction
+    const upScale = dirY === 0
+      ? Math.max(...this.canvases.map(c => c.getHeight()))
+      : Math.max(...this.canvases.map(c => c.getWidth()));
+
     let incX = 0;
     let incY = 0;
 
@@ -38,15 +44,20 @@ export default class CanvasWorld {
       let canvasHeight = 0;
       let canvasWidth = 0;
 
+      // Factor to scale elements on the canvas by to give the
+      // world position
+      let worldScale = 1;
       if (!isNaN(canvas.aspectRatio)) {
         if (dirY === 0) {
           // constant height
           canvasHeight = scale;
           canvasWidth = Math.floor(scale * canvas.aspectRatio);
+          worldScale = upScale / canvas.getHeight();
         } else {
           // constant width
           canvasWidth = scale;
           canvasHeight = Math.floor(scale * (1 / canvas.aspectRatio));
+          worldScale = upScale / canvas.getWidth();
         }
       }
 
@@ -54,6 +65,7 @@ export default class CanvasWorld {
         canvas,
         height: canvasHeight,
         width: canvasWidth,
+        worldScale,
         x: incX,
         y: incY,
       });
@@ -196,6 +208,15 @@ export default class CanvasWorld {
       x: coordinates[0],
       y: coordinates[1],
     };
+  }
+
+  /** scaleByCanvas - Get the scaling factor for the given canvas.
+   *  For a given element on the canvas, multiplying its offset coordinates
+   *  (i.e. [elemenX + canvasX, elemY + canvasY, elemWidth, elemHeight]) by
+   *  this factor returns the coordinates of the element in the world
+   */
+  scaleByCanvas(canvasTarget) {
+    return this.canvasDimensions.find(c => c.canvas.id === canvasTarget).worldScale;
   }
 
   /**


### PR DESCRIPTION
Previously, when one of the two canvases was scaled in book-view, the search annotations on this canvas would not match the page image.
This PR fixes this by passing a scaling factor from `CanvasWorld` to `CanvasAnnotationDisplay`, multiplication with which fixes the offset fragment so it matches the rendered canvas image.

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/608610/100461185-b698ed00-30c8-11eb-8852-9eda65535d0e.png)
</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/608610/100461297-e47e3180-30c8-11eb-9951-7a3ab057435f.png)
</details>

Unfortunately the test manifest with the content search service is not public (yet), so I can't add it to the integration test suite :-/

To be honest, I'm not completely confident that this change is the best way to fix this behavior, since I have not yet completely understood how the scaling in bookview relates to the annotation overlay, but this seems to fix it in the cases I tested. If there's a better way to do this, let me know and I'll implement it :-)

-- Edit: **Don't merge yet,** I just found a case where this fix doesn't work, investigating...