### PR TITLE
Enhance configuration settings so that a window can specify the sideb…

### DIFF
--- a/__tests__/src/actions/window.test.js
+++ b/__tests__/src/actions/window.test.js
@@ -152,6 +152,31 @@ describe('window actions', () => {
       expect(action.companionWindows[0]).toMatchObject({ content: 'thumbnailNavigation' });
     });
 
+    it('enables a window to override the panel being displayed', () => {
+      const options = {
+        id: 'helloworld',
+        sideBarPanel: 'canvas',
+      };
+      const mockState = {
+        companionWindows: {},
+        config: {
+          thumbnailNavigation: {},
+          window: {
+            defaultSideBarPanel: 'info',
+          },
+        },
+        workspace: {},
+      };
+      const mockDispatch = jest.fn(() => ({}));
+      const mockGetState = jest.fn(() => mockState);
+      const thunk = actions.addWindow(options);
+
+      thunk(mockDispatch, mockGetState);
+
+      const action = mockDispatch.mock.calls[0][0];
+      expect(action.window.sideBarPanel).toEqual('canvas');
+    });
+
     it('pulls a provided manifest out', () => {
       const options = {
         canvasIndex: 1,

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -44,10 +44,12 @@ export function addWindow({ companionWindows, manifest, ...options }) {
       ),
     ];
 
-    if (config.window.defaultSideBarPanel || config.window.sideBarPanel) {
+    if (options.sideBarPanel || config.window.defaultSideBarPanel || config.window.sideBarPanel) {
       defaultCompanionWindows.unshift(
         {
-          content: config.window.defaultSideBarPanel || config.window.sideBarPanel,
+          content: options.sideBarPanel
+            || config.window.defaultSideBarPanel
+            || config.window.sideBarPanel,
           default: true,
           id: `cw-${uuid()}`,
           position: 'left',
@@ -72,7 +74,9 @@ export function addWindow({ companionWindows, manifest, ...options }) {
       sideBarOpen: config.window.sideBarOpenByDefault !== undefined
         ? config.window.sideBarOpenByDefault
         : config.window.sideBarOpen,
-      sideBarPanel: config.window.defaultSideBarPanel || config.window.sideBarPanel,
+      sideBarPanel: options.sideBarPanel
+        || config.window.defaultSideBarPanel
+        || config.window.sideBarPanel,
       thumbnailNavigationId: cwThumbs,
     };
 


### PR DESCRIPTION
…arPanel

One could then add a window with canvas configured like so:

```javascript
var miradorInstance = Mirador.viewer({
  id: 'mirador',
  windows: [{
   manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
   canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
   thumbnailNavigationPosition: 'far-bottom',
   sideBarOpen: true,
   sideBarPanel: 'canvas',
  },
});
```