### PR TITLE
Lockdown @material-ui/icons to ~v4.9 until upstream displayName issue…

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "repository": "https://github.com/ProjectMirador/mirador",
   "dependencies": {
     "@material-ui/core": "^4.11.0",
-    "@material-ui/icons": "^4.9.1",
+    "@material-ui/icons": "~4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.53",
     "@researchgate/react-intersection-observer": "^1.0.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
… is resolved

An intermediate solution to #3366 until upstream makes a change.