### PR TITLE
Fix bad plugin hook name in AttributionPanel

### DIFF
--- a/src/containers/AttributionPanel.js
+++ b/src/containers/AttributionPanel.js
@@ -46,7 +46,7 @@ const enhance = compose(
   withStyles(styles),
   withTranslation(),
   connect(mapStateToProps),
-  withPlugins('ManifestInfo'),
+  withPlugins('AttributionPanel'),
 );
 
 export default enhance(AttributionPanel);


### PR DESCRIPTION
Seems this was missed during copy-pasting from `ManifestInfo` :-)

I grepped the codebase for other instances of a mismatch between Component name and plugin hook identifier, but found none, so this seems to be the only instance.