### PR TITLE
Fixes an issue with A/V to allow configurable element attribution and crossOrigin options

### DIFF
--- a/__tests__/integration/mirador/video.html
+++ b/__tests__/integration/mirador/video.html
@@ -24,7 +24,7 @@
            manifestId: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json'
          },
          {
-           manifestId: 'https://iiif-commons.github.io/iiif-av-component/examples/data/iiif/lunchroom-manners.json'
+           manifestId: 'https://preview.iiif.io/cookbook/0219-using-caption-file/recipe/0219-using-caption-file/manifest.json'
          }
       ],
      });

--- a/__tests__/src/components/AudioViewer.test.js
+++ b/__tests__/src/components/AudioViewer.test.js
@@ -23,8 +23,8 @@ describe('AudioViewer', () => {
           { getFormat: () => 'video/mp4', id: 2 },
         ],
       }, true);
-      expect(wrapper.contains(<source src="1" type="video/mp4" />));
-      expect(wrapper.contains(<source src="2" type="video/mp4" />));
+      expect(wrapper.contains(<source src={1} type="video/mp4" />)).toBe(true);
+      expect(wrapper.contains(<source src={2} type="video/mp4" />)).toBe(true);
     });
     it('passes through configurable options', () => {
       wrapper = createWrapper({
@@ -44,8 +44,8 @@ describe('AudioViewer', () => {
           { getLabel: () => 'French', getProperty: () => 'fr', id: 2 },
         ],
       }, true);
-      expect(wrapper.contains(<track src="1" label="English" srcLang="en" />));
-      expect(wrapper.contains(<track src="2" label="French" srcLang="fr" />));
+      expect(wrapper.contains(<track src={1} label="English" srcLang="en" />)).toBe(true);
+      expect(wrapper.contains(<track src={2} label="French" srcLang="fr" />)).toBe(true);
     });
   });
 });

--- a/__tests__/src/components/AudioViewer.test.js
+++ b/__tests__/src/components/AudioViewer.test.js
@@ -7,6 +7,7 @@ function createWrapper(props, suspenseFallback) {
   return shallow(
     <AudioViewer
       classes={{}}
+      audioOptions={{ crossOrigin: 'anonymous' }}
       {...props}
     />,
   );
@@ -24,6 +25,14 @@ describe('AudioViewer', () => {
       }, true);
       expect(wrapper.contains(<source src="1" type="video/mp4" />));
       expect(wrapper.contains(<source src="2" type="video/mp4" />));
+    });
+    it('passes through configurable options', () => {
+      wrapper = createWrapper({
+        audioResources: [
+          { getFormat: () => 'audio/mp3', id: 1 },
+        ],
+      }, true);
+      expect(wrapper.exists('audio[crossOrigin="anonymous"]')).toBe(true); // eslint-disable-line jsx-a11y/media-has-caption
     });
     it('captions', () => {
       wrapper = createWrapper({

--- a/__tests__/src/components/AudioViewer.test.js
+++ b/__tests__/src/components/AudioViewer.test.js
@@ -40,8 +40,8 @@ describe('AudioViewer', () => {
           { getFormat: () => 'video/mp4', id: 1 },
         ],
         captions: [
-          { getLabel: () => 'English', getProperty: () => 'en', id: 1 },
-          { getLabel: () => 'French', getProperty: () => 'fr', id: 2 },
+          { getDefaultLabel: () => 'English', getProperty: () => 'en', id: 1 },
+          { getDefaultLabel: () => 'French', getProperty: () => 'fr', id: 2 },
         ],
       }, true);
       expect(wrapper.contains(<track src={1} label="English" srcLang="en" />)).toBe(true);

--- a/__tests__/src/components/VideoViewer.test.js
+++ b/__tests__/src/components/VideoViewer.test.js
@@ -37,8 +37,8 @@ describe('VideoViewer', () => {
     it('captions', () => {
       wrapper = createWrapper({
         captions: [
-          { getLabel: () => 'English', getProperty: () => 'en', id: 1 },
-          { getLabel: () => 'French', getProperty: () => 'fr', id: 2 },
+          { getDefaultLabel: () => 'English', getProperty: () => 'en', id: 1 },
+          { getDefaultLabel: () => 'French', getProperty: () => 'fr', id: 2 },
         ],
         videoResources: [
           { getFormat: () => 'video/mp4', id: 1 },

--- a/__tests__/src/components/VideoViewer.test.js
+++ b/__tests__/src/components/VideoViewer.test.js
@@ -7,6 +7,7 @@ function createWrapper(props, suspenseFallback) {
   return shallow(
     <VideoViewer
       classes={{}}
+      videoOptions={{ crossOrigin: 'anonymous' }}
       {...props}
     />,
   );
@@ -24,6 +25,14 @@ describe('VideoViewer', () => {
       }, true);
       expect(wrapper.contains(<source src="1" type="video/mp4" />));
       expect(wrapper.contains(<source src="2" type="video/mp4" />));
+    });
+    it('passes through configurable options', () => {
+      wrapper = createWrapper({
+        videoResources: [
+          { getFormat: () => 'video/mp4', id: 1 },
+        ],
+      }, true);
+      expect(wrapper.exists('video[crossOrigin="anonymous"]')).toBe(true); // eslint-disable-line jsx-a11y/media-has-caption
     });
     it('captions', () => {
       wrapper = createWrapper({

--- a/__tests__/src/components/VideoViewer.test.js
+++ b/__tests__/src/components/VideoViewer.test.js
@@ -23,8 +23,8 @@ describe('VideoViewer', () => {
           { getFormat: () => 'video/mp4', id: 2 },
         ],
       }, true);
-      expect(wrapper.contains(<source src="1" type="video/mp4" />));
-      expect(wrapper.contains(<source src="2" type="video/mp4" />));
+      expect(wrapper.contains(<source src={1} type="video/mp4" />)).toBe(true);
+      expect(wrapper.contains(<source src={2} type="video/mp4" />)).toBe(true);
     });
     it('passes through configurable options', () => {
       wrapper = createWrapper({
@@ -44,8 +44,8 @@ describe('VideoViewer', () => {
           { getFormat: () => 'video/mp4', id: 1 },
         ],
       }, true);
-      expect(wrapper.contains(<track src="1" label="English" srcLang="en" />));
-      expect(wrapper.contains(<track src="2" label="French" srcLang="fr" />));
+      expect(wrapper.contains(<track src={1} label="English" srcLang="en" />)).toBe(true);
+      expect(wrapper.contains(<track src={2} label="French" srcLang="fr" />)).toBe(true);
     });
   });
 });

--- a/src/components/AudioViewer.js
+++ b/src/components/AudioViewer.js
@@ -6,11 +6,11 @@ export class AudioViewer extends Component {
   /* eslint-disable jsx-a11y/media-has-caption */
   /** */
   render() {
-    const { classes, audioResources } = this.props;
+    const { classes, audioOptions, audioResources } = this.props;
 
     return (
       <div className={classes.container}>
-        <audio controls className={classes.audio}>
+        <audio controls className={classes.audio} {...audioOptions}>
           {audioResources.map(audio => (
             <Fragment key={audio.id}>
               <source src={audio.id} type={audio.getFormat()} />
@@ -24,10 +24,12 @@ export class AudioViewer extends Component {
 }
 
 AudioViewer.propTypes = {
+  audioOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   audioResources: PropTypes.arrayOf(PropTypes.object),
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 
 AudioViewer.defaultProps = {
+  audioOptions: {},
   audioResources: [],
 };

--- a/src/components/AudioViewer.js
+++ b/src/components/AudioViewer.js
@@ -12,7 +12,7 @@ export class AudioViewer extends Component {
 
     return (
       <div className={classes.container}>
-        <audio controls className={classes.audio} {...audioOptions}>
+        <audio className={classes.audio} {...audioOptions}>
           {audioResources.map(audio => (
             <Fragment key={audio.id}>
               <source src={audio.id} type={audio.getFormat()} />

--- a/src/components/AudioViewer.js
+++ b/src/components/AudioViewer.js
@@ -6,7 +6,9 @@ export class AudioViewer extends Component {
   /* eslint-disable jsx-a11y/media-has-caption */
   /** */
   render() {
-    const { classes, audioOptions, audioResources } = this.props;
+    const {
+      captions, classes, audioOptions, audioResources,
+    } = this.props;
 
     return (
       <div className={classes.container}>
@@ -14,6 +16,11 @@ export class AudioViewer extends Component {
           {audioResources.map(audio => (
             <Fragment key={audio.id}>
               <source src={audio.id} type={audio.getFormat()} />
+            </Fragment>
+          ))}
+          {captions.map(caption => (
+            <Fragment key={caption.id}>
+              <track src={caption.id} label={caption.getLabel()} srcLang={caption.getProperty('language')} />
             </Fragment>
           ))}
         </audio>
@@ -26,10 +33,12 @@ export class AudioViewer extends Component {
 AudioViewer.propTypes = {
   audioOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   audioResources: PropTypes.arrayOf(PropTypes.object),
+  captions: PropTypes.arrayOf(PropTypes.object),
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 
 AudioViewer.defaultProps = {
   audioOptions: {},
   audioResources: [],
+  captions: [],
 };

--- a/src/components/AudioViewer.js
+++ b/src/components/AudioViewer.js
@@ -20,7 +20,7 @@ export class AudioViewer extends Component {
           ))}
           {captions.map(caption => (
             <Fragment key={caption.id}>
-              <track src={caption.id} label={caption.getLabel()} srcLang={caption.getProperty('language')} />
+              <track src={caption.id} label={caption.getDefaultLabel()} srcLang={caption.getProperty('language')} />
             </Fragment>
           ))}
         </audio>

--- a/src/components/VideoViewer.js
+++ b/src/components/VideoViewer.js
@@ -6,10 +6,12 @@ export class VideoViewer extends Component {
   /* eslint-disable jsx-a11y/media-has-caption */
   /** */
   render() {
-    const { captions, classes, videoResources } = this.props;
+    const {
+      captions, classes, videoOptions, videoResources,
+    } = this.props;
     return (
       <div className={classes.container}>
-        <video controls className={classes.video}>
+        <video controls className={classes.video} {...videoOptions}>
           {videoResources.map(video => (
             <Fragment key={video.id}>
               <source src={video.id} type={video.getFormat()} />
@@ -30,10 +32,12 @@ export class VideoViewer extends Component {
 VideoViewer.propTypes = {
   captions: PropTypes.arrayOf(PropTypes.object),
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  videoOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   videoResources: PropTypes.arrayOf(PropTypes.object),
 };
 
 VideoViewer.defaultProps = {
   captions: [],
+  videoOptions: {},
   videoResources: [],
 };

--- a/src/components/VideoViewer.js
+++ b/src/components/VideoViewer.js
@@ -11,7 +11,7 @@ export class VideoViewer extends Component {
     } = this.props;
     return (
       <div className={classes.container}>
-        <video controls className={classes.video} {...videoOptions}>
+        <video className={classes.video} {...videoOptions}>
           {videoResources.map(video => (
             <Fragment key={video.id}>
               <source src={video.id} type={video.getFormat()} />

--- a/src/components/VideoViewer.js
+++ b/src/components/VideoViewer.js
@@ -19,7 +19,7 @@ export class VideoViewer extends Component {
           ))}
           {captions.map(caption => (
             <Fragment key={caption.id}>
-              <track src={caption.id} label={caption.getLabel()} srcLang={caption.getProperty('language')} />
+              <track src={caption.id} label={caption.getDefaultLabel()} srcLang={caption.getProperty('language')} />
             </Fragment>
           ))}
         </video>

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -343,9 +343,11 @@ export default {
     workspace: true,
   },
   audioOptions: { // Additional props passed to <audio> element
+    controls: true,
     crossOrigin: 'anonymous',
   },
   videoOptions: { // Additional props passed to <audio> element
+    controls: true,
     crossOrigin: 'anonymous',
   },
   auth: {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -342,6 +342,12 @@ export default {
     windows: true,
     workspace: true,
   },
+  audioOptions: { // Additional props passed to <audio> element
+    crossOrigin: 'anonymous',
+  },
+  videoOptions: { // Additional props passed to <audio> element
+    crossOrigin: 'anonymous',
+  },
   auth: {
     serviceProfiles: [
       { profile: 'http://iiif.io/api/auth/1/external', external: true },

--- a/src/containers/AudioViewer.js
+++ b/src/containers/AudioViewer.js
@@ -4,13 +4,14 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend/withPlugins';
 import { AudioViewer } from '../components/AudioViewer';
-import { getConfig, getVisibleCanvasAudioResources } from '../state/selectors';
+import { getConfig, getVisibleCanvasAudioResources, getVisibleCanvasCaptions } from '../state/selectors';
 
 /** */
 const mapStateToProps = (state, { windowId }) => (
   {
     audioOptions: getConfig(state).audioOptions,
     audioResources: getVisibleCanvasAudioResources(state, { windowId }) || [],
+    captions: getVisibleCanvasCaptions(state, { windowId }) || [],
   }
 );
 

--- a/src/containers/AudioViewer.js
+++ b/src/containers/AudioViewer.js
@@ -4,11 +4,12 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend/withPlugins';
 import { AudioViewer } from '../components/AudioViewer';
-import { getVisibleCanvasAudioResources } from '../state/selectors';
+import { getConfig, getVisibleCanvasAudioResources } from '../state/selectors';
 
 /** */
 const mapStateToProps = (state, { windowId }) => (
   {
+    audioOptions: getConfig(state).audioOptions,
     audioResources: getVisibleCanvasAudioResources(state, { windowId }) || [],
   }
 );

--- a/src/containers/VideoViewer.js
+++ b/src/containers/VideoViewer.js
@@ -4,12 +4,13 @@ import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend/withPlugins';
 import { VideoViewer } from '../components/VideoViewer';
-import { getVisibleCanvasCaptions, getVisibleCanvasVideoResources } from '../state/selectors';
+import { getConfig, getVisibleCanvasCaptions, getVisibleCanvasVideoResources } from '../state/selectors';
 
 /** */
 const mapStateToProps = (state, { windowId }) => (
   {
     captions: getVisibleCanvasCaptions(state, { windowId }) || [],
+    videoOptions: getConfig(state).videoOptions,
     videoResources: getVisibleCanvasVideoResources(state, { windowId }) || [],
   }
 );


### PR DESCRIPTION
Enables actual use of VTT via `crossorigin="anonymous"` See: https://preview.iiif.io/cookbook/0219-using-caption-file/recipe/0219-using-caption-file/manifest.json
