### PR TITLE
Fix ProjectMirador/mirador-annotations#41, make plugin order stable

### DIFF
--- a/src/extend/withPlugins.js
+++ b/src/extend/withPlugins.js
@@ -43,7 +43,8 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
       );
     };
 
-    return plugins.wrap.reverse().reduce(pluginWrapper, <TargetComponent {...passDownProps} />);
+    return plugins.wrap.slice().reverse()
+      .reduce(pluginWrapper, <TargetComponent {...passDownProps} />);
   }
   const whatever = React.forwardRef(PluginHoc);
 


### PR DESCRIPTION
`Array.prototype.reverse()` modifies the original array. If there are multiple wrap plugins for a specific component, their order changes every time.

https://github.com/ProjectMirador/mirador/blob/4835e128abc3eee24667cea6bcc7a4c00b3e35fb/src/extend/withPlugins.js#L46

This change should fix ProjectMirador/mirador-annotations#41.