### PR TITLE
Add option to disable automatic canvas switching upon receiving search results

### DIFF
--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -14,6 +14,7 @@ import {
   getSortedSearchAnnotationsForCompanionWindow,
   getVisibleCanvasIds, getCanvasForAnnotation,
   getCanvases, selectInfoResponses,
+  getWindowConfig,
 } from '../../../src/state/selectors';
 import { fetchManifests } from '../../../src/state/sagas/iiif';
 import {
@@ -343,6 +344,7 @@ describe('window-level sagas', () => {
 
       return expectSaga(setCanvasOfFirstSearchResult, action)
         .provide([
+          [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: true }],
           [select(getSelectedContentSearchAnnotationIds, { companionWindowId, windowId }), []],
           [select(getSortedSearchAnnotationsForCompanionWindow, { companionWindowId, windowId }), [{ id: 'a' }, { id: 'b' }]],
         ])
@@ -365,7 +367,24 @@ describe('window-level sagas', () => {
 
       return expectSaga(setCanvasOfFirstSearchResult, action)
         .provide([
+          [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: true }],
           [select(getSelectedContentSearchAnnotationIds, { companionWindowId, windowId }), ['y']],
+        ])
+        .run().then(({ allEffects }) => allEffects.length === 0);
+    });
+
+    it('does nothing if canvas switching for searches is disabled', () => {
+      const companionWindowId = 'x';
+      const windowId = 'y';
+      const action = {
+        companionWindowId,
+        type: ActionTypes.RECEIVE_SEARCH,
+        windowId,
+      };
+
+      return expectSaga(setCanvasOfFirstSearchResult, action)
+        .provide([
+          [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: false }],
         ])
         .run().then(({ allEffects }) => allEffects.length === 0);
     });

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -268,6 +268,7 @@ export default {
     highlightAllAnnotations: false, // Configure whether to display annotations on the canvas by default
     showLocalePicker: false, // Configure locale picker for multi-lingual metadata
     sideBarOpen: false, // Configure if the sidebar (and its content panel) is open by default
+    switchCanvasOnSearch: true, // Configure if Mirador should automatically switch to the canvas of the first search result
     panels: { // Configure which panels are visible in WindowSideBarButtons
       info: true,
       attribution: true,

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -27,6 +27,7 @@ import {
   getElasticLayout,
   getCanvases,
   selectInfoResponses,
+  getWindowConfig,
 } from '../selectors';
 import { fetchManifests } from './iiif';
 
@@ -202,6 +203,10 @@ export function* updateVisibleCanvases({ windowId }) {
 
 /** @private */
 export function* setCanvasOfFirstSearchResult({ companionWindowId, windowId }) {
+  const { switchCanvasOnSearch } = yield select(getWindowConfig, { windowId });
+  if (!switchCanvasOnSearch) {
+    return;
+  }
   const selectedIds = yield select(getSelectedContentSearchAnnotationIds, {
     companionWindowId, windowId,
   });


### PR DESCRIPTION
This allows integrators to customize this behavior, e.g. by not selecting the first, but another canvas via a custom saga.[1]

The default is set to `true`, so there is no change in behavior for integrators not setting this option.

[1] Our use case that requires this option is that we want to combine an initial search with an initial canvas, so that upon rendering not the first global hit for the search is selected, but instead the first hit on the initial canvas. Without this option, the saga that does this is very brittle and can lead to infinite loops in some circumstances.