### PR TITLE
Support two additional modes of canvas thumbnail specification

### DIFF
--- a/__tests__/src/components/IIIFThumbnail.test.js
+++ b/__tests__/src/components/IIIFThumbnail.test.js
@@ -72,11 +72,6 @@ describe('IIIFThumbnail', () => {
     expect(wrapper.find('img').props().style).toMatchObject({ height: 60, width: 50 });
   });
 
-  it('relaxes constraints when the image dimensions are unknown', () => {
-    wrapper = createWrapper({ thumbnail: { url } });
-    expect(wrapper.find('img').props().style).toMatchObject({ height: 'auto', width: 'auto' });
-  });
-
   it('constrains what it can when the image dimensions are unknown', () => {
     wrapper = createWrapper({ maxHeight: 90, thumbnail: { height: 120, url } });
     expect(wrapper.find('img').props().style).toMatchObject({ height: 90, width: 'auto' });

--- a/__tests__/src/lib/ThumbnailFactory.test.js
+++ b/__tests__/src/lib/ThumbnailFactory.test.js
@@ -48,39 +48,37 @@ describe('getThumbnail', () => {
 
   describe('with a IIIF resource', () => {
     for (const type of ['Collection', 'Manifest', 'Canvas', 'Image']) {
+      describe('with a thumbnail', () => {
+        it('return the thumbnail and metadata', () => {
+          expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: { '@id': url, height: 70, width: 50 } }, type)).toMatchObject({ height: 70, url, width: 50 });
+        });
 
-  describe('with a thumbnail', () => {
-    it('return the thumbnail and metadata', () => {
-      expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: { '@id': url, height: 70, width: 50 } }, type)).toMatchObject({ height: 70, url, width: 50 });
-    });
+        it('return the IIIF service of the thumbnail', () => {
+          expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel1Service }, type)).toMatchObject({ url: `${url}/full/,120/0/default.jpg` });
+        });
 
-    it('return the IIIF service of the thumbnail', () => {
-      expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel1Service }, type)).toMatchObject({ url: `${url}/full/,120/0/default.jpg` });
-    });
+        describe('with image size constraints', () => {
+          it('does nothing with a static resource', () => {
+            expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: { '@id': url } }, type, { maxWidth: 50 })).toMatchObject({ url });
+          });
 
-    describe('with image size constraints', () => {
-      it('does nothing with a static resource', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: { '@id': url } }, type, { maxWidth: 50 })).toMatchObject({ url });
+          it('does nothing with a IIIF level 0 service', () => {
+            expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel0Service }, type, { maxWidth: 50 })).toMatchObject({ url: 'arbitrary-url' });
+          });
+
+          it('calculates constraints for a IIIF level 1 service', () => {
+            expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel1Service }, type, { maxWidth: 150 })).toMatchObject({ height: 300, url: `${url}/full/150,/0/default.jpg`, width: 150 });
+          });
+
+          it('calculates constraints for a IIIF level 2 service', () => {
+            expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel2Service }, type, { maxHeight: 200, maxWidth: 150 })).toMatchObject({ height: 200, url: `${url}/full/!150,200/0/default.jpg`, width: 100 });
+          });
+
+          it('applies a minumum size to image constraints to encourage asset reuse', () => {
+            expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel2Service }, type, { maxHeight: 100, maxWidth: 100 })).toMatchObject({ height: 120, url: `${url}/full/!120,120/0/default.jpg`, width: 60 });
+          });
+        });
       });
-
-      it('does nothing with a IIIF level 0 service', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel0Service }, type, { maxWidth: 50 })).toMatchObject({ url: 'arbitrary-url' });
-      });
-
-      it('calculates constraints for a IIIF level 1 service', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel1Service }, type, { maxWidth: 150 })).toMatchObject({ height: 300, url: `${url}/full/150,/0/default.jpg`, width: 150 });
-      });
-
-      it('calculates constraints for a IIIF level 2 service', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel2Service }, type, { maxHeight: 200, maxWidth: 150 })).toMatchObject({ height: 200, url: `${url}/full/!150,200/0/default.jpg`, width: 100 });
-      });
-
-      it('applies a minumum size to image constraints to encourage asset reuse', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel2Service }, type, { maxHeight: 100, maxWidth: 100 })).toMatchObject({ height: 120, url: `${url}/full/!120,120/0/default.jpg`, width: 60 });
-      });
-    });
-  });
-
     }
   });
 

--- a/__tests__/src/lib/ThumbnailFactory.test.js
+++ b/__tests__/src/lib/ThumbnailFactory.test.js
@@ -1,5 +1,7 @@
-import { ManifestResource, Resource, Utils } from 'manifesto.js/dist-esmodule';
-import getThumbnail from '../../../src/lib/ThumbnailFactory';
+import {
+  ManifestResource, Resource, Service, Utils,
+} from 'manifesto.js/dist-esmodule';
+import getThumbnail, { ThumbnailFactory } from '../../../src/lib/ThumbnailFactory';
 import fixture from '../../fixtures/version-2/019.json';
 
 const manifest = Utils.parseManifest(fixture);
@@ -243,5 +245,44 @@ describe('getThumbnail', () => {
       });
       expect(getThumbnail(collection)).toMatchObject({ url: 'https://example.org/manifest1/thumbnail.jpg' });
     });
+  });
+});
+
+describe('selectBestImageSize', () => {
+  const targetWidth = 120;
+  const targetHeight = 120;
+
+  it('selects the smallest size larger than the target, if one is available', () => {
+    const sizes = [
+      { height: 75, width: 75 },
+      { height: 150, width: 150 },
+      { height: 300, width: 300 },
+    ];
+    const service = new Service({
+      id: 'arbitrary-url',
+      profile: 'level0',
+      sizes,
+      type: 'ImageService3',
+    });
+
+    expect(ThumbnailFactory.selectBestImageSize(service, targetWidth * targetHeight))
+      .toEqual(sizes[1]);
+  });
+
+  it('selects the largest size smaller than the target, if none larger are available', () => {
+    const sizes = [
+      { height: 25, width: 25 },
+      { height: 50, width: 50 },
+      { height: 75, width: 75 },
+    ];
+    const service = new Service({
+      id: 'arbitrary-url',
+      profile: 'level0',
+      sizes,
+      type: 'ImageService3',
+    });
+
+    expect(ThumbnailFactory.selectBestImageSize(service, targetWidth * targetHeight))
+      .toEqual(sizes[2]);
   });
 });

--- a/__tests__/src/lib/ThumbnailFactory.test.js
+++ b/__tests__/src/lib/ThumbnailFactory.test.js
@@ -6,7 +6,10 @@ const manifest = Utils.parseManifest(fixture);
 const canvas = manifest.getSequences()[0].getCanvases()[0];
 
 /** */
-function createSubject(jsonld, iiifOpts) {
+function createSubject(jsonld, resourceType, iiifOpts) {
+  if (resourceType === 'Image') {
+    return createImageSubject(jsonld, iiifOpts);
+  }
   return getThumbnail(new ManifestResource(jsonld, {}), iiifOpts);
 }
 
@@ -43,36 +46,42 @@ describe('getThumbnail', () => {
     { height: 1000, width: 1000 },
   ];
 
+  describe('with a IIIF resource', () => {
+    for (const type of ['Collection', 'Manifest', 'Canvas', 'Image']) {
+
   describe('with a thumbnail', () => {
     it('return the thumbnail and metadata', () => {
-      expect(createSubject({ '@id': 'xyz', '@type': 'Whatever', thumbnail: { '@id': url, height: 70, width: 50 } })).toMatchObject({ height: 70, url, width: 50 });
+      expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: { '@id': url, height: 70, width: 50 } }, type)).toMatchObject({ height: 70, url, width: 50 });
     });
 
     it('return the IIIF service of the thumbnail', () => {
-      expect(createSubject({ '@id': 'xyz', '@type': 'Whatever', thumbnail: iiifLevel1Service })).toMatchObject({ url: `${url}/full/,120/0/default.jpg` });
+      expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel1Service }, type)).toMatchObject({ url: `${url}/full/,120/0/default.jpg` });
     });
 
     describe('with image size constraints', () => {
       it('does nothing with a static resource', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': 'Whatever', thumbnail: { '@id': url } }, { maxWidth: 50 })).toMatchObject({ url });
+        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: { '@id': url } }, type, { maxWidth: 50 })).toMatchObject({ url });
       });
 
       it('does nothing with a IIIF level 0 service', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': 'Whatever', thumbnail: iiifLevel0Service }, { maxWidth: 50 })).toMatchObject({ url: 'arbitrary-url' });
+        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel0Service }, type, { maxWidth: 50 })).toMatchObject({ url: 'arbitrary-url' });
       });
 
       it('calculates constraints for a IIIF level 1 service', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': 'Whatever', thumbnail: iiifLevel1Service }, { maxWidth: 150 })).toMatchObject({ height: 300, url: `${url}/full/150,/0/default.jpg`, width: 150 });
+        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel1Service }, type, { maxWidth: 150 })).toMatchObject({ height: 300, url: `${url}/full/150,/0/default.jpg`, width: 150 });
       });
 
       it('calculates constraints for a IIIF level 2 service', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': 'Whatever', thumbnail: iiifLevel2Service }, { maxHeight: 200, maxWidth: 150 })).toMatchObject({ height: 200, url: `${url}/full/!150,200/0/default.jpg`, width: 100 });
+        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel2Service }, type, { maxHeight: 200, maxWidth: 150 })).toMatchObject({ height: 200, url: `${url}/full/!150,200/0/default.jpg`, width: 100 });
       });
 
       it('applies a minumum size to image constraints to encourage asset reuse', () => {
-        expect(createSubject({ '@id': 'xyz', '@type': 'Whatever', thumbnail: iiifLevel2Service }, { maxHeight: 100, maxWidth: 100 })).toMatchObject({ height: 120, url: `${url}/full/!120,120/0/default.jpg`, width: 60 });
+        expect(createSubject({ '@id': 'xyz', '@type': type, thumbnail: iiifLevel2Service }, type, { maxHeight: 100, maxWidth: 100 })).toMatchObject({ height: 120, url: `${url}/full/!120,120/0/default.jpg`, width: 60 });
       });
     });
+  });
+
+    }
   });
 
   describe('with an image resource', () => {
@@ -125,7 +134,7 @@ describe('getThumbnail', () => {
 
   describe('with a canvas', () => {
     it('uses the thumbnail', () => {
-      expect(createSubject({ ...canvas.__jsonld, thumbnail: { ...iiifLevel1Service } })).toMatchObject({ url: `${url}/full/,120/0/default.jpg` });
+      expect(createSubject({ ...canvas.__jsonld, thumbnail: { ...iiifLevel1Service } }, 'Canvas')).toMatchObject({ url: `${url}/full/,120/0/default.jpg` });
     });
 
     it('uses the first image resource', () => {

--- a/src/components/IIIFThumbnail.js
+++ b/src/components/IIIFThumbnail.js
@@ -98,6 +98,12 @@ export class IIIFThumbnail extends Component {
       styleProps.height = maxHeight;
     } else if (!thumbHeight && thumbWidth) {
       styleProps.width = maxWidth;
+    } else {
+      // The thumbnail wasn't retrieved via an Image API service,
+      // and its dimensions are not specified in the JSON-LD
+      // (note that this may result in a blurry image)
+      styleProps.width = maxWidth;
+      styleProps.height = maxHeight;
     }
 
     return {

--- a/src/lib/ThumbnailFactory.js
+++ b/src/lib/ThumbnailFactory.js
@@ -67,6 +67,16 @@ class ThumbnailFactory {
   }
 
   /**
+   * Selects the image resource that is representative of the given canvas.
+   * @param {Object} canvas A Manifesto Canvas
+   * @return {Object} A Manifesto Image Resource
+   */
+  static getPreferredImage(canvas) {
+    const miradorCanvas = new MiradorCanvas(canvas);
+    return miradorCanvas.iiifImageResources[0] || miradorCanvas.imageResource;
+  }
+
+  /**
    * Chooses the best available image size based on a target area (w x h) value.
    * @param {Object} service A IIIF Image API service that has a `sizes` array
    * @param {Number} targetArea The target area value to compare potential sizes against
@@ -114,8 +124,9 @@ class ThumbnailFactory {
   }
 
   /**
-   * Creates a canonical image request for a thumb
-   * @param {Number} height
+   * Determines the appropriate thumbnail to use to represent an Image Resource.
+   * @param {Object} resource The Image Resource from which to derive a thumbnail
+   * @return {Object} The thumbnail URL and any spatial dimensions that can be determined
    */
   iiifThumbnailUrl(resource) {
     let size;
@@ -131,27 +142,26 @@ class ThumbnailFactory {
 
     const service = iiifImageService(resource);
 
-    if (!service) return undefined;
+    if (!service) return ThumbnailFactory.staticImageUrl(resource);
 
     const aspectRatio = resource.getWidth()
       && resource.getHeight()
       && (resource.getWidth() / resource.getHeight());
+    const target = (requestedMaxWidth && requestedMaxHeight)
+      ? requestedMaxWidth * requestedMaxHeight
+      : maxHeight * maxWidth;
+    const closestSize = ThumbnailFactory.selectBestImageSize(service, target);
 
-    // just bail to a static image, even though sizes might provide something better
-    if (isLevel0ImageProfile(service)) {
-      const target = (requestedMaxWidth && requestedMaxHeight)
-        ? requestedMaxWidth * requestedMaxHeight
-        : maxHeight * maxWidth;
-      const closestSize = ThumbnailFactory.selectBestImageSize(service, target);
-
-      /** Bail if the best available size is the full size.. maybe we'll get lucky with the @id */
-      if (!closestSize && !service.getProperty('height') && !service.getProperty('width')) {
-        return ThumbnailFactory.staticImageUrl(resource);
-      }
-
+    if (closestSize) {
+      // Embedded service advertises an appropriate size
       width = closestSize.width;
       height = closestSize.height;
       size = `${width},${height}`;
+    } else if (isLevel0ImageProfile(service)) {
+      /** Bail if the best available size is the full size.. maybe we'll get lucky with the @id */
+      if (!service.getProperty('height') && !service.getProperty('width')) {
+        return ThumbnailFactory.staticImageUrl(resource);
+      }
     } else if (requestedMaxHeight && requestedMaxWidth) {
       // IIIF level 2, no problem.
       if (isLevel2ImageProfile(service)) {
@@ -195,77 +205,76 @@ class ThumbnailFactory {
     };
   }
 
-  /** */
-  getThumbnail(resource, { requireIiif, quirksMode }) {
-    if (!resource) return undefined;
-    const thumb = resource.getThumbnail();
-    if (thumb && iiifImageService(thumb)) return this.iiifThumbnailUrl(thumb);
+  /**
+   * Determines the content resource from which to derive a thumbnail to represent a given resource.
+   * This method is recursive.
+   * @param {Object} resource A IIIF resource to derive a thumbnail from
+   * @return {Object|undefined} The Image Resource to derive a thumbnail from, or undefined
+   * if no appropriate resource exists
+   */
+  getSourceContentResource(resource) {
+    const thumbnail = resource.getThumbnail();
 
-    if (requireIiif) return undefined;
-    if (thumb && typeof thumb.__jsonld !== 'string') return ThumbnailFactory.staticImageUrl(thumb);
+    // Any resource type may have a thumbnail
+    if (thumbnail) {
+      if (typeof thumbnail.__jsonld === 'string') return thumbnail.__jsonld;
 
-    if (!quirksMode) return undefined;
+      // Prefer an image's ImageService over its image's thumbnail
+      // Note that Collection, Manifest, and Canvas don't have `getType()`
+      if (!resource.isCollection() && !resource.isManifest() && !resource.isCanvas()) {
+        if (resource.getType() === 'image' && iiifImageService(resource) && !iiifImageService(thumbnail)) {
+          return resource;
+        }
+      }
 
-    return (thumb && typeof thumb.__jsonld === 'string') ? { url: thumb.__jsonld } : undefined;
+      return thumbnail;
+    }
+
+    if (resource.isCollection()) {
+      const firstManifest = resource.getManifests()[0];
+      if (firstManifest) return this.getSourceContentResource(firstManifest);
+
+      return undefined;
+    }
+
+    if (resource.isManifest()) {
+      const miradorManifest = new MiradorManifest(resource);
+      const canvas = miradorManifest.startCanvas || miradorManifest.canvasAt(0);
+      if (canvas) return this.getSourceContentResource(canvas);
+
+      return undefined;
+    }
+
+    if (resource.isCanvas()) {
+      const image = ThumbnailFactory.getPreferredImage(resource);
+      if (image) return this.getSourceContentResource(image);
+
+      return undefined;
+    }
+
+    if (resource.getType() === 'image') {
+      return resource;
+    }
+
+    return undefined;
   }
 
-  /** */
-  getResourceThumbnail(resource) {
-    const thumb = this.getThumbnail(resource, { requireIiif: true });
-
-    if (thumb) return thumb;
-
-    if (iiifImageService(resource)) return this.iiifThumbnailUrl(resource);
-    if (['image', 'dctypes:Image'].includes(resource.getProperty('type'))) return ThumbnailFactory.staticImageUrl(resource);
-
-    return this.getThumbnail(resource, { quirksMode: true, requireIiif: false });
-  }
-
-  /** */
-  getIIIFThumbnail(canvas) {
-    const thumb = this.getThumbnail(canvas, { requireIiif: true });
-    if (thumb) return thumb;
-
-    const miradorCanvas = new MiradorCanvas(canvas);
-
-    const preferredCanvasResource = miradorCanvas.iiifImageResources[0]
-     || canvas.imageResource;
-
-    return (preferredCanvasResource && this.getResourceThumbnail(preferredCanvasResource))
-      || this.getThumbnail(canvas, { quirksMode: true, requireIiif: false });
-  }
-
-  /** */
-  getManifestThumbnail(manifest) {
-    const thumb = this.getThumbnail(manifest, { requireIiif: true });
-    if (thumb) return thumb;
-
-    const miradorManifest = new MiradorManifest(manifest);
-    const canvas = miradorManifest.startCanvas || miradorManifest.canvasAt(0);
-
-    return (canvas && this.getIIIFThumbnail(canvas))
-      || this.getThumbnail(manifest, { quirksMode: true, requireIiif: false });
-  }
-
-  /** */
-  getCollectionThumbnail(collection) {
-    const thumb = this.getThumbnail(collection, { requireIiif: true });
-    if (thumb) return thumb;
-
-    const firstManifest = this.resource.getManifests()[0];
-
-    return (firstManifest && this.getManifestThumbnail(firstManifest))
-      || this.getThumbnail(collection, { quirksMode: true, requireIiif: false });
-  }
-
-  /** */
+  /**
+   * Gets a thumbnail representing the resource.
+   * @return {Object|undefined} A thumbnail representing the resource, or undefined if none could
+   * be determined
+   */
   get() {
     if (!this.resource) return undefined;
 
-    if (this.resource.isCanvas()) return this.getIIIFThumbnail(this.resource);
-    if (this.resource.isManifest()) return this.getManifestThumbnail(this.resource);
-    if (this.resource.isCollection()) return this.getCollectionThumbnail(this.resource);
-    return this.getResourceThumbnail(this.resource, { requireIiif: true });
+    // Determine which content resource we should use to derive a thumbnail
+    const sourceContentResource = this.getSourceContentResource(this.resource);
+    if (!sourceContentResource) return undefined;
+
+    // Special treatment for external resources
+    if (typeof sourceContentResource === 'string') return { url: sourceContentResource };
+
+    return this.iiifThumbnailUrl(sourceContentResource);
   }
 }
 


### PR DESCRIPTION
These changes add support for two modes of specifying exactly which thumbnails to fetch for a particular canvas (`'with a canvas'`):
- `'uses the width and height of a thumbnail without a IIIF Image API service'`
- `'uses embedded sizes of a IIIF Image API service to find an appropriate size'`

The several `test-tightening` commits are changes that I saw as necessary to make the test cases either easier (IMO) to reason about, more aligned to ThumbnailFactory's actual usage, or more specific (eliminating false positives), so that I could better ensure that I wasn't breaking existing functionality. For instance:
- while `{ "url": "myId" }` and `{ "url": "myId", "width": 80, "height": 120 }` may both cause `expect({ "url": "myId", "width": 80, "height": 120 }).toMatchObject(...)` to return true, only the latter will cause `toEqual(...)` to do the same
- the application never calls the ThumbnailFactory directly on an Image, so I wrapped each test Image in a Canvas
- callers also always provide at least one size constraint on the UI (`maxWidth`, `maxHeight`), so I made sure it was always getting passed at least one of the two
- the construction of the test data using combinations of `createSubject`, `createImageSubject`, `iiifService`, and the `...` operator often made it difficult for me to tell what the test data actually looked like, so I deleted those "helper" methods (I believe the test data should be further moved to a test fixture JSON file)

The most important code changes are at `3b9526c` and `d845c5e`; the former (IMO) clarifies how an Image is selected as a candidate from which to derive a "thumbnail" by using two methods to do so rather than five, and the latter is necessary for the two tests I've added to pass.

I hoped to make it possible, by allowing one to walk through a series of focused commits, to observe that I'm not breaking existing functionality. Also, I see that the four `test-tightening` commits at the tip of this branch might be good to group with the rest of them at the base, and I am happy to attempt a rebase if desired.

(P.S. These changes also add one test (`'with a manifest'` > `'does nothing with a plain URL'`) that I saw that was missing, for functionality that I inadvertently broke at one point while making these changes.)