### PR TITLE
Add children rendering to PrimaryWindow

### DIFF
--- a/__tests__/src/components/PrimaryWindow.test.js
+++ b/__tests__/src/components/PrimaryWindow.test.js
@@ -20,6 +20,13 @@ describe('PrimaryWindow', () => {
     const wrapper = createWrapper();
     expect(wrapper.find('.mirador-primary-window')).toHaveLength(1);
   });
+  it('should only render children when available', () => {
+    const wrapper = createWrapper({ children: <span>hi</span>, isFetching: false });
+    expect(wrapper.find('span')).toHaveLength(1);
+    const suspenseComponent = wrapper.find('Suspense');
+    const lazyComponent = suspenseComponent.dive().find('lazy');
+    expect(lazyComponent).toHaveLength(0);
+  });
   it('should render <WindowSideBar>', () => {
     const wrapper = createWrapper();
     expect(wrapper.find(WindowSideBar)).toHaveLength(1);

--- a/src/components/PrimaryWindow.js
+++ b/src/components/PrimaryWindow.js
@@ -75,14 +75,16 @@ export class PrimaryWindow extends Component {
    * Render the component
    */
   render() {
-    const { isCollectionDialogVisible, windowId, classes } = this.props;
+    const {
+      isCollectionDialogVisible, windowId, classes, children,
+    } = this.props;
     return (
       <div className={classNames(ns('primary-window'), classes.primaryWindow)}>
         <WindowSideBar windowId={windowId} />
         <CompanionArea windowId={windowId} position="left" />
         { isCollectionDialogVisible && <CollectionDialog windowId={windowId} /> }
         <Suspense fallback={<div />}>
-          {this.renderViewer()}
+          {children || this.renderViewer()}
         </Suspense>
       </div>
     );
@@ -91,6 +93,7 @@ export class PrimaryWindow extends Component {
 
 PrimaryWindow.propTypes = {
   audioResources: PropTypes.arrayOf(PropTypes.object),
+  children: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   isCollection: PropTypes.bool,
   isCollectionDialogVisible: PropTypes.bool,
@@ -102,6 +105,7 @@ PrimaryWindow.propTypes = {
 
 PrimaryWindow.defaultProps = {
   audioResources: [],
+  children: undefined,
   isCollection: false,
   isCollectionDialogVisible: false,
   isFetching: false,


### PR DESCRIPTION
This enhances the `PrimaryWindow` API for plugins to be able to customize behavior when wrapping.

For example, for a 3D viewer plugin, this allows the following:

```javascript
  render() {
    const { TargetComponent, targetProps, threeDResources } = this.props;
    return (
      <TargetComponent {...targetProps}>
        { threeDResources && threeDResources.length > 0 && this.render3DViewer() }
      </TargetComponent>
    )
  }
```

Other implementations could support a map/geo viewer or really anything here is a nice tap in point.

The change here also prevents `this.renderViewer()` from being called if `children` prop is provided. I implemented something similar with a different prop argument name (which totally works), but `children` seemed like a more "React" way of doing things. However, I wonder if this could be problematic? It feels clean, but would be curious about other's thoughts here.

