### PR TITLE
Add npm script for running the test suite in a debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ $ npm run lint
 ```
 
 ## Debugging
-Useful browser extensions for debugging/development purposes
+
+### Local instance
+
+The following browser extensions are useful for debugging a local development instance of Mirador:
+
  - [React DevTools](https://github.com/facebook/react-devtools)
  - [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension)
+
+### Test suite
+
+To debug the test suite, run:
+
+```sh
+$ npm run test:debug
+```
+
+then spin up a [nodejs inspector client](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients) and set some breakpoints. See [here](https://www.digitalocean.com/community/tutorials/how-to-debug-node-js-with-the-built-in-debugger-and-chrome-devtools#step-3-%E2%80%94-debugging-node-js-with-chrome-devtools) for a guide to debugging with Chrome DevTools.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:translations": "node ./scripts/i18n-lint.js",
     "server": "node_modules/.bin/http-server --cors",
     "test": "npm run build && npm run lint && npm run size && jest -c jest.json",
+    "test:debug": "node --inspect node_modules/.bin/jest -c jest.json --runInBand",
     "test:watch": "jest -c jest.json --watch",
     "build": "NODE_ENV=production webpack --mode=production",
     "build:dev": "webpack --mode=development",


### PR DESCRIPTION
I found this to be pretty indispensable when I was modifying the test suite, so I figure others might find it useful too. Lifted from https://artsy.github.io/blog/2018/08/24/How-to-debug-jest-tests/.