### PR TITLE
Bump jest-pupeteer to resolve deps error on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "http-server": "^0.12.3",
     "jest": "^26.0.1",
     "jest-fetch-mock": "^3.0.0",
-    "jest-puppeteer": "^4.1.1",
+    "jest-puppeteer": "^5.0.2",
     "jsdom": "15.1.1",
     "puppeteer": "^4.0.0",
     "react": "^16.8.6",


### PR DESCRIPTION
The jest-puppeteer dependency required a puppeteer <= 3 and master currently includes puppeteer 4.0.0. This PR bumps jest-puppeteer to 5.0.2 to resolve this conflict and make npm install work.