### PR TITLE
Prevent item labels in Collection modal from being cut off

### DIFF
--- a/src/components/CollectionDialog.js
+++ b/src/components/CollectionDialog.js
@@ -243,7 +243,11 @@ export class CollectionDialog extends Component {
             <MenuList>
               {
                 collections.map(c => (
-                  <MenuItem key={c.id} onClick={() => { this.selectCollection(c);}} className={classes.collectionItem}>
+                  <MenuItem
+                    key={c.id}
+                    onClick={() => { this.selectCollection(c); }}
+                    className={classes.collectionItem}
+                  >
                     {CollectionDialog.getUseableLabel(c)}
                   </MenuItem>
                 ))
@@ -254,7 +258,11 @@ export class CollectionDialog extends Component {
             <MenuList>
               {
                 manifest.getManifests().map(m => (
-                  <MenuItem key={m.id} onClick={() => { this.selectManifest(m);}} className={classes.collectionItem}>
+                  <MenuItem
+                    key={m.id}
+                    onClick={() => { this.selectManifest(m); }}
+                    className={classes.collectionItem}
+                  >
                     {CollectionDialog.getUseableLabel(m)}
                   </MenuItem>
                 ))

--- a/src/components/CollectionDialog.js
+++ b/src/components/CollectionDialog.js
@@ -244,7 +244,7 @@ export class CollectionDialog extends Component {
               {
                 collections.map(c => (
                   <MenuItem key={c.id} onClick={() => { this.selectCollection(c);}} className={classes.collectionItem}>
-                      {CollectionDialog.getUseableLabel(c)}
+                    {CollectionDialog.getUseableLabel(c)}
                   </MenuItem>
                 ))
               }
@@ -255,7 +255,7 @@ export class CollectionDialog extends Component {
               {
                 manifest.getManifests().map(m => (
                   <MenuItem key={m.id} onClick={() => { this.selectManifest(m);}} className={classes.collectionItem}>
-                      {CollectionDialog.getUseableLabel(m)}
+                    {CollectionDialog.getUseableLabel(m)}
                   </MenuItem>
                 ))
               }

--- a/src/components/CollectionDialog.js
+++ b/src/components/CollectionDialog.js
@@ -243,8 +243,8 @@ export class CollectionDialog extends Component {
             <MenuList>
               {
                 collections.map(c => (
-                  <MenuItem key={c.id} onClick={() => { this.selectCollection(c); }}>
-                    {CollectionDialog.getUseableLabel(c)}
+                  <MenuItem key={c.id} onClick={() => { this.selectCollection(c);}} className={classes.collectionItem}>
+                      {CollectionDialog.getUseableLabel(c)}
                   </MenuItem>
                 ))
               }
@@ -254,8 +254,8 @@ export class CollectionDialog extends Component {
             <MenuList>
               {
                 manifest.getManifests().map(m => (
-                  <MenuItem key={m.id} onClick={() => { this.selectManifest(m); }}>
-                    {CollectionDialog.getUseableLabel(m)}
+                  <MenuItem key={m.id} onClick={() => { this.selectManifest(m);}} className={classes.collectionItem}>
+                      {CollectionDialog.getUseableLabel(m)}
                   </MenuItem>
                 ))
               }

--- a/src/containers/CollectionDialog.js
+++ b/src/containers/CollectionDialog.js
@@ -78,6 +78,9 @@ const styles = theme => ({
     },
     cursor: 'pointer',
   },
+  collectionItem: {
+    whiteSpace: 'normal',
+  }
 });
 
 const enhance = compose(

--- a/src/containers/CollectionDialog.js
+++ b/src/containers/CollectionDialog.js
@@ -54,6 +54,9 @@ const styles = theme => ({
     padding: '16px',
     paddingTop: 0,
   },
+  collectionItem: {
+    whiteSpace: 'normal',
+  },
   collectionMetadata: {
     padding: '16px',
   },
@@ -78,9 +81,6 @@ const styles = theme => ({
     },
     cursor: 'pointer',
   },
-  collectionItem: {
-    whiteSpace: 'normal',
-  }
 });
 
 const enhance = compose(


### PR DESCRIPTION
Fixes #3424 


Example Manifest: https://portail.biblissima.fr/iiif/collection/ark:/43093/coldata5151005ea5833e5a05e2639cbb210946cb7e0609

<img width="560" alt="Screen Shot 2021-05-12 at 07 47 48" src="https://user-images.githubusercontent.com/111218/117995659-5b655a80-b2f6-11eb-8374-8f1ef403bd8f.png">