### PR TITLE
Stop displaying 'added from url placeholder'

### DIFF
--- a/__tests__/src/components/ManifestListItem.test.js
+++ b/__tests__/src/components/ManifestListItem.test.js
@@ -63,9 +63,9 @@ describe('ManifestListItem', () => {
     expect(wrapper.find('.mirador-manifest-list-item-provider').children().text()).toEqual('ACME');
   });
 
-  it('displays a placeholder provider if no information is given', () => {
+  it('displays nothing  if no information is given', () => {
     const wrapper = createWrapper();
-    expect(wrapper.find('.mirador-manifest-list-item-provider').children().text()).toEqual('addedFromUrl');
+    expect(wrapper.find('.mirador-manifest-list-item-provider').children().length).toEqual(0);
   });
 
   it('displays a collection label for collections', () => {

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -138,7 +138,7 @@ export class ManifestListItem extends React.Component {
               </ButtonBase>
             </Grid>
             <Grid item xs={8} sm={4}>
-              <Typography className={ns('manifest-list-item-provider')}>{provider || t('addedFromUrl')}</Typography>
+              <Typography className={ns('manifest-list-item-provider')}>{provider}</Typography>
               <Typography>{t('numItems', { count: size, number: size })}</Typography>
             </Grid>
 


### PR DESCRIPTION
Fixes #3270

I've left the i18n strings in place, on the off-chance they are used downstream or in plugins 🤷 