### PR TITLE
point pkg.main to cjs modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mirador",
   "version": "3.2.0",
   "description": "An open-source, web-based 'multi-up' viewer that supports zoom-pan-rotate functionality, ability to display/compare simple images, and images with annotations.",
-  "main": "dist/mirador.min.js",
+  "main": "dist/cjs/src/index.js",
   "module": "dist/es/src/index.js",
   "files": [
     "dist"


### PR DESCRIPTION
It is common in many npm projects that the "main" field of the package.json points to the CJS modules. Currently we let the main field point to the UMD bundle. In theory this shouldn't be a problem as UMD supports CJS (as well as AMD and the browser). But it's a bit more complicated:

The UMD is built by Webpack; and when Webpack resolves the import paths of the dependencies it will by default use the ES modules of the libraries (if they provide them). Actually it shouldn't make a difference whether Webpack uses CJS or ES modules from a library. But in some libraries the code of ES and CJS differs slightly to work around plattform differences (e.g. Node vs. browser). That is, the UMD bundle may not work in in CJS environments out of the box even if a library provides alternative CJS code that will work. 

Here is an example of an issue with the Mirador UMD bundle and Jest

Somewhere in my app:
```javascript
import Mirador from 'mirador'

export function createMirador() {
  return Mirador.viewer({ id: 'mirador-container' })
}
```

And the test:
```javascript
import { createMirador } from './somewhere'

test('renders Mirador', function() {
  const container = document.createElement('div')
  container.id = 'mirador-container'
  document.body.append(container)

  createMirador()
  expect(document.getElementsByClassName('mirador-viewer').length).toBe(1)
})
```

Currently without the fix of this PR Jest will throw an error saying:

```
crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported
...
at rng (node_modules/mirador/dist/webpack:/Mirador/node_modules/uuid/dist/esm-browser/rng.js:14:13)
```

The problem here is that Jest is a CJS environment and runs the Mirador UMD bundle that was refered to by pkg.main. The bundle contains code from UUID that uses the browser crypto API which is not supported by jest/jsdom. I think this is not intended by UUID because it also provides code that will work under Jest (see uuid/dist/rng.js).

We can fix that by pointing pkg.main field to the CJS modules of Mirador. That way a CJS environment can decide by itself what kind of modules to import by analyzing the package.json of the libraries.

Do you see any trouble with that? Do you know any tool that expects a UMD bundle at pkg.main rather than a CJS module? Could that change break any integration?


