### PR TITLE
Fix annotation rendering when OSD has viewport margin.

### DIFF
--- a/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
+++ b/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
@@ -17,7 +17,7 @@ describe('OpenSeadragonCanvasOverlay', () => {
         clientWidth: 200,
       },
       viewport: {
-        getBoundsNoRotate: jest.fn(() => ({
+        getBoundsNoRotateWithMargins: jest.fn(() => ({
           height: 300,
           width: 200,
           x: 40,
@@ -92,7 +92,7 @@ describe('OpenSeadragonCanvasOverlay', () => {
           clientWidth: 200,
         },
         viewport: {
-          getBoundsNoRotate: jest.fn(() => (new OpenSeadragon.Rect(0, 0, 200, 200))),
+          getBoundsNoRotateWithMargins: jest.fn(() => (new OpenSeadragon.Rect(0, 0, 200, 200))),
         },
         world: {
           getItemAt: jest.fn(),

--- a/src/lib/OpenSeadragonCanvasOverlay.js
+++ b/src/lib/OpenSeadragonCanvasOverlay.js
@@ -58,7 +58,7 @@ export default class OpenSeadragonCanvasOverlay {
     }
 
     this.viewportOrigin = new OpenSeadragon.Point(0, 0);
-    const boundsRect = this.viewer.viewport.getBoundsNoRotate(true);
+    const boundsRect = this.viewer.viewport.getBoundsNoRotateWithMargins(true);
     this.viewportOrigin.x = boundsRect.x;
     this.viewportOrigin.y = boundsRect.y * this.imgAspectRatio;
 


### PR DESCRIPTION
When users configure a viewport margin for OSD (via `osdConfig.viewportMargins`), annotation rendering would be broken, since the `osd.viewport.getBoundsNoRottate()` call to get the viewport boundary would return the viewport *without* the margin, which would
lead to wrong calculations down the line.
The fix is to simply call `osd.viewport.getBoundsNoRotateWithMargins` instead to obtain the correct full viewport size.

Before:

https://user-images.githubusercontent.com/608610/142643167-04d29575-f44b-41db-abac-2b17407e973a.mp4

After:

https://user-images.githubusercontent.com/608610/142643190-1c69c4d6-d763-4c69-9072-5dd852bf5a12.mp4



