### PR TITLE
Fix error when style props don't have left property (fix #3511)

### DIFF
--- a/src/components/ThumbnailCanvasGrouping.js
+++ b/src/components/ThumbnailCanvasGrouping.js
@@ -44,7 +44,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
           ...style,
           boxSizing: 'content-box',
           height: (Number.isInteger(style.height)) ? style.height - SPACING : null,
-          left: style.left + SPACING,
+          left: (Number.isInteger(style.left)) ? style.left + SPACING : null,
           top: style.top + SPACING,
           width: (Number.isInteger(style.width)) ? style.width - SPACING : null,
         }}


### PR DESCRIPTION
manifest with viewingDirection as 'right-to-left' might not have left property in style thus cause the problem
#3511