### PR TITLE
Scroll the selected image to view in Gallery

### DIFF
--- a/src/components/GalleryViewThumbnail.js
+++ b/src/components/GalleryViewThumbnail.js
@@ -19,11 +19,20 @@ export class GalleryViewThumbnail extends Component {
   constructor(props) {
     super(props);
 
+    this.myRef = React.createRef();
     this.state = { requestedAnnotations: false };
 
     this.handleSelect = this.handleSelect.bind(this);
     this.handleKey = this.handleKey.bind(this);
     this.handleIntersection = this.handleIntersection.bind(this);
+  }
+
+  // eslint-disable-next-line require-jsdoc
+  componentDidMount() {
+    const { selected } = this.props;
+    if (selected) {
+      this.myRef.current?.scrollIntoView(true);
+    }
   }
 
   /** @private */
@@ -112,6 +121,7 @@ export class GalleryViewThumbnail extends Component {
           }
           onClick={this.handleSelect}
           onKeyUp={this.handleKey}
+          ref={this.myRef}
           role="button"
           tabIndex={0}
         >


### PR DESCRIPTION
When gallery view opens in mirador, it always displays images from the beginning of the sequence. This is not user friendly when a user switches from single or book view to gallery view, especially when the current image is not at the beginning of the sequence. Requires a lot of scrolling from the user.  So the aim is to keep the selected image in focus and in view while switching between the views.

For this, we modify `GalleryViewThumbnail` to scroll itself into view if it is marked as selected when it's mounted.