### PR TITLE
Fix unmount not finding container when already detached from document

### DIFF
--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -7,11 +7,18 @@ jest.mock('react-dom');
 jest.mock('isomorphic-unfetch', () => jest.fn(() => Promise.resolve({ json: () => ({}) })));
 
 describe('MiradorViewer', () => {
+  let container;
   let instance;
   beforeAll(() => {
+    container = document.createElement('div');
+    container.id = 'mirador';
+    document.body.appendChild(container);
     ReactDOM.render = jest.fn();
     ReactDOM.unmountComponentAtNode = jest.fn();
     instance = new MiradorViewer({ id: 'mirador' });
+  });
+  afterAll(() => {
+    document.body.removeChild(container);
   });
   describe('constructor', () => {
     it('returns viewer store', () => {

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -19,10 +19,13 @@ class MiradorViewer {
     this.store = viewerConfig.store
       || createPluggableStore(this.config, this.plugins);
 
-    config.id && ReactDOM.render(
-      this.render(),
-      document.getElementById(config.id),
-    );
+    if (config.id) {
+      this.container = document.getElementById(config.id);
+      config.id && ReactDOM.render(
+        this.render(),
+        this.container,
+      );
+    }
   }
 
   /**
@@ -40,7 +43,7 @@ class MiradorViewer {
    * Cleanup method to unmount Mirador from the dom
    */
   unmount() {
-    this.config.id && ReactDOM.unmountComponentAtNode(document.getElementById(this.config.id));
+    this.container && ReactDOM.unmountComponentAtNode(this.container);
   }
 }
 


### PR DESCRIPTION
This PR changes the viewer `unmount` method to not use `document.getElementById` since in in some cases, the container element could be detached from the document.

Closes #3533.