### PR TITLE
Add "related" to the getManifestHomepage selector, fix #3522

### DIFF
--- a/__tests__/fixtures/version-2/related-objects.json
+++ b/__tests__/fixtures/version-2/related-objects.json
@@ -1,0 +1,14 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "http://example.com/iiif/manifest/related-objects.json",
+  "@type": "sc:Manifest",
+  "related": [
+    {
+      "@id": "http://example.com/related1",
+      "label": "1st related"
+    },
+    {
+      "@id": "http://example.com/related2"
+    }
+  ]
+}

--- a/__tests__/fixtures/version-2/related-url.json
+++ b/__tests__/fixtures/version-2/related-url.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "http://example.com/iiif/manifest/related-urls.json",
+  "@type": "sc:Manifest",
+  "related": [
+    "http://example.com/related1",
+    "http://example.com/related2"
+  ]
+}

--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -6,6 +6,8 @@ import manifestFixtureSn904cj3429 from '../../fixtures/version-2/sn904cj3429.jso
 import manifestFixturev3001 from '../../fixtures/version-3/001.json';
 import manifestFixtureWithAProvider from '../../fixtures/version-3/with_a_provider.json';
 import manifestFixtureFg165hz3589 from '../../fixtures/version-2/fg165hz3589.json';
+import manifestFixtureRelatedObjects from '../../fixtures/version-2/related-objects.json';
+import manifestFixtureRelatedUrls from '../../fixtures/version-2/related-url.json';
 import {
   getManifestoInstance,
   getManifestLocale,
@@ -163,6 +165,36 @@ describe('getManifestHomepage', () => {
       {
         label: 'View on Digital Bodleian',
         value: 'https://digital.bodleian.ox.ac.uk/inquire/p/9cca8fdd-4a61-4429-8ac1-f648764b4d6d',
+      },
+    ]);
+  });
+
+  it('should return related urls as homepage', () => {
+    const state = { manifests: { x: { json: manifestFixtureRelatedUrls } } };
+    const received = getManifestHomepage(state, { manifestId: 'x' });
+    expect(received).toEqual([
+      {
+        label: 'http://example.com/related1',
+        value: 'http://example.com/related1',
+      },
+      {
+        label: 'http://example.com/related2',
+        value: 'http://example.com/related2',
+      },
+    ]);
+  });
+
+  it('should return related objects as homepage', () => {
+    const state = { manifests: { x: { json: manifestFixtureRelatedObjects } } };
+    const received = getManifestHomepage(state, { manifestId: 'x' });
+    expect(received).toEqual([
+      {
+        label: '1st related',
+        value: 'http://example.com/related1',
+      },
+      {
+        label: 'http://example.com/related2',
+        value: 'http://example.com/related2',
       },
     ]);
   });

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -120,16 +120,29 @@ export const getManifestProvider = createSelector(
 export const getManifestHomepage = createSelector(
   [
     getProperty('homepage'),
+    getProperty('related'),
     getManifestLocale,
   ],
-  (homepages, locale) => homepages
+  (homepages, relatedLinks, locale) => ((homepages
     && asArray(homepages).map(homepage => (
       {
         label: PropertyValue.parse(homepage.label, locale)
           .getValue(),
         value: homepage.id || homepage['@id'],
       }
-    )),
+    ))) || (relatedLinks
+    && asArray(relatedLinks).map(related => (
+      typeof related === 'string'
+        ? {
+          label: related,
+          value: related,
+        } : {
+          label: PropertyValue.parse(related.label, locale)
+            .getValue() || related.id || related['@id'],
+          value: related.id || related['@id'],
+        }
+    )))
+  ),
 );
 
 /**


### PR DESCRIPTION
Fixes #3522. This is an alternative to #3535. It reuses the `getManifestHomepage` selector for the v2 `related` property. While it is a much simpler approach, it looks like the less clean alternative to me.