### PR TITLE
Allow some more PropTypes.object through eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,13 @@
     }],
     "react/jsx-props-no-spreading": "off",
     "arrow-parens": "off",
-    "import/no-anonymous-default-export": "off"
+    "import/no-anonymous-default-export": "off",
+    "max-len": ["error", {
+      "code": 120,
+      "ignoreComments": true,
+      "ignoreStrings": true,
+      "ignoreTemplateLiterals": true,
+      "ignoreRegExpLiterals": true
+    }]
   }
 }

--- a/src/components/AnnotationsOverlay.js
+++ b/src/components/AnnotationsOverlay.js
@@ -423,7 +423,7 @@ AnnotationsOverlay.defaultProps = {
 };
 
 AnnotationsOverlay.propTypes = {
-  annotations: PropTypes.arrayOf(PropTypes.object),
+  annotations: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   canvasWorld: PropTypes.instanceOf(CanvasWorld).isRequired,
   deselectAnnotation: PropTypes.func,
   drawAnnotations: PropTypes.bool,
@@ -432,7 +432,7 @@ AnnotationsOverlay.propTypes = {
   hoverAnnotation: PropTypes.func,
   hoveredAnnotationIds: PropTypes.arrayOf(PropTypes.string),
   palette: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  searchAnnotations: PropTypes.arrayOf(PropTypes.object),
+  searchAnnotations: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   selectAnnotation: PropTypes.func,
   selectedAnnotationId: PropTypes.string,
   viewer: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/src/components/AudioViewer.js
+++ b/src/components/AudioViewer.js
@@ -32,8 +32,8 @@ export class AudioViewer extends Component {
 
 AudioViewer.propTypes = {
   audioOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  audioResources: PropTypes.arrayOf(PropTypes.object),
-  captions: PropTypes.arrayOf(PropTypes.object),
+  audioResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
+  captions: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -383,7 +383,7 @@ OpenSeadragonViewer.propTypes = {
   children: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   drawAnnotations: PropTypes.bool,
-  infoResponses: PropTypes.arrayOf(PropTypes.object),
+  infoResponses: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   label: PropTypes.string,
   nonTiledImages: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   osdConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/src/components/PrimaryWindow.js
+++ b/src/components/PrimaryWindow.js
@@ -92,13 +92,13 @@ export class PrimaryWindow extends Component {
 }
 
 PrimaryWindow.propTypes = {
-  audioResources: PropTypes.arrayOf(PropTypes.object),
+  audioResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   children: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   isCollection: PropTypes.bool,
   isCollectionDialogVisible: PropTypes.bool,
   isFetching: PropTypes.bool,
-  videoResources: PropTypes.arrayOf(PropTypes.object),
+  videoResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   view: PropTypes.string,
   windowId: PropTypes.string.isRequired,
 };

--- a/src/components/SearchPanelNavigation.js
+++ b/src/components/SearchPanelNavigation.js
@@ -84,7 +84,7 @@ SearchPanelNavigation.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
   direction: PropTypes.string.isRequired,
   numTotal: PropTypes.number,
-  searchHits: PropTypes.arrayOf(PropTypes.object),
+  searchHits: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   searchService: PropTypes.shape({
     id: PropTypes.string,
   }).isRequired,

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -149,8 +149,8 @@ SearchResults.propTypes = {
   isFetching: PropTypes.bool,
   nextSearch: PropTypes.string,
   query: PropTypes.string,
-  searchAnnotations: PropTypes.arrayOf(PropTypes.object),
-  searchHits: PropTypes.arrayOf(PropTypes.object),
+  searchAnnotations: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
+  searchHits: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   searchNumTotal: PropTypes.number,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types

--- a/src/components/VideoViewer.js
+++ b/src/components/VideoViewer.js
@@ -30,10 +30,10 @@ export class VideoViewer extends Component {
 }
 
 VideoViewer.propTypes = {
-  captions: PropTypes.arrayOf(PropTypes.object),
+  captions: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   videoOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  videoResources: PropTypes.arrayOf(PropTypes.object),
+  videoResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
 };
 
 VideoViewer.defaultProps = {

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -162,7 +162,7 @@ WindowSideBarCanvasPanel.propTypes = {
   collection: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   id: PropTypes.string.isRequired,
   sequenceId: PropTypes.string,
-  sequences: PropTypes.arrayOf(PropTypes.object),
+  sequences: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   showMultipart: PropTypes.func.isRequired,
   showToc: PropTypes.bool,
   t: PropTypes.func.isRequired,

--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -179,7 +179,10 @@ export class WorkspaceAdd extends React.Component {
 
 WorkspaceAdd.propTypes = {
   addResource: PropTypes.func,
-  catalog: PropTypes.arrayOf(PropTypes.object),
+  catalog: PropTypes.arrayOf(PropTypes.shape({
+    manifestId: PropTypes.string.isRequired,
+    provider: PropTypes.string,
+  })),
   classes: PropTypes.objectOf(PropTypes.string),
   setWorkspaceAddVisibility: PropTypes.func.isRequired,
   t: PropTypes.func,


### PR DESCRIPTION
Newer versions of eslint catch `PropTypes.arrayOf(PropTypes.object)`. 