### PR TITLE
Load manifests provided by the imported configuration

### DIFF
--- a/__tests__/src/reducers/manifests.test.js
+++ b/__tests__/src/reducers/manifests.test.js
@@ -94,4 +94,10 @@ describe('manifests reducer', () => {
       type: ActionTypes.IMPORT_MIRADOR_STATE,
     })).toEqual({ new: 'stuff' });
   });
+  it('should handle IMPORT_CONFIG setting to load manifests', () => {
+    expect(manifestsReducer({}, {
+      config: { manifests: { new: 'stuff' } },
+      type: ActionTypes.IMPORT_CONFIG,
+    })).toEqual({ new: 'stuff' });
+  });
 });

--- a/src/state/reducers/manifests.js
+++ b/src/state/reducers/manifests.js
@@ -1,4 +1,5 @@
 import omit from 'lodash/omit';
+import deepmerge from 'deepmerge';
 import ActionTypes from '../actions/action-types';
 
 /**
@@ -36,6 +37,9 @@ export const manifestsReducer = (state = {}, action) => {
           isFetching: false,
         },
       };
+    case ActionTypes.UPDATE_CONFIG:
+    case ActionTypes.IMPORT_CONFIG:
+      return deepmerge(state, action.config.manifests || {});
     case ActionTypes.REMOVE_MANIFEST:
       return Object.keys(state).reduce((object, key) => {
         if (key !== action.manifestId) {

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -39,8 +39,10 @@ export function* fetchWindowManifest(action) {
 
   if (!manifestId) return;
 
-  if (action.manifest) {
-    yield put(receiveManifest(manifestId, action.manifest));
+  const sideloadedManifest = action.manifest || (action.payload || {}).manifest;
+
+  if (sideloadedManifest) {
+    yield put(receiveManifest(manifestId, sideloadedManifest));
   } else {
     yield call(fetchManifests, manifestId, ...(collectionPath || []));
   }


### PR DESCRIPTION
TODO:

Collect more use cases for side-loading manifests