### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ If you are interested in integrating Mirador with plugins into your project, we 
 
 [https://github.com/ProjectMirador/mirador-integration](https://github.com/ProjectMirador/mirador-integration)
 
+If you want to simply embed Mirador in an HTML page without further customization, include the Mirador UMD build:
+
+```
+<script src="https://unpkg.com/mirador@latest/dist/mirador.min.js"></script>
+```
+
+More examples of embedding Mirador can be found at [https://github.com/ProjectMirador/mirador/wiki/M3-Embedding-in-Another-Environment#in-an-html-document-with-javascript](https://github.com/ProjectMirador/mirador/wiki/M3-Embedding-in-Another-Environment#in-an-html-document-with-javascript).
+
 ## Adding translations to Mirador
 For help with adding a translation, see [src/locales/README.md](src/locales/README.md)
 


### PR DESCRIPTION
This adds the simplest way to embed Mirador (including a reference to the UMD build) on the base readme. There are regular questions in the IIIF Slack about the fastest way to get started with Mirador without a build system, so this seems like a useful thing to highlight.