### PR TITLE
Stop requiring polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,6 @@
     "redux-mock-store": "^1.5.1",
     "redux-saga-test-plan": "^4.0.0-rc.3",
     "terser-webpack-plugin": "^5.3.1",
-    "unfetch": "^4.1.0",
-    "url-polyfill": "^1.1.7",
     "webpack": "^5.70.0",
     "webpack-cli": "^5.0.0",
     "webpack-dev-server": "^4.7.4"

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -5,5 +5,3 @@
  */
 
 import 'core-js/stable'; // eslint-disable-line import/no-extraneous-dependencies
-import 'url-polyfill/url-polyfill'; // eslint-disable-line import/no-extraneous-dependencies
-import 'unfetch/polyfill'; // eslint-disable-line import/no-extraneous-dependencies


### PR DESCRIPTION
IE is no longer a supported browser.  Edge has switched to Chromium