### PR TITLE
Drop node 14.x from the test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [16.x, 18.x, 19.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
It is no longer receiving active support and security support ends in April 2023 https://endoflife.date/nodejs