### PR TITLE
Change cursor icon when user's cursor is over canvas image

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -23,7 +23,7 @@ export class OpenSeadragonViewer extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { viewer: undefined };
+    this.state = { grabbing: false, viewer: undefined };
     this.ref = createRef();
     this.apiRef = createRef();
     OSDReferences.set(props.windowId, this.apiRef);
@@ -57,6 +57,15 @@ export class OpenSeadragonViewer extends Component {
     this.apiRef.current = viewer;
 
     this.setState({ viewer });
+
+    viewer.addHandler('canvas-press', () => {
+      this.setState({ grabbing: true });
+    });
+
+    viewer.addHandler('canvas-release', () => {
+      console.log('canvas-release!');
+      this.setState({ grabbing: false });
+    });
 
     // Set a flag when OSD starts animating (so that viewer updates are not used)
     viewer.addHandler('animation-start', () => {
@@ -345,7 +354,7 @@ export class OpenSeadragonViewer extends Component {
       children, classes, label, t, windowId,
       drawAnnotations,
     } = this.props;
-    const { viewer } = this.state;
+    const { viewer, grabbing } = this.state;
 
     const enhancedChildren = Children.map(children, child => (
       cloneElement(
@@ -359,6 +368,7 @@ export class OpenSeadragonViewer extends Component {
     return (
       <section
         className={classNames(ns('osd-container'), classes.osdContainer)}
+        style={{ cursor: grabbing ? 'grabbing' : 'grab' }}
         id={`${windowId}-osd`}
         ref={this.ref}
         aria-label={t('item', { label })}

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -367,7 +367,7 @@ export class OpenSeadragonViewer extends Component {
     return (
       <section
         className={classNames(ns('osd-container'), classes.osdContainer)}
-        style={{ cursor: grabbing ? 'grabbing' : 'grab' }}
+        style={{ cursor: grabbing ? 'grabbing' : undefined }}
         id={`${windowId}-osd`}
         ref={this.ref}
         aria-label={t('item', { label })}

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -63,7 +63,6 @@ export class OpenSeadragonViewer extends Component {
     });
 
     viewer.addHandler('canvas-release', () => {
-      console.log('canvas-release!');
       this.setState({ grabbing: false });
     });
 

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -58,11 +58,11 @@ export class OpenSeadragonViewer extends Component {
 
     this.setState({ viewer });
 
-    viewer.addHandler('canvas-press', () => {
+    viewer.addHandler('canvas-drag', () => {
       this.setState({ grabbing: true });
     });
 
-    viewer.addHandler('canvas-release', () => {
+    viewer.addHandler('canvas-drag-end', () => {
       this.setState({ grabbing: false });
     });
 

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -58,6 +58,7 @@ const mapDispatchToProps = {
 const styles = {
   osdContainer: {
     flex: 1,
+    pointer: 'grab',
     position: 'relative',
   },
 };

--- a/src/containers/OpenSeadragonViewer.js
+++ b/src/containers/OpenSeadragonViewer.js
@@ -57,8 +57,8 @@ const mapDispatchToProps = {
 
 const styles = {
   osdContainer: {
+    cursor: 'grab',
     flex: 1,
-    pointer: 'grab',
     position: 'relative',
   },
 };

--- a/src/containers/WindowCanvasNavigationControls.js
+++ b/src/containers/WindowCanvasNavigationControls.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state, { windowId }) => ({
  */
 const styles = theme => ({
   canvasNav: {
+    cursor: 'default',
     display: 'flex',
     flexDirection: 'row',
     flexWrap: 'wrap',


### PR DESCRIPTION
This PR solves this issue: https://github.com/ProjectMirador/mirador/issues/3325

This PR adds viewer handlers for the [canvas-press](https://openseadragon.github.io/docs/OpenSeadragon.Viewer.html#.event:canvas-press) and [canvas-release](https://openseadragon.github.io/docs/OpenSeadragon.Viewer.html#.event:canvas-release) OpenSeadragon events then adds that value to the state. 

The state determines which [CSS cursor icon](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) is used (`grab` or `grabbing`) in the style attribute of the `<section>` tag. 