### PR TITLE
Use context to manage access to the workspace ref instead of going through redux

### DIFF
--- a/__tests__/src/components/MiradorMenuButton.test.js
+++ b/__tests__/src/components/MiradorMenuButton.test.js
@@ -9,7 +9,7 @@ import { MiradorMenuButton } from '../../../src/components/MiradorMenuButton';
 */
 function createWrapper(props) {
   return shallow(
-    <MiradorMenuButton aria-label="The Label" containerId="mirador" {...props}>
+    <MiradorMenuButton aria-label="The Label" {...props}>
       icon
     </MiradorMenuButton>,
   );

--- a/__tests__/src/components/SearchPanelControls.test.js
+++ b/__tests__/src/components/SearchPanelControls.test.js
@@ -55,7 +55,7 @@ describe('SearchPanelControls', () => {
       .dive();
     expect(divedInput.find(CircularProgress).length).toEqual(0);
     expect(divedInput.find(SearchIcon).length).toEqual(1);
-    expect(divedInput.find('Connect(WithPlugins(MiradorMenuButton))[type="submit"]').length).toEqual(1);
+    expect(divedInput.find('WithWorkspaceContext(WithPlugins(MiradorMenuButton))[type="submit"]').length).toEqual(1);
   });
 
   it('endAdornment has a CircularProgress indicator when there the current search is fetching', () => {

--- a/__tests__/src/components/SearchPanelNavigation.test.js
+++ b/__tests__/src/components/SearchPanelNavigation.test.js
@@ -25,10 +25,10 @@ describe('SearchPanelNavigation', () => {
         selectedContentSearchAnnotation: ['2'],
       });
       expect(wrapper.find('WithStyles(ForwardRef(Typography))').text()).toEqual('pagination');
-      expect(wrapper.find('Connect(WithPlugins(MiradorMenuButton))[disabled=false]').length).toEqual(2);
-      wrapper.find('Connect(WithPlugins(MiradorMenuButton))[disabled=false]').first().props().onClick();
+      expect(wrapper.find('WithWorkspaceContext(WithPlugins(MiradorMenuButton))[disabled=false]').length).toEqual(2);
+      wrapper.find('WithWorkspaceContext(WithPlugins(MiradorMenuButton))[disabled=false]').first().props().onClick();
       expect(selectAnnotation).toHaveBeenCalledWith('1');
-      wrapper.find('Connect(WithPlugins(MiradorMenuButton))[disabled=false]').last().props().onClick();
+      wrapper.find('WithWorkspaceContext(WithPlugins(MiradorMenuButton))[disabled=false]').last().props().onClick();
       expect(selectAnnotation).toHaveBeenCalledWith('3');
     });
     it('buttons disabled when no next/prev', () => {
@@ -36,7 +36,7 @@ describe('SearchPanelNavigation', () => {
         searchHits: [{ annotations: ['1'] }],
         selectedContentSearchAnnotation: ['1'],
       });
-      expect(wrapper.find('Connect(WithPlugins(MiradorMenuButton))[disabled=true]').length).toEqual(2);
+      expect(wrapper.find('WithWorkspaceContext(WithPlugins(MiradorMenuButton))[disabled=true]').length).toEqual(2);
     });
   });
 });

--- a/__tests__/src/components/WindowList.test.js
+++ b/__tests__/src/components/WindowList.test.js
@@ -16,7 +16,6 @@ describe('WindowList', () => {
 
     wrapper = shallow(
       <WindowList
-        containerId="mirador"
         anchorEl={{}}
         titles={titles}
         windowIds={[]}
@@ -34,7 +33,6 @@ describe('WindowList', () => {
     beforeEach(() => {
       wrapper = shallow(
         <WindowList
-          containerId="mirador"
           anchorEl={{}}
           titles={titles}
           windowIds={['xyz']}
@@ -63,7 +61,6 @@ describe('WindowList', () => {
 
       wrapper = shallow(
         <WindowList
-          containerId="mirador"
           anchorEl={{}}
           titles={titles}
           windowIds={['xyz']}

--- a/__tests__/src/components/WindowTopBarPluginMenu.test.js
+++ b/__tests__/src/components/WindowTopBarPluginMenu.test.js
@@ -8,7 +8,6 @@ import { WindowTopBarPluginMenu } from '../../../src/components/WindowTopBarPlug
 function createWrapper(props) {
   return shallow(
     <WindowTopBarPluginMenu
-      containerId="abc123-container"
       t={k => k}
       windowId="abc123"
       {...props}

--- a/__tests__/src/components/WindowTopMenu.test.js
+++ b/__tests__/src/components/WindowTopMenu.test.js
@@ -8,7 +8,6 @@ import { WindowTopMenu } from '../../../src/components/WindowTopMenu';
 function createWrapper(props) {
   return shallow(
     <WindowTopMenu
-      containerId="mirador"
       windowId="xyz"
       handleClose={() => {}}
       anchorEl={null}

--- a/__tests__/src/components/WorkspaceMenu.test.js
+++ b/__tests__/src/components/WorkspaceMenu.test.js
@@ -7,7 +7,6 @@ import { WorkspaceMenu } from '../../../src/components/WorkspaceMenu';
 function createShallow(props) {
   return shallow(
     <WorkspaceMenu
-      containerId="mirador"
       showThemePicker
       {...props}
     />,

--- a/__tests__/src/components/WorkspaceOptionsMenu.test.js
+++ b/__tests__/src/components/WorkspaceOptionsMenu.test.js
@@ -8,7 +8,6 @@ import { WorkspaceOptionsMenu } from '../../../src/components/WorkspaceOptionsMe
 function createShallow(props) {
   return shallow(
     <WorkspaceOptionsMenu
-      containerId="mirador"
       handleClose={() => {}}
       t={k => k}
       {...props}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,10 @@
-import { Component, lazy, Suspense } from 'react';
+import {
+  createRef, Component, lazy, Suspense,
+} from 'react';
 import PropTypes from 'prop-types';
 import PluginProvider from '../extend/PluginProvider';
 import AppProviders from '../containers/AppProviders';
+import WorkspaceContext from '../contexts/WorkspaceContext';
 
 const WorkspaceArea = lazy(() => import('../containers/WorkspaceArea'));
 
@@ -10,6 +13,13 @@ const WorkspaceArea = lazy(() => import('../containers/WorkspaceArea'));
  * @prop {Object} manifests
  */
 export class App extends Component {
+  /** */
+  constructor(props) {
+    super(props);
+
+    this.areaRef = createRef();
+  }
+
   /**
    * render
    * @return {String} - HTML markup for the component
@@ -20,11 +30,13 @@ export class App extends Component {
     return (
       <PluginProvider plugins={plugins}>
         <AppProviders dndManager={dndManager}>
-          <Suspense
-            fallback={<div />}
-          >
-            <WorkspaceArea />
-          </Suspense>
+          <WorkspaceContext.Provider value={this.areaRef}>
+            <Suspense
+              fallback={<div />}
+            >
+              <WorkspaceArea areaRef={this.areaRef} />
+            </Suspense>
+          </WorkspaceContext.Provider>
         </AppProviders>
       </PluginProvider>
     );

--- a/src/components/CollectionDialog.js
+++ b/src/components/CollectionDialog.js
@@ -102,8 +102,8 @@ export class CollectionDialog extends Component {
 
   /** */
   dialogContainer() {
-    const { containerId, windowId } = this.props;
-    return document.querySelector(`#${containerId} #${windowId}`);
+    const { container, windowId } = this.props;
+    return (container?.current || document.body).querySelector(`#${windowId}`);
   }
 
   /** */
@@ -276,7 +276,7 @@ CollectionDialog.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   collection: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   collectionPath: PropTypes.arrayOf(PropTypes.string),
-  containerId: PropTypes.string,
+  container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   error: PropTypes.string,
   hideCollectionDialog: PropTypes.func.isRequired,
   isMultipart: PropTypes.bool,
@@ -293,7 +293,7 @@ CollectionDialog.propTypes = {
 CollectionDialog.defaultProps = {
   collection: null,
   collectionPath: [],
-  containerId: null,
+  container: null,
   error: null,
   isMultipart: false,
   ready: false,

--- a/src/components/MiradorMenuButton.js
+++ b/src/components/MiradorMenuButton.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import Badge from '@material-ui/core/Badge';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
-import ns from '../config/css-ns';
 
 /**
  * MiradorMenuButton ~ Wrap the given icon prop in an IconButton and a Tooltip.
@@ -14,7 +13,7 @@ export function MiradorMenuButton(props) {
   const {
     badge,
     children,
-    containerId,
+    container,
     dispatch,
     BadgeProps,
     TooltipProps,
@@ -34,7 +33,7 @@ export function MiradorMenuButton(props) {
   return (
     <Tooltip
       PopperProps={{
-        container: document.querySelector(`#${containerId} .${ns('viewer')}`),
+        container: container?.current,
       }}
       title={ariaLabel}
       {...TooltipProps}
@@ -49,7 +48,7 @@ MiradorMenuButton.propTypes = {
   badge: PropTypes.bool,
   BadgeProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   children: PropTypes.element.isRequired,
-  containerId: PropTypes.string.isRequired,
+  container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   dispatch: PropTypes.func,
   TooltipProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
@@ -57,6 +56,7 @@ MiradorMenuButton.propTypes = {
 MiradorMenuButton.defaultProps = {
   badge: false,
   BadgeProps: {},
+  container: null,
   dispatch: () => {},
   TooltipProps: {},
 };

--- a/src/components/WindowList.js
+++ b/src/components/WindowList.js
@@ -4,7 +4,6 @@ import MenuItem from '@material-ui/core/MenuItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import PropTypes from 'prop-types';
-import ns from '../config/css-ns';
 
 /**
  */
@@ -35,7 +34,7 @@ export class WindowList extends Component {
    */
   render() {
     const {
-      containerId, handleClose, anchorEl, windowIds, focusWindow, t,
+      container, handleClose, anchorEl, windowIds, focusWindow, t,
     } = this.props;
 
     return (
@@ -49,7 +48,7 @@ export class WindowList extends Component {
           vertical: 'top',
         }}
         id="window-list-menu"
-        container={document.querySelector(`#${containerId} .${ns('viewer')}`)}
+        container={container?.current}
         disableAutoFocusItem
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
@@ -82,7 +81,7 @@ export class WindowList extends Component {
 
 WindowList.propTypes = {
   anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  containerId: PropTypes.string.isRequired,
+  container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   focusWindow: PropTypes.func.isRequired,
   handleClose: PropTypes.func.isRequired,
   t: PropTypes.func,
@@ -92,6 +91,7 @@ WindowList.propTypes = {
 
 WindowList.defaultProps = {
   anchorEl: null,
+  container: null,
   t: key => key,
   titles: {},
 };

--- a/src/components/WindowTopBarPluginMenu.js
+++ b/src/components/WindowTopBarPluginMenu.js
@@ -4,7 +4,6 @@ import MoreVertIcon from '@material-ui/icons/MoreVertSharp';
 import Menu from '@material-ui/core/Menu';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 import { PluginHook } from './PluginHook';
-import ns from '../config/css-ns';
 
 /**
  *
@@ -45,7 +44,7 @@ export class WindowTopBarPluginMenu extends Component {
    */
   render() {
     const {
-      classes, containerId, PluginComponents, t, windowId, menuIcon,
+      classes, container, PluginComponents, t, windowId, menuIcon,
     } = this.props;
     const { anchorEl } = this.state;
 
@@ -65,7 +64,7 @@ export class WindowTopBarPluginMenu extends Component {
 
         <Menu
           id={`window-plugin-menu_${windowId}`}
-          container={document.querySelector(`#${containerId} .${ns('viewer')}`)}
+          container={container?.current}
           anchorEl={anchorEl}
           anchorOrigin={{
             horizontal: 'right',
@@ -90,7 +89,7 @@ WindowTopBarPluginMenu.propTypes = {
   classes: PropTypes.shape({
     ctrlBtnSelected: PropTypes.string,
   }),
-  containerId: PropTypes.string.isRequired,
+  container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   menuIcon: PropTypes.element,
   PluginComponents: PropTypes.arrayOf(
     PropTypes.node,
@@ -101,6 +100,7 @@ WindowTopBarPluginMenu.propTypes = {
 
 WindowTopBarPluginMenu.defaultProps = {
   classes: {},
+  container: null,
   menuIcon: <MoreVertIcon />,
   PluginComponents: [],
 };

--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import WindowThumbnailSettings from '../containers/WindowThumbnailSettings';
 import WindowViewSettings from '../containers/WindowViewSettings';
 import { PluginHook } from './PluginHook';
-import ns from '../config/css-ns';
 
 /** Renders plugins */
 function PluginHookWithHeader(props) {
@@ -27,14 +26,14 @@ export class WindowTopMenu extends Component {
    */
   render() {
     const {
-      containerId, handleClose, anchorEl, showThumbnailNavigationSettings,
+      container, handleClose, anchorEl, showThumbnailNavigationSettings,
       toggleDraggingEnabled, windowId,
     } = this.props;
 
     return (
       <Menu
         id={`window-menu_${windowId}`}
-        container={document.querySelector(`#${containerId} .${ns('viewer')}`)}
+        container={container?.current}
         anchorEl={anchorEl}
         anchorOrigin={{
           horizontal: 'right',
@@ -64,7 +63,7 @@ export class WindowTopMenu extends Component {
 
 WindowTopMenu.propTypes = {
   anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  containerId: PropTypes.string.isRequired,
+  container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   handleClose: PropTypes.func.isRequired,
   showThumbnailNavigationSettings: PropTypes.bool,
   toggleDraggingEnabled: PropTypes.func.isRequired,
@@ -73,5 +72,6 @@ WindowTopMenu.propTypes = {
 
 WindowTopMenu.defaultProps = {
   anchorEl: null,
+  container: null,
   showThumbnailNavigationSettings: true,
 };

--- a/src/components/WorkspaceArea.js
+++ b/src/components/WorkspaceArea.js
@@ -19,6 +19,7 @@ export class WorkspaceArea extends Component {
    */
   render() {
     const {
+      areaRef,
       classes,
       controlPanelVariant,
       isWorkspaceAddVisible,
@@ -37,6 +38,7 @@ export class WorkspaceArea extends Component {
           className={classNames(classes.viewer, ns('viewer'))}
           lang={lang}
           aria-label={t('workspace')}
+          {...(areaRef ? { ref: areaRef } : {})}
         >
           {
             isWorkspaceAddVisible
@@ -52,6 +54,7 @@ export class WorkspaceArea extends Component {
 }
 
 WorkspaceArea.propTypes = {
+  areaRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   controlPanelVariant: PropTypes.string,
   isWorkspaceAddVisible: PropTypes.bool,
@@ -61,6 +64,7 @@ WorkspaceArea.propTypes = {
 };
 
 WorkspaceArea.defaultProps = {
+  areaRef: null,
   controlPanelVariant: undefined,
   isWorkspaceAddVisible: false,
   lang: undefined,

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import LanguageSettings from '../containers/LanguageSettings';
 import { NestedMenu } from './NestedMenu';
 import WorkspaceSelectionDialog from '../containers/WorkspaceSelectionDialog';
-import ns from '../config/css-ns';
 import ChangeThemeDialog from '../containers/ChangeThemeDialog';
 import { PluginHook } from './PluginHook';
 
@@ -65,7 +64,7 @@ export class WorkspaceMenu extends Component {
    */
   render() {
     const {
-      containerId,
+      container,
       handleClose,
       anchorEl,
       showThemePicker,
@@ -80,13 +79,11 @@ export class WorkspaceMenu extends Component {
       workspaceSelection,
     } = this.state;
 
-    const container = document.querySelector(`#${containerId} .${ns('viewer')}`);
-
     return (
       <>
         <Menu
           id="workspace-menu"
-          container={container}
+          container={container?.current}
           anchorEl={anchorEl}
           anchorOrigin={{
             horizontal: 'right',
@@ -133,7 +130,7 @@ export class WorkspaceMenu extends Component {
         </Menu>
         {Boolean(changeTheme.open) && (
           <ChangeThemeDialog
-            container={container}
+            container={container?.current}
             handleClose={this.handleMenuItemClose('changeTheme')}
             open={Boolean(changeTheme.open)}
           />
@@ -141,7 +138,7 @@ export class WorkspaceMenu extends Component {
         {Boolean(workspaceSelection.open) && (
           <WorkspaceSelectionDialog
             open={Boolean(workspaceSelection.open)}
-            container={container}
+            container={container?.current}
             handleClose={this.handleMenuItemClose('workspaceSelection')}
           />
         )}
@@ -152,7 +149,7 @@ export class WorkspaceMenu extends Component {
 
 WorkspaceMenu.propTypes = {
   anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  containerId: PropTypes.string.isRequired,
+  container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   handleClose: PropTypes.func.isRequired,
   isWorkspaceAddVisible: PropTypes.bool,
   showThemePicker: PropTypes.bool,
@@ -163,6 +160,7 @@ WorkspaceMenu.propTypes = {
 
 WorkspaceMenu.defaultProps = {
   anchorEl: null,
+  container: null,
   isWorkspaceAddVisible: false,
   showThemePicker: false,
   showZoomControls: false,

--- a/src/components/WorkspaceOptionsMenu.js
+++ b/src/components/WorkspaceOptionsMenu.js
@@ -9,7 +9,6 @@ import Typography from '@material-ui/core/Typography';
 import WorkspaceExport from '../containers/WorkspaceExport';
 import WorkspaceImport from '../containers/WorkspaceImport';
 import { PluginHook } from './PluginHook';
-import ns from '../config/css-ns';
 
 /**
  * WorkspaceOptionsMenu ~ the menu for workspace options such as import/export
@@ -55,16 +54,15 @@ export class WorkspaceOptionsMenu extends Component {
   */
   render() {
     const {
-      anchorEl, containerId, handleClose, t,
+      anchorEl, container, handleClose, t,
     } = this.props;
     const { exportWorkspace, importWorkspace } = this.state;
-    const container = document.querySelector(`#${containerId} .${ns('viewer')}`);
 
     return (
       <>
         <Menu
           id="workspace-options-menu"
-          container={container}
+          container={container?.current}
           anchorEl={anchorEl}
           anchorOrigin={{
             horizontal: 'right',
@@ -103,14 +101,14 @@ export class WorkspaceOptionsMenu extends Component {
         {Boolean(exportWorkspace.open) && (
           <WorkspaceExport
             open={Boolean(exportWorkspace.open)}
-            container={container}
+            container={container?.current}
             handleClose={this.handleMenuItemClose('exportWorkspace')}
           />
         )}
         {Boolean(importWorkspace.open) && (
           <WorkspaceImport
             open={Boolean(importWorkspace.open)}
-            container={container}
+            container={container?.current}
             handleClose={this.handleMenuItemClose('importWorkspace')}
           />
         )}
@@ -121,11 +119,12 @@ export class WorkspaceOptionsMenu extends Component {
 
 WorkspaceOptionsMenu.propTypes = {
   anchorEl: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  containerId: PropTypes.string.isRequired,
+  container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   handleClose: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
 };
 
 WorkspaceOptionsMenu.defaultProps = {
   anchorEl: null,
+  container: null,
 };

--- a/src/containers/CollectionDialog.js
+++ b/src/containers/CollectionDialog.js
@@ -5,9 +5,10 @@ import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
 import {
-  getContainerId, getManifest, getManifestoInstance, getSequenceBehaviors, getWindow,
+  getManifest, getManifestoInstance, getSequenceBehaviors, getWindow,
 } from '../state/selectors';
 import { CollectionDialog } from '../components/CollectionDialog';
+import { withWorkspaceContext } from '../contexts/WorkspaceContext';
 
 /**
  * mapDispatchToProps - used to hook up connect to action creators
@@ -37,7 +38,6 @@ const mapStateToProps = (state, { windowId }) => {
   return {
     collection: collection && getManifestoInstance(state, { manifestId: collection.id }),
     collectionPath,
-    containerId: getContainerId(state),
     error: manifest && manifest.error,
     isMultipart: getSequenceBehaviors(state, { manifestId }).includes('multi-part'),
     manifest: manifest && getManifestoInstance(state, { manifestId }),
@@ -86,6 +86,7 @@ const styles = theme => ({
 const enhance = compose(
   withTranslation(),
   withStyles(styles),
+  withWorkspaceContext,
   connect(mapStateToProps, mapDispatchToProps),
   withPlugins('CollectionDialog'),
 );

--- a/src/containers/MiradorMenuButton.js
+++ b/src/containers/MiradorMenuButton.js
@@ -1,16 +1,10 @@
 import { compose } from 'redux';
-import { connect } from 'react-redux';
 import { withPlugins } from '../extend/withPlugins';
 import { MiradorMenuButton } from '../components/MiradorMenuButton';
-import { getContainerId } from '../state/selectors';
-
-/** */
-const mapStateToProps = state => ({
-  containerId: getContainerId(state),
-});
+import { withWorkspaceContext } from '../contexts/WorkspaceContext';
 
 const enhance = compose(
-  connect(mapStateToProps, null),
+  withWorkspaceContext,
   withPlugins('MiradorMenuButton'),
 );
 

--- a/src/containers/WindowList.js
+++ b/src/containers/WindowList.js
@@ -3,8 +3,9 @@ import { compose } from 'redux';
 import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
-import { getContainerId, getWindowIds, getWindowTitles } from '../state/selectors';
+import { getWindowIds, getWindowTitles } from '../state/selectors';
 import { WindowList } from '../components/WindowList';
+import { withWorkspaceContext } from '../contexts/WorkspaceContext';
 
 /**
  * mapDispatchToProps - used to hook up connect to action creators
@@ -22,7 +23,6 @@ const mapDispatchToProps = {
  */
 const mapStateToProps = state => (
   {
-    containerId: getContainerId(state),
     titles: getWindowTitles(state),
     windowIds: getWindowIds(state),
   }
@@ -30,6 +30,7 @@ const mapStateToProps = state => (
 
 const enhance = compose(
   withTranslation(),
+  withWorkspaceContext,
   connect(mapStateToProps, mapDispatchToProps),
   withPlugins('WindowList'),
 );

--- a/src/containers/WindowTopBarPluginMenu.js
+++ b/src/containers/WindowTopBarPluginMenu.js
@@ -1,19 +1,9 @@
 import { compose } from 'redux';
-import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { withStyles } from '@material-ui/core';
 import { withPlugins } from '../extend/withPlugins';
 import { WindowTopBarPluginMenu } from '../components/WindowTopBarPluginMenu';
-import { getContainerId } from '../state/selectors';
-
-/**
- * mapStateToProps - to hook up connect
- * @memberof WindowTopBarPluginMenu
- * @private
- */
-const mapStateToProps = state => ({
-  containerId: getContainerId(state),
-});
+import { withWorkspaceContext } from '../contexts/WorkspaceContext';
 
 /**
  *
@@ -28,8 +18,8 @@ const styles = theme => ({
 
 const enhance = compose(
   withTranslation(),
+  withWorkspaceContext,
   withStyles(styles),
-  connect(mapStateToProps, null),
   withPlugins('WindowTopBarPluginMenu'),
 );
 

--- a/src/containers/WindowTopMenu.js
+++ b/src/containers/WindowTopMenu.js
@@ -4,7 +4,8 @@ import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
 import { WindowTopMenu } from '../components/WindowTopMenu';
-import { getConfig, getContainerId } from '../state/selectors';
+import { getConfig } from '../state/selectors';
+import { withWorkspaceContext } from '../contexts/WorkspaceContext';
 
 /**
  * mapStateToProps - to hook up connect
@@ -12,7 +13,6 @@ import { getConfig, getContainerId } from '../state/selectors';
  * @private
  */
 const mapStateToProps = state => ({
-  containerId: getContainerId(state),
   showThumbnailNavigationSettings: getConfig(state).thumbnailNavigation.displaySettings,
 });
 
@@ -27,6 +27,7 @@ const mapDispatchToProps = dispatch => ({
 
 const enhance = compose(
   withTranslation(),
+  withWorkspaceContext,
   connect(mapStateToProps, mapDispatchToProps),
   withPlugins('WindowTopMenu'),
 );

--- a/src/containers/WorkspaceMenu.js
+++ b/src/containers/WorkspaceMenu.js
@@ -4,9 +4,10 @@ import { withTranslation } from 'react-i18next';
 import { withPlugins } from '../extend/withPlugins';
 import * as actions from '../state/actions';
 import {
-  getContainerId, getShowZoomControlsConfig, getThemeIds,
+  getShowZoomControlsConfig, getThemeIds,
   getWorkspace,
 } from '../state/selectors';
+import { withWorkspaceContext } from '../contexts/WorkspaceContext';
 import { WorkspaceMenu } from '../components/WorkspaceMenu';
 
 /**
@@ -24,7 +25,6 @@ const mapDispatchToProps = {
  * @private
  */
 const mapStateToProps = state => ({
-  containerId: getContainerId(state),
   isWorkspaceAddVisible: getWorkspace(state).isWorkspaceAddVisible,
   showThemePicker: getThemeIds(state).length > 0,
   showZoomControls: getShowZoomControlsConfig(state),
@@ -32,6 +32,7 @@ const mapStateToProps = state => ({
 
 const enhance = compose(
   withTranslation(),
+  withWorkspaceContext,
   connect(mapStateToProps, mapDispatchToProps),
   withPlugins('WorkspaceMenu'),
 );

--- a/src/containers/WorkspaceOptionsMenu.js
+++ b/src/containers/WorkspaceOptionsMenu.js
@@ -1,18 +1,11 @@
 import { compose } from 'redux';
-import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import { getContainerId } from '../state/selectors';
+import { withWorkspaceContext } from '../contexts/WorkspaceContext';
 import { WorkspaceOptionsMenu } from '../components/WorkspaceOptionsMenu';
 
-/** Used for connect */
-const mapStateToProps = state => ({
-  containerId: getContainerId(state),
-});
-
-// containerId: getContainerId(state),/
 const enhance = compose(
   withTranslation(),
-  connect(mapStateToProps, null),
+  withWorkspaceContext,
 );
 
 export default enhance(WorkspaceOptionsMenu);

--- a/src/contexts/WorkspaceContext.js
+++ b/src/contexts/WorkspaceContext.js
@@ -1,0 +1,36 @@
+import {
+  createContext, useContext, useState, useEffect, forwardRef,
+} from 'react';
+
+const WorkspaceContext = createContext({ current: document.body });
+
+/**
+ * @returns HOC that injects the workspace ref into the component
+ */
+export const withWorkspaceContext = (Component) => {
+  /**
+   * Wrap the component with the context
+   */
+  function ContextHoc(props, ref) {
+    const workspaceContext = useContext(WorkspaceContext);
+
+    const [workspaceRef, setWorkspaceRef] = useState();
+
+    useEffect(() => {
+      setWorkspaceRef(workspaceContext);
+    }, [workspaceContext]);
+
+    const passDownProps = {
+      ...props,
+      ...(ref ? { ref } : {}),
+    };
+
+    return <Component container={workspaceRef} {...passDownProps} />;
+  }
+
+  const whatever = forwardRef(ContextHoc);
+  whatever.displayName = `WithWorkspaceContext(${Component.displayName || Component.name || 'Component'})`;
+  return whatever;
+};
+
+export default WorkspaceContext;

--- a/src/state/selectors/config.js
+++ b/src/state/selectors/config.js
@@ -72,6 +72,7 @@ export const getThemeIds = createSelector(
   ({ themes }) => Object.keys(themes),
 );
 
+/* @deprecated */
 export const getContainerId = createSelector(
   [getConfig],
   ({ id }) => id,


### PR DESCRIPTION
We're passing the container id around in order to provide the right context for tooltips, dialogs, etc (e.g. #2233). Storing this in redux has been... fine, but it's going to be a pain with react-testing-library because we'll have to mock out that state and deal with more connected components than we'd otherwise have to.

The new workspace context gets us out of that, means we're passing around refs instead of DOM IDs (probably a net good?), and lets us fall back on a reasonable default if there's no context available.
