### PR TITLE
WIP: get the provider logo thumbnail

### DIFF
--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -15,7 +15,7 @@ import {
   getManifestLogo,
   getManifestDescription,
   getManifestHomepage,
-  getManifestProvider,
+  getManifestProviderName,
   getManifestTitle,
   getManifestThumbnail,
   getManifestMetadata,
@@ -159,15 +159,15 @@ describe('getManifestSummary', () => {
   });
 });
 
-describe('getManifestProvider', () => {
+describe('getManifestProviderName', () => {
   it('should return manifest provider label', () => {
     const state = { manifests: { x: { json: manifestFixtureWithAProvider } } };
-    const received = getManifestProvider(state, { manifestId: 'x' });
+    const received = getManifestProviderName(state, { manifestId: 'x' });
     expect(received).toBe('Example Organization');
   });
 
   it('should return undefined if manifest undefined', () => {
-    const received = getManifestProvider({ manifests: {} }, { manifestId: 'x' });
+    const received = getManifestProviderName({ manifests: {} }, { manifestId: 'x' });
     expect(received).toBeUndefined();
   });
 });

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -6,7 +6,7 @@ import { withPlugins } from '../extend/withPlugins';
 import {
   getManifest,
   getManifestTitle, getManifestThumbnail, getCanvases,
-  getManifestLogo, getManifestProvider, getWindowManifests,
+  getManifestLogo, getManifestProviderName, getWindowManifests,
   getManifestoInstance, getSequenceBehaviors,
 } from '../state/selectors';
 import * as actions from '../state/actions';
@@ -32,7 +32,7 @@ const mapStateToProps = (state, { manifestId, provider }) => {
       && getSequenceBehaviors(state, { manifestId }).includes('multi-part'),
     manifestLogo: getManifestLogo(state, { manifestId }),
     provider: provider
-      || getManifestProvider(state, { manifestId }),
+      || getManifestProviderName(state, { manifestId }),
     ready: !!manifest.json,
     size,
     thumbnail: getManifestThumbnail(state, { manifestId }),

--- a/src/lib/ImageFactory.js
+++ b/src/lib/ImageFactory.js
@@ -1,0 +1,178 @@
+import MiradorCanvas from './MiradorCanvas';
+import asArray from './asArray';
+import { ThumbnailUtils } from './ThumbnailUtils';
+
+/** */
+class ImageFactory {
+  /** */
+  constructor(resource, imageService, getSourceContentResource, iiifOpts = {}) {
+    this.resource = resource;
+    this.iiifOpts = iiifOpts;
+    this.iiifImageService = imageService;
+    this.getSourceContentResource = getSourceContentResource;
+  }
+
+  /** */
+  static staticImageUrl(resource) {
+    return { height: resource.height, url: resource.id, width: resource.width };
+  }
+
+  /**
+   * Selects the image resource that is representative of the given canvas.
+   * @param {Object} canvas A Manifesto Canvas
+   * @return {Object} A Manifesto Image Resource
+   */
+  static getPreferredImage(canvas) {
+    const miradorCanvas = new MiradorCanvas(canvas);
+    return miradorCanvas.iiifImageResources[0] || miradorCanvas.imageResource;
+  }
+
+  /**
+   * Chooses the best available image size based on a target area (w x h) value.
+   * @param {Object} service A IIIF Image API service that has a `sizes` array
+   * @param {Number} targetArea The target area value to compare potential sizes against
+   * @return {Object|undefined} The best size, or undefined if none are acceptable
+   */
+  static selectBestImageSize(service, targetArea) {
+    const sizes = asArray(service.sizes);
+
+    let closestSize = {
+      default: true,
+      height: service.height || Number.MAX_SAFE_INTEGER,
+      width: service.width || Number.MAX_SAFE_INTEGER,
+    };
+
+    /** Compare the total image area to our target */
+    const imageFitness = (test) => test.width * test.height - targetArea;
+
+    /** Look for the size that's just bigger than we prefer... */
+    closestSize = sizes.reduce((best, test) => {
+      const score = imageFitness(test);
+
+      if (score < 0) return best;
+
+      return Math.abs(score) < Math.abs(imageFitness(best))
+        ? test
+        : best;
+    }, closestSize);
+
+    /** .... but not "too" big; we'd rather scale up an image than download too much */
+    if (closestSize.width * closestSize.height > targetArea * 6) {
+      closestSize = sizes.reduce((best, test) => (
+        Math.abs(imageFitness(test)) < Math.abs(imageFitness(best))
+          ? test
+          : best
+      ), closestSize);
+    }
+
+    if (closestSize.default) return undefined;
+
+    return closestSize;
+  }
+
+  /**
+   * Determines the appropriate thumbnail to use to represent an Image Resource.
+   * @param {Object} resource The Image Resource from which to derive a thumbnail
+   * @return {Object} The thumbnail URL and any spatial dimensions that can be determined
+   */
+  iiifThumbnailUrl(resource) {
+    let size;
+    let width;
+    let height;
+    const minDimension = 120;
+    let maxHeight = minDimension;
+    let maxWidth = minDimension;
+    const { maxHeight: requestedMaxHeight, maxWidth: requestedMaxWidth } = this.iiifOpts;
+
+    if (requestedMaxHeight) maxHeight = Math.max(requestedMaxHeight, minDimension);
+    if (requestedMaxWidth) maxWidth = Math.max(requestedMaxWidth, minDimension);
+
+    const service = this.iiifImageService(resource);
+
+    if (!service) return ImageFactory.staticImageUrl(resource);
+
+    const aspectRatio = resource.width
+        && resource.height
+        && (resource.width / resource.height);
+
+    const target = (requestedMaxWidth && requestedMaxHeight)
+      ? requestedMaxWidth * requestedMaxHeight
+      : maxHeight * maxWidth;
+
+    const closestSize = ImageFactory.selectBestImageSize(service, target);
+
+    if (closestSize) {
+      // Embedded service advertises an appropriate size
+      width = closestSize.width;
+      height = closestSize.height;
+      size = `${width},${height}`;
+    } else if (ThumbnailUtils.isLevel0ImageProfile(service)) {
+      /** Bail if the best available size is the full size.. maybe we'll get lucky with the @id */
+      if (!service.height && !service.width) {
+        return ImageFactory.staticImageUrl(resource);
+      }
+    } else if (requestedMaxHeight && requestedMaxWidth) {
+      // IIIF level 2, no problem.
+      if (ThumbnailUtils.isLevel2ImageProfile(service)) {
+        size = `!${maxWidth},${maxHeight}`;
+        width = maxWidth;
+        height = maxHeight;
+
+        if (aspectRatio && aspectRatio > 1) height = Math.round(maxWidth / aspectRatio);
+        if (aspectRatio && aspectRatio < 1) width = Math.round(maxHeight * aspectRatio);
+      } else if ((maxWidth / maxHeight) < aspectRatio) {
+        size = `${maxWidth},`;
+        width = maxWidth;
+        if (aspectRatio) height = Math.round(maxWidth / aspectRatio);
+      } else {
+        size = `,${maxHeight}`;
+        height = maxHeight;
+        if (aspectRatio) width = Math.round(maxHeight * aspectRatio);
+      }
+    } else if (requestedMaxHeight && !requestedMaxWidth) {
+      size = `,${maxHeight}`;
+      height = maxHeight;
+      if (aspectRatio) width = Math.round(maxHeight * aspectRatio);
+    } else if (!requestedMaxHeight && requestedMaxWidth) {
+      size = `${maxWidth},`;
+      width = maxWidth;
+      if (aspectRatio) height = Math.round(maxWidth / aspectRatio);
+    } else {
+      size = `,${minDimension}`;
+      height = minDimension;
+      if (aspectRatio) width = Math.round(height * aspectRatio);
+    }
+
+    const region = 'full';
+    // const quality = Utils.getImageQuality(service.getProfile());
+    const quality = 'default';
+    const id = service.id.replace(/\/+$/, '');
+    const format = ThumbnailUtils.getFormat(service, this.iiifOpts);
+    return {
+      height,
+      url: [id, region, size, 0, `${quality}.${format}`].join('/'),
+      width,
+    };
+  }
+
+  /**
+   * Gets a thumbnail representing the resource.
+   * @return {Object|undefined} A thumbnail representing the resource, or undefined if none could
+   * be determined
+   */
+  get() {
+    if (!this.resource) return undefined;
+
+    // Determine which content resource we should use to derive a thumbnail
+    const sourceContentResource = this.getSourceContentResource(this.resource);
+
+    if (!sourceContentResource) return undefined;
+
+    // Special treatment for external resources
+    if (typeof sourceContentResource === 'string') return { url: sourceContentResource };
+
+    return this.iiifThumbnailUrl(sourceContentResource);
+  }
+}
+
+export { ImageFactory };

--- a/src/lib/ProviderLogoFactory.js
+++ b/src/lib/ProviderLogoFactory.js
@@ -1,0 +1,59 @@
+import { ThumbnailUtils } from './ThumbnailUtils';
+import { ImageFactory } from './ImageFactory';
+
+/** */
+function iiifProviderLogoService(resource) {
+  const service = resource
+    && resource.service.find(s => (
+      ThumbnailUtils.iiifv3ImageServiceType(s)
+    ));
+
+  if (!(service)) return undefined;
+  return service;
+}
+
+/**
+ * Determines the content resource from which to derive a thumbnail to represent a given resource.
+ * This method is recursive.
+ * @param {Object} resource A IIIF resource to derive a thumbnail from
+ * @return {Object|undefined} The Image Resource to derive a thumbnail from, or undefined
+ * if no appropriate resource exists
+ */
+function getLogoSourceContent(resource) {
+  if (resource.type === 'Agent') {
+    const { logo } = resource;
+    if (logo && logo[0]) { return this.getSourceContentResource(logo[0]); }
+    return undefined;
+  }
+
+  if (resource.type === 'Image') {
+    return resource;
+  }
+
+  return undefined;
+}
+
+// Adapted from Manifesto's IIIF v2 getLogo method:
+// https://github.com/IIIF-Commons/manifesto/blob/6e355e34c38b64b9cf9c366d6ff60006db341968/src/IIIFResource.ts#LL93C3-L98C35
+/** */
+function getLogo(logo) {
+  if (!logo) return null;
+  if (typeof logo === 'string') return logo;
+  return logo && logo.url;
+}
+
+/** */
+class ProviderLogoFactory extends ImageFactory {
+  /** */
+  constructor(resource, iiifOpts = {}) {
+    super(resource, iiifProviderLogoService, getLogoSourceContent, iiifOpts);
+  }
+}
+/** */
+function getBestLogo(agent, iiifOpts) {
+  const logoData = new ProviderLogoFactory(agent, iiifOpts).get();
+  return getLogo(logoData);
+}
+
+export { ProviderLogoFactory };
+export default getBestLogo;

--- a/src/lib/ThumbnailFactory.js
+++ b/src/lib/ThumbnailFactory.js
@@ -1,46 +1,13 @@
 import { Utils } from 'manifesto.js';
+import { ThumbnailUtils } from './ThumbnailUtils';
+import { ImageFactory } from './ImageFactory';
 import MiradorManifest from './MiradorManifest';
-import MiradorCanvas from './MiradorCanvas';
-import asArray from './asArray';
-
-/** */
-function isLevel0ImageProfile(service) {
-  const profile = service.getProfile();
-
-  // work around a bug in manifesto with normalized urls that strip # values.
-  if (profile.endsWith('#level1') || profile.endsWith('#level2')) return false;
-
-  // support IIIF v3-style profiles
-  if (profile === 'level0') return true;
-
-  return Utils.isLevel0ImageProfile(profile);
-}
-
-/** */
-function isLevel2ImageProfile(service) {
-  const profile = service.getProfile();
-
-  // work around a bug in manifesto with normalized urls that strip # values.
-  if (profile.endsWith('#level0') || profile.endsWith('#level1')) return false;
-
-  // support IIIF v3-style profiles
-  if (profile === 'level2') return true;
-
-  return Utils.isLevel2ImageProfile(profile);
-}
-
-/** */
-function iiifv3ImageServiceType(service) {
-  const type = service.getProperty('type') || [];
-
-  return asArray(type).some(v => v.startsWith('ImageService'));
-}
 
 /** */
 function iiifImageService(resource) {
   const service = resource
     && resource.getServices().find(s => (
-      iiifv3ImageServiceType(s) || Utils.isImageProfile(s.getProfile())
+      ThumbnailUtils.iiifv3ImageServiceType(s) || Utils.isImageProfile(s.getProfile())
     ));
 
   if (!(service)) return undefined;
@@ -48,259 +15,65 @@ function iiifImageService(resource) {
   return service;
 }
 
-/** */
-class ThumbnailFactory {
-  /** */
-  constructor(resource, iiifOpts = {}) {
-    this.resource = resource;
-    this.iiifOpts = iiifOpts;
-  }
+/**
+ * Determines the content resource from which to derive a thumbnail to represent a given resource.
+ * This method is recursive.
+ * @param {Object} resource A IIIF resource to derive a thumbnail from
+ * @return {Object|undefined} The Image Resource to derive a thumbnail from, or undefined
+ * if no appropriate resource exists
+ */
+function getSourceContentResource(resource) {
+  const thumbnail = resource.getThumbnail();
 
-  /** */
-  static staticImageUrl(resource) {
-    return { height: resource.getProperty('height'), url: resource.id, width: resource.getProperty('width') };
-  }
+  // Any resource type may have a thumbnail
+  if (thumbnail) {
+    if (typeof thumbnail.__jsonld === 'string') return thumbnail.__jsonld;
 
-  /**
-   * Selects the image resource that is representative of the given canvas.
-   * @param {Object} canvas A Manifesto Canvas
-   * @return {Object} A Manifesto Image Resource
-   */
-  static getPreferredImage(canvas) {
-    const miradorCanvas = new MiradorCanvas(canvas);
-    return miradorCanvas.iiifImageResources[0] || miradorCanvas.imageResource;
-  }
-
-  /**
-   * Chooses the best available image size based on a target area (w x h) value.
-   * @param {Object} service A IIIF Image API service that has a `sizes` array
-   * @param {Number} targetArea The target area value to compare potential sizes against
-   * @return {Object|undefined} The best size, or undefined if none are acceptable
-   */
-  static selectBestImageSize(service, targetArea) {
-    const sizes = asArray(service.getProperty('sizes'));
-
-    let closestSize = {
-      default: true,
-      height: service.getProperty('height') || Number.MAX_SAFE_INTEGER,
-      width: service.getProperty('width') || Number.MAX_SAFE_INTEGER,
-    };
-
-    /** Compare the total image area to our target */
-    const imageFitness = (test) => test.width * test.height - targetArea;
-
-    /** Look for the size that's just bigger than we prefer... */
-    closestSize = sizes.reduce((best, test) => {
-      const score = imageFitness(test);
-
-      if (score < 0) return best;
-
-      return Math.abs(score) < Math.abs(imageFitness(best))
-        ? test
-        : best;
-    }, closestSize);
-
-    /** .... but not "too" big; we'd rather scale up an image than download too much */
-    if (closestSize.width * closestSize.height > targetArea * 6) {
-      closestSize = sizes.reduce((best, test) => (
-        Math.abs(imageFitness(test)) < Math.abs(imageFitness(best))
-          ? test
-          : best
-      ), closestSize);
-    }
-
-    if (closestSize.default) return undefined;
-
-    return closestSize;
-  }
-
-  /**
-   * Determines the appropriate thumbnail to use to represent an Image Resource.
-   * @param {Object} resource The Image Resource from which to derive a thumbnail
-   * @return {Object} The thumbnail URL and any spatial dimensions that can be determined
-   */
-  iiifThumbnailUrl(resource) {
-    let size;
-    let width;
-    let height;
-    const minDimension = 120;
-    let maxHeight = minDimension;
-    let maxWidth = minDimension;
-    const { maxHeight: requestedMaxHeight, maxWidth: requestedMaxWidth } = this.iiifOpts;
-
-    if (requestedMaxHeight) maxHeight = Math.max(requestedMaxHeight, minDimension);
-    if (requestedMaxWidth) maxWidth = Math.max(requestedMaxWidth, minDimension);
-
-    const service = iiifImageService(resource);
-
-    if (!service) return ThumbnailFactory.staticImageUrl(resource);
-
-    const aspectRatio = resource.getWidth()
-      && resource.getHeight()
-      && (resource.getWidth() / resource.getHeight());
-    const target = (requestedMaxWidth && requestedMaxHeight)
-      ? requestedMaxWidth * requestedMaxHeight
-      : maxHeight * maxWidth;
-    const closestSize = ThumbnailFactory.selectBestImageSize(service, target);
-
-    if (closestSize) {
-      // Embedded service advertises an appropriate size
-      width = closestSize.width;
-      height = closestSize.height;
-      size = `${width},${height}`;
-    } else if (isLevel0ImageProfile(service)) {
-      /** Bail if the best available size is the full size.. maybe we'll get lucky with the @id */
-      if (!service.getProperty('height') && !service.getProperty('width')) {
-        return ThumbnailFactory.staticImageUrl(resource);
+    // Prefer an image's ImageService over its image's thumbnail
+    // Note that Collection, Manifest, and Canvas don't have `getType()`
+    if (!resource.isCollection() && !resource.isManifest() && !resource.isCanvas()) {
+      if (resource.getType() === 'image' && this.iiifImageService(resource) && !this.iiifImageService(thumbnail)) {
+        return resource;
       }
-    } else if (requestedMaxHeight && requestedMaxWidth) {
-      // IIIF level 2, no problem.
-      if (isLevel2ImageProfile(service)) {
-        size = `!${maxWidth},${maxHeight}`;
-        width = maxWidth;
-        height = maxHeight;
-
-        if (aspectRatio && aspectRatio > 1) height = Math.round(maxWidth / aspectRatio);
-        if (aspectRatio && aspectRatio < 1) width = Math.round(maxHeight * aspectRatio);
-      } else if ((maxWidth / maxHeight) < aspectRatio) {
-        size = `${maxWidth},`;
-        width = maxWidth;
-        if (aspectRatio) height = Math.round(maxWidth / aspectRatio);
-      } else {
-        size = `,${maxHeight}`;
-        height = maxHeight;
-        if (aspectRatio) width = Math.round(maxHeight * aspectRatio);
-      }
-    } else if (requestedMaxHeight && !requestedMaxWidth) {
-      size = `,${maxHeight}`;
-      height = maxHeight;
-      if (aspectRatio) width = Math.round(maxHeight * aspectRatio);
-    } else if (!requestedMaxHeight && requestedMaxWidth) {
-      size = `${maxWidth},`;
-      width = maxWidth;
-      if (aspectRatio) height = Math.round(maxWidth / aspectRatio);
-    } else {
-      size = `,${minDimension}`;
-      height = minDimension;
-      if (aspectRatio) width = Math.round(height * aspectRatio);
     }
 
-    const region = 'full';
-    const quality = Utils.getImageQuality(service.getProfile());
-    const id = service.id.replace(/\/+$/, '');
-    const format = this.getFormat(service);
-    return {
-      height,
-      url: [id, region, size, 0, `${quality}.${format}`].join('/'),
-      width,
-    };
+    return thumbnail;
   }
 
-  /**
-   * Figure out what format thumbnail to use by looking at the preferred formats
-   * on offer, and selecting a format shared in common with the application's
-   * preferred format list.
-   *
-   * Fall back to jpg, which is required to work for all IIIF services.
-   */
-  getFormat(service) {
-    const { preferredFormats = [] } = this.iiifOpts;
-    const servicePreferredFormats = service.getProperty('preferredFormats');
-
-    if (!servicePreferredFormats) return 'jpg';
-
-    const filteredFormats = servicePreferredFormats.filter(
-      value => preferredFormats.includes(value),
-    );
-
-    // this is a format found in common between the preferred formats of the service
-    // and the application
-    if (filteredFormats[0]) return filteredFormats[0];
-
-    // IIIF Image API guarantees jpg support; if it wasn't provided by the service
-    // but the application is fine with it, we might as well try it.
-    if (!servicePreferredFormats.includes('jpg') && preferredFormats.includes('jpg')) {
-      return 'jpg';
-    }
-
-    // there were no formats in common, and the application didn't want jpg... so
-    // just trust that the IIIF service is advertising something useful?
-    if (servicePreferredFormats[0]) return servicePreferredFormats[0];
-
-    // JPG support is guaranteed by the spec, so it's a good worst-case fallback
-    return 'jpg';
-  }
-
-  /**
-   * Determines the content resource from which to derive a thumbnail to represent a given resource.
-   * This method is recursive.
-   * @param {Object} resource A IIIF resource to derive a thumbnail from
-   * @return {Object|undefined} The Image Resource to derive a thumbnail from, or undefined
-   * if no appropriate resource exists
-   */
-  getSourceContentResource(resource) {
-    const thumbnail = resource.getThumbnail();
-
-    // Any resource type may have a thumbnail
-    if (thumbnail) {
-      if (typeof thumbnail.__jsonld === 'string') return thumbnail.__jsonld;
-
-      // Prefer an image's ImageService over its image's thumbnail
-      // Note that Collection, Manifest, and Canvas don't have `getType()`
-      if (!resource.isCollection() && !resource.isManifest() && !resource.isCanvas()) {
-        if (resource.getType() === 'image' && iiifImageService(resource) && !iiifImageService(thumbnail)) {
-          return resource;
-        }
-      }
-
-      return thumbnail;
-    }
-
-    if (resource.isCollection()) {
-      const firstManifest = resource.getManifests()[0];
-      if (firstManifest) return this.getSourceContentResource(firstManifest);
-
-      return undefined;
-    }
-
-    if (resource.isManifest()) {
-      const miradorManifest = new MiradorManifest(resource);
-      const canvas = miradorManifest.startCanvas || miradorManifest.canvasAt(0);
-      if (canvas) return this.getSourceContentResource(canvas);
-
-      return undefined;
-    }
-
-    if (resource.isCanvas()) {
-      const image = ThumbnailFactory.getPreferredImage(resource);
-      if (image) return this.getSourceContentResource(image);
-
-      return undefined;
-    }
-
-    if (resource.getType() === 'image') {
-      return resource;
-    }
+  if (resource.isCollection()) {
+    const firstManifest = resource.getManifests()[0];
+    if (firstManifest) return this.getSourceContentResource(firstManifest);
 
     return undefined;
   }
 
-  /**
-   * Gets a thumbnail representing the resource.
-   * @return {Object|undefined} A thumbnail representing the resource, or undefined if none could
-   * be determined
-   */
-  get() {
-    if (!this.resource) return undefined;
+  if (resource.isManifest()) {
+    const miradorManifest = new MiradorManifest(resource);
+    const canvas = miradorManifest.startCanvas || miradorManifest.canvasAt(0);
+    if (canvas) return this.getSourceContentResource(canvas);
 
-    // Determine which content resource we should use to derive a thumbnail
-    const sourceContentResource = this.getSourceContentResource(this.resource);
-    if (!sourceContentResource) return undefined;
+    return undefined;
+  }
 
-    // Special treatment for external resources
-    if (typeof sourceContentResource === 'string') return { url: sourceContentResource };
+  if (resource.isCanvas()) {
+    const image = ImageFactory.getPreferredImage(resource);
+    if (image) return this.getSourceContentResource(image);
 
-    return this.iiifThumbnailUrl(sourceContentResource);
+    return undefined;
+  }
+
+  if (resource.getType() === 'image' || resource.type === 'Image') {
+    return resource;
+  }
+
+  return undefined;
+}
+
+/** */
+class ThumbnailFactory extends ImageFactory {
+/** */
+  constructor(resource, iiifOpts = {}) {
+    super(resource, iiifImageService, getSourceContentResource, iiifOpts);
   }
 }
 

--- a/src/lib/ThumbnailUtils.js
+++ b/src/lib/ThumbnailUtils.js
@@ -1,0 +1,77 @@
+import { Utils } from 'manifesto.js';
+import asArray from './asArray';
+
+/** */
+class ThumbnailUtils {
+  /**
+   * Figure out what format thumbnail to use by looking at the preferred formats
+   * on offer, and selecting a format shared in common with the application's
+   * preferred format list.
+   *
+   * Fall back to jpg, which is required to work for all IIIF services.
+   */
+  static getFormat(service, iiifOpts) {
+    const { preferredFormats = [] } = iiifOpts;
+    const servicePreferredFormats = service.preferredFormats;
+
+    if (!servicePreferredFormats) return 'jpg';
+
+    const filteredFormats = servicePreferredFormats.filter(
+      value => preferredFormats.includes(value),
+    );
+
+    // this is a format found in common between the preferred formats of the service
+    // and the application
+    if (filteredFormats[0]) return filteredFormats[0];
+
+    // IIIF Image API guarantees jpg support; if it wasn't provided by the service
+    // but the application is fine with it, we might as well try it.
+    if (!servicePreferredFormats.includes('jpg') && preferredFormats.includes('jpg')) {
+      return 'jpg';
+    }
+
+    // there were no formats in common, and the application didn't want jpg... so
+    // just trust that the IIIF service is advertising something useful?
+    if (servicePreferredFormats[0]) return servicePreferredFormats[0];
+
+    // JPG support is guaranteed by the spec, so it's a good worst-case fallback
+    return 'jpg';
+  }
+
+  /** */
+  static isLevel0ImageProfile(service) {
+    // .getProfile() does not work on the v3 provider logos, check the property directly
+    const profile = ThumbnailUtils.iiifv3ImageServiceType(service) ? service.profile : service.getProfile();
+
+    // work around a bug in manifesto with normalized urls that strip # values.
+    if (profile.endsWith('#level1') || profile.endsWith('#level2')) return false;
+
+    // support IIIF v3-style profiles
+    if (profile === 'level0') return true;
+
+    return Utils.isLevel0ImageProfile(profile);
+  }
+
+  /** */
+  static isLevel2ImageProfile(service) {
+    // .getProfile() does not work on the v3 provider logos, check the property directly
+    const profile = ThumbnailUtils.iiifv3ImageServiceType(service) ? service.profile : service.getProfile();
+
+    // work around a bug in manifesto with normalized urls that strip # values.
+    if (profile.endsWith('#level0') || profile.endsWith('#level1')) return false;
+
+    // support IIIF v3-style profiles
+    if (profile === 'level2') return true;
+
+    return Utils.isLevel2ImageProfile(profile);
+  }
+
+  /** */
+  static iiifv3ImageServiceType(service) {
+    const type = service.type || [];
+
+    return asArray(type).some(v => v.startsWith('ImageService'));
+  }
+}
+
+export { ThumbnailUtils };

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import createCachedSelector from 're-reselect';
 import { PropertyValue, Utils } from 'manifesto.js';
 import getThumbnail from '../../lib/ThumbnailFactory';
+import getLogo from '../../lib/ProviderLogoFactory';
 import asArray from '../../lib/asArray';
 import { getCompanionWindow } from './companionWindows';
 import { getManifest } from './getters';
@@ -78,17 +79,12 @@ function getProperty(property) {
   );
 }
 
-/**
- * Get the logo for a manifest
- * @param {object} state
- * @param {object} props
- * @param {string} props.manifestId
- * @param {string} props.windowId
- * @return {String|null}
- */
-export const getManifestLogo = createSelector(
-  [getManifestoInstance],
-  manifest => manifest && manifest.getLogo(),
+/** */
+export const getManifestProvider = createSelector(
+  [
+    getProperty('provider'),
+  ],
+  (provider) => provider,
 );
 
 /**
@@ -99,7 +95,7 @@ export const getManifestLogo = createSelector(
 * @param {string} props.windowId
 * @return {String|null}
 */
-export const getManifestProvider = createSelector(
+export const getManifestProviderName = createSelector(
   [
     getProperty('provider'),
     getManifestLocale,
@@ -107,6 +103,40 @@ export const getManifestProvider = createSelector(
   (provider, locale) => provider
     && provider[0].label
     && PropertyValue.parse(provider[0].label, locale).getValue(),
+);
+
+/**
+ * Return the IIIF v3 provider logo
+ * @param {object} state
+ * @param {object} props
+ * @param {string} props.manifestId
+ * @param {string} props.windowId
+ * @return {String|null}
+ */
+export const getProviderLogo = createSelector(
+  [getManifestProvider],
+  (provider) => {
+    // There may be more than 1 provider. We are only dealing with the first one (provider[0]) here.
+    if (provider) {
+      return getLogo(provider[0], {
+        maxHeight: 80, maxWidth: 120,
+      });
+    }
+    return null;
+  },
+);
+
+/**
+ * Get the logo for a manifest
+ * @param {object} state
+ * @param {object} props
+ * @param {string} props.manifestId
+ * @param {string} props.windowId
+ * @return {String|null}
+ */
+export const getManifestLogo = createSelector(
+  [getManifestoInstance, getProviderLogo],
+  (manifest, v3logo) => v3logo || (manifest && manifest.getLogo()),
 );
 
 /**


### PR DESCRIPTION
<img width="1629" alt="Screenshot 2023-02-23 at 17 25 05" src="https://user-images.githubusercontent.com/1328900/221054184-9e1a4428-ae4e-4e4b-ace7-aa772d0ca8e2.png">

WIP.
We have the UCLA logo requested in #3405 
I had to extract a more general image factory and pass in some functions depending on whether we were dealing with the v3 `provider.logo` structure (the provider/Agent resource can't understand any manifesto methods like `.getProperty` or  `.getHeight` or `.isCollection`)
This is obviously not complete yet and there may be more we want to do to support v3
Manifesto itself doesn't support the provider logo yet 