### PR TITLE
Handle v3 Provider logos as thumbnails

### DIFF
--- a/__tests__/fixtures/version-3/with_a_provider.json
+++ b/__tests__/fixtures/version-3/with_a_provider.json
@@ -10,18 +10,18 @@
       "id": "https://example.org/about",
       "type": "Agent",
       "label": {"en": ["Example Organization"]},
-      "homepage": {
+      "homepage": [{
         "id": "https://example.org/",
         "type": "Text",
         "label": {"en": ["Example Organization Homepage"]},
         "format": "text/html"
-      },
-      "logo": {
+      }],
+      "logo": [{
         "id": "https://example.org/images/logo.png",
         "type": "Image",
         "height": 100,
         "width": 120
-      },
+      }],
       "seeAlso": [
         {
           "id": "https://data.example.org/about/us.jsonld",

--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -15,7 +15,8 @@ import {
   getManifestLogo,
   getManifestDescription,
   getManifestHomepage,
-  getManifestProvider,
+  getProviderLogo,
+  getManifestProviderName,
   getManifestTitle,
   getManifestThumbnail,
   getManifestMetadata,
@@ -159,15 +160,30 @@ describe('getManifestSummary', () => {
   });
 });
 
-describe('getManifestProvider', () => {
+describe('getProviderLogo', () => {
+  it('should return manifest provider logo', () => {
+    const state = { manifests: { x: { json: manifestFixtureWithAProvider } } };
+    const received = getProviderLogo(state, { manifestId: 'x' });
+    expect(received).toBe('https://example.org/images/logo.png');
+  });
+
+  it('should return null if no logo', () => {
+    // use the fixture but overwrite the 'provider' property to be empty/not include logo
+    const state = { manifests: { x: { json: { ...manifestFixtureWithAProvider, provider: [] } } } };
+    const received = getProviderLogo(state, { manifestId: 'x' });
+    expect(received).toBeNull();
+  });
+});
+
+describe('getManifestProviderName', () => {
   it('should return manifest provider label', () => {
     const state = { manifests: { x: { json: manifestFixtureWithAProvider } } };
-    const received = getManifestProvider(state, { manifestId: 'x' });
+    const received = getManifestProviderName(state, { manifestId: 'x' });
     expect(received).toBe('Example Organization');
   });
 
   it('should return undefined if manifest undefined', () => {
-    const received = getManifestProvider({ manifests: {} }, { manifestId: 'x' });
+    const received = getManifestProviderName({ manifests: {} }, { manifestId: 'x' });
     expect(received).toBeUndefined();
   });
 });

--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -6,7 +6,7 @@ import { withPlugins } from '../extend/withPlugins';
 import {
   getManifest,
   getManifestTitle, getManifestThumbnail, getCanvases,
-  getManifestLogo, getManifestProvider, getWindowManifests,
+  getManifestLogo, getManifestProviderName, getWindowManifests,
   getManifestoInstance, getSequenceBehaviors,
 } from '../state/selectors';
 import * as actions from '../state/actions';
@@ -32,7 +32,7 @@ const mapStateToProps = (state, { manifestId, provider }) => {
       && getSequenceBehaviors(state, { manifestId }).includes('multi-part'),
     manifestLogo: getManifestLogo(state, { manifestId }),
     provider: provider
-      || getManifestProvider(state, { manifestId }),
+      || getManifestProviderName(state, { manifestId }),
     ready: !!manifest.json,
     size,
     thumbnail: getManifestThumbnail(state, { manifestId }),

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import createCachedSelector from 're-reselect';
-import { PropertyValue, Utils } from 'manifesto.js';
+import { PropertyValue, Utils, Resource } from 'manifesto.js';
 import getThumbnail from '../../lib/ThumbnailFactory';
 import asArray from '../../lib/asArray';
 import { getCompanionWindow } from './companionWindows';
@@ -78,17 +78,12 @@ function getProperty(property) {
   );
 }
 
-/**
- * Get the logo for a manifest
- * @param {object} state
- * @param {object} props
- * @param {string} props.manifestId
- * @param {string} props.windowId
- * @return {String|null}
- */
-export const getManifestLogo = createSelector(
-  [getManifestoInstance],
-  manifest => manifest && manifest.getLogo(),
+/** */
+export const getManifestProvider = createSelector(
+  [
+    getProperty('provider'),
+  ],
+  (provider) => provider,
 );
 
 /**
@@ -99,7 +94,7 @@ export const getManifestLogo = createSelector(
 * @param {string} props.windowId
 * @return {String|null}
 */
-export const getManifestProvider = createSelector(
+export const getManifestProviderName = createSelector(
   [
     getProperty('provider'),
     getManifestLocale,
@@ -107,6 +102,47 @@ export const getManifestProvider = createSelector(
   (provider, locale) => provider
     && provider[0].label
     && PropertyValue.parse(provider[0].label, locale).getValue(),
+);
+
+/** */
+function providerLogo(provider) {
+  if (!provider) return null;
+  const logo = provider[0] && provider[0].logo && provider[0].logo[0];
+  return logo || null;
+}
+
+/** */
+function thumbnailUrl(thumbnail) {
+  if (!thumbnail) return null;
+  if (typeof thumbnail === 'string') return thumbnail;
+  return thumbnail && thumbnail.url;
+}
+
+/**
+ * Return the IIIF v3 provider logo
+ * @param {object} state
+ * @param {object} props
+ * @return {String|null}
+ */
+export const getProviderLogo = createSelector(
+  [getManifestProvider],
+  (provider) => {
+    const logo = providerLogo(provider);
+    if (!logo) return null;
+    const thumbnail = getThumbnail(new Resource(logo));
+    return thumbnailUrl(thumbnail);
+  },
+);
+
+/**
+ * Get the logo for a manifest
+ * @param {object} state
+ * @param {object} props
+ * @return {String|null}
+ */
+export const getManifestLogo = createSelector(
+  [getManifestoInstance, getProviderLogo],
+  (manifest, v3logo) => v3logo || (manifest && manifest.getLogo()),
 );
 
 /**


### PR DESCRIPTION
I also changed the provider test fixture because it seemed improperly formed to me -- we had objects instead of arrays as the values of the keys, i.e. `logo: {}` rather than `logo: [{}]` which is described [in the spec](https://iiif.io/api/presentation/3.0/#provider). 