### PR TITLE
Convert tests for Window to RTL

### DIFF
--- a/__tests__/src/components/ErrorContent.test.js
+++ b/__tests__/src/components/ErrorContent.test.js
@@ -1,0 +1,65 @@
+import i18next from 'i18next';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../utils/store';
+import { ErrorContent } from '../../../src/components/ErrorContent';
+
+describe('ErrorContent', () => {
+  it('should render everything when showJsError is true', async () => {
+    renderWithProviders(
+      <ErrorContent
+        error={new Error('Invalid JSON')}
+        windowId="xyz"
+        manifestId="foo"
+        classes={{}}
+        t={i18next.t}
+      />,
+      {
+        preloadedState: {
+          config: {
+            window: {
+              showJsError: true,
+            },
+          },
+          windows: {
+            xyz: {
+              collectionDialogOn: false,
+              companionWindowIds: [],
+            },
+          },
+        },
+      },
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('An error occurred')).toBeInTheDocument();
+    expect(screen.getByText('Technical details')).toBeInTheDocument();
+    expect(document.querySelector('pre')).toHaveTextContent('Invalid JSON'); // eslint-disable-line testing-library/no-node-access
+  });
+  it('renders the alert title with no details when showJsError is false ', async () => {
+    renderWithProviders(
+      <ErrorContent
+        error={new Error('Invalid JSON')}
+        windowId="xyz"
+        manifestId="foo"
+        showJsError={false}
+        classes={{}}
+        t={i18next.t}
+      />,
+      {
+        preloadedState: {
+          config: {
+            window: {
+              showJsError: false,
+            },
+          },
+          windows: {
+            xyz: {
+              collectionDialogOn: false,
+              companionWindowIds: [],
+            },
+          },
+        },
+      },
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
When running the Window test (not the ErrorContent test) I get this warning:
` Warning: [JSS] Could not find the referenced rule "icon" in "Connect(WithPlugins(ErrorContent))".`
-- which comes from the style in the container set [here](https://github.com/ProjectMirador/mirador/blob/a708a7d9d30af99fd1501a26e08386c0868cbcc3/src/containers/ErrorContent.js#L33).

Is this OK to leave?
