### PR TITLE
Refactor SidebarIndexTableOfContents to use MUI's tree view keyboard …

### DIFF
--- a/src/components/SidebarIndexList.js
+++ b/src/components/SidebarIndexList.js
@@ -49,24 +49,24 @@ export class SidebarIndexList extends Component {
             const onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
 
             return (
-              <ScrollTo
-                containerRef={containerRef}
-                key={`${canvas.id}-${variant}`}
-                offsetTop={96} // offset for the height of the form above
-                scrollTo={selectedCanvasIds.includes(canvas.id)}
+              <MenuItem
+                key={canvas.id}
+                className={classes.listItem}
+                alignItems="flex-start"
+                onClick={onClick}
+                button
+                component="li"
+                selected={selectedCanvasIds.includes(canvas.id)}
               >
-                <MenuItem
-                  key={canvas.id}
-                  className={classes.listItem}
-                  alignItems="flex-start"
-                  onClick={onClick}
-                  button
-                  component="li"
-                  selected={selectedCanvasIds.includes(canvas.id)}
+                <ScrollTo
+                  containerRef={containerRef}
+                  key={`${canvas.id}-${variant}`}
+                  offsetTop={96} // offset for the height of the form above
+                  scrollTo={selectedCanvasIds.includes(canvas.id)}
                 >
                   <Item label={canvas.label} canvas={canvases[canvasIndex]} />
-                </MenuItem>
-              </ScrollTo>
+                </ScrollTo>
+              </MenuItem>
             );
           })
         }

--- a/src/containers/SidebarIndexTableOfContents.js
+++ b/src/containers/SidebarIndexTableOfContents.js
@@ -66,7 +66,7 @@ const styles = theme => ({
     },
   },
   visibleNode: {
-    backgroundColor: alpha(theme.palette.highlights.primary, 0.35),
+    backgroundColor: alpha(theme.palette.highlights?.primary || theme.palette.action.selected, 0.35),
     display: 'inline',
   },
 });

--- a/src/containers/SidebarIndexTableOfContents.js
+++ b/src/containers/SidebarIndexTableOfContents.js
@@ -29,6 +29,7 @@ const mapStateToProps = (state, { id, windowId }) => ({
  * @private
  */
 const mapDispatchToProps = (dispatch, { id, windowId }) => ({
+  expandNodes: nodeIds => dispatch(actions.expandNodes(windowId, id, nodeIds)),
   setCanvas: (...args) => dispatch(actions.setCanvas(...args)),
   toggleNode: nodeId => dispatch(actions.toggleNode(windowId, id, nodeId)),
 });

--- a/src/state/actions/companionWindow.js
+++ b/src/state/actions/companionWindow.js
@@ -77,3 +77,27 @@ export function toggleNode(windowId, id, nodeId) {
     });
   };
 }
+
+/** Update the expanded nodes state */
+export function expandNodes(windowId, id, nodeIds) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const expandedNodeIds = getManuallyExpandedNodeIds(state, { companionWindowId: id }, true);
+    const payload = {};
+
+    expandedNodeIds.forEach(nodeId => {
+      payload[nodeId] = { expanded: false };
+    });
+
+    nodeIds.forEach(nodeId => {
+      payload[nodeId] = { expanded: true };
+    });
+
+    return dispatch({
+      id,
+      payload,
+      type: ActionTypes.TOGGLE_TOC_NODE,
+      windowId,
+    });
+  };
+}


### PR DESCRIPTION
…controls natively.

This work was originally done in https://github.com/ProjectMirador/mirador/pull/2916. Upstream has since improved their keyboard accessibility, but we also had (presumably) a conflict with our `ScrollTo` (as an aside: the upstream behavior is still incomplete; MUI 5.x actually addresses some of the controls we need to currently work around).

MUI now appropriately handles left/right arrow keys and at least part of the space/enter interaction.

