### PR TITLE
fix: elastic window DnD on mobile

### DIFF
--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -48,6 +48,7 @@ export class WindowTopBar extends Component {
               <MiradorMenuButton
                 aria-label={t('toggleWindowSideBar')}
                 onClick={toggleWindowSideBar}
+                className={ns('window-menu-btn')}
               >
                 <MenuIcon />
               </MiradorMenuButton>
@@ -56,26 +57,26 @@ export class WindowTopBar extends Component {
               windowId={windowId}
             />
             {allowTopMenuButton && (
-              <WindowTopMenuButton className={ns('window-menu-btn')} windowId={windowId} />
+              <WindowTopMenuButton windowId={windowId} className={ns('window-menu-btn')} />
             )}
             <WindowTopBarPluginArea windowId={windowId} />
             <WindowTopBarPluginMenu windowId={windowId} />
             {allowMaximize && (
               <MiradorMenuButton
                 aria-label={(maximized ? t('minimizeWindow') : t('maximizeWindow'))}
-                className={ns('window-maximize')}
+                className={classNames(ns('window-maximize'), ns('window-menu-btn'))}
                 onClick={(maximized ? minimizeWindow : maximizeWindow)}
               >
                 {(maximized ? <WindowMinIcon /> : <WindowMaxIcon />)}
               </MiradorMenuButton>
             )}
             {allowFullscreen && (
-              <FullScreenButton />
+              <FullScreenButton className={ns('window-menu-btn')} />
             )}
             {allowClose && (
               <MiradorMenuButton
                 aria-label={t('closeWindow')}
-                className={ns('window-close')}
+                className={classNames(ns('window-close'), ns('window-menu-btn'))}
                 onClick={removeWindow}
               >
                 <CloseIcon />

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import WindowTopMenu from '../containers/WindowTopMenu';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 import WindowOptionsIcon from './icons/WindowOptionsIcon';
@@ -45,7 +46,9 @@ export class WindowTopMenuButton extends Component {
    * @return
    */
   render() {
-    const { classes, t, windowId } = this.props;
+    const {
+      classes, className, t, windowId,
+    } = this.props;
     const { open, anchorEl } = this.state;
     const menuId = `window-menu_${windowId}`;
     return (
@@ -54,7 +57,7 @@ export class WindowTopMenuButton extends Component {
           aria-haspopup="true"
           aria-label={t('windowMenu')}
           aria-owns={open ? menuId : undefined}
-          className={open ? classes.ctrlBtnSelected : null}
+          className={classNames(className, open ? classes.ctrlBtnSelected : null)}
           onClick={this.handleMenuClick}
         >
           <WindowOptionsIcon />
@@ -73,10 +76,12 @@ export class WindowTopMenuButton extends Component {
 
 WindowTopMenuButton.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  className: PropTypes.string,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
 };
 
 WindowTopMenuButton.defaultProps = {
+  className: '',
   t: key => key,
 };

--- a/src/components/WorkspaceElasticWindow.js
+++ b/src/components/WorkspaceElasticWindow.js
@@ -49,6 +49,7 @@ class WorkspaceElasticWindow extends Component {
           });
         }}
         dragHandleClassName={ns('window-top-bar')}
+        cancel={`.${ns('window-menu-btn')}`}
         className={
           focused ? classes.focused : null
         }


### PR DESCRIPTION
This is a fix for #3494.
It's a workaround for a bug that has been around in react-draggable since [v4.3.0 of react-draggable](https://github.com/react-grid-layout/react-draggable/blob/master/CHANGELOG.md#430-apr-10-2020).

A good description of why this bug happens: https://github.com/react-grid-layout/react-draggable/issues/550#issuecomment-947166613.

By canceling the drag event when one tries to drag on the top menu buttons, they become clickable again. The same feature is already used here: https://github.com/ProjectMirador/mirador/blob/b65ef2c778d2d84aa82e9a1054a10bae6263d3ad/src/components/WorkspaceElastic.js#L58.

If this workaround is not sufficient, the only other way (besides fixing react-draggable) I see is to implement some custom "click" logic, like described here: https://github.com/react-grid-layout/react-draggable/issues/550#issuecomment-1221555269.