### PR TITLE
theme.mixins.gutters() is deprecated; use the mixin source directly

### DIFF
--- a/src/containers/ManifestListItem.js
+++ b/src/containers/ManifestListItem.js
@@ -73,7 +73,6 @@ const styles = theme => ({
     backgroundColor: theme.palette.grey[300],
   },
   root: {
-    ...theme.mixins.gutters(),
     '&$active': {
       borderLeft: `4px solid ${theme.palette.primary.main}`,
     },
@@ -85,6 +84,12 @@ const styles = theme => ({
       borderLeft: `4px solid ${theme.palette.action.hover}`,
     },
     borderLeft: '4px solid transparent',
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      paddingLeft: theme.spacing(3),
+      paddingRight: theme.spacing(3),
+    },
   },
   thumbnail: {
     maxWidth: '100%',

--- a/src/containers/WorkspaceAdd.js
+++ b/src/containers/WorkspaceAdd.js
@@ -42,10 +42,15 @@ const styles = theme => ({
     right: theme.spacing(2),
   },
   form: {
-    ...theme.mixins.gutters(),
     left: '0',
     marginTop: 48,
     paddingBottom: theme.spacing(2),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      paddingLeft: theme.spacing(3),
+      paddingRight: theme.spacing(3),
+    },
     paddingTop: theme.spacing(2),
     right: '0',
   },


### PR DESCRIPTION
Fixes:

```
    Material-UI: theme.mixins.gutters() is deprecated.
    You can use the source of the mixin directly:
    
          paddingLeft: theme.spacing(2),
          paddingRight: theme.spacing(2),
          [theme.breakpoints.up('sm')]: {
            paddingLeft: theme.spacing(3),
            paddingRight: theme.spacing(3),
          },
```