### PR TITLE
MUI's onClose now handles escapeKeyDown internally

### DIFF
--- a/src/components/WorkspaceImport.js
+++ b/src/components/WorkspaceImport.js
@@ -68,7 +68,6 @@ export class WorkspaceImport extends Component {
       <Dialog
         aria-labelledby="workspace-import-title"
         id="workspace-import"
-        onEscapeKeyDown={handleClose}
         onClose={handleClose}
         open={open}
         fullWidth


### PR DESCRIPTION
Fixes

```
Warning: Failed prop type: The prop `onEscapeKeyDown` of `ForwardRef(Dialog)` is deprecated. Use the onClose prop with the `reason` argument to handle the `escapeKeyDown` events.
```