### PR TITLE
Use minRows instead of rows

### DIFF
--- a/src/components/WorkspaceImport.js
+++ b/src/components/WorkspaceImport.js
@@ -83,7 +83,7 @@ export class WorkspaceImport extends Component {
             id="workspace-import-input"
             multiline
             onChange={this.handleChange}
-            rows="15"
+            minRows={15}
             variant="filled"
             inputProps={{ autoFocus: 'autofocus', className: classes.textInput }}
             helperText={t('importWorkspaceHint')}


### PR DESCRIPTION
Fixes:

```
Failed prop type: The prop `rows` of `ForwardRef(TextField)` is deprecated. Use `minRows` instead
```