### PR TITLE
Add a style.top property to the test object in order to silence a rea…

### DIFF
--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.js
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.js
@@ -15,6 +15,7 @@ function createWrapper(props) {
       classes={{}}
       style={{
         height: 90,
+        top: 0,
         width: 100,
       }}
       {...props}


### PR DESCRIPTION
…ct warning.

Fixes

```
console.error
[1727](https://github.com/ProjectMirador/mirador/actions/runs/4568010602/jobs/8062531314#step:5:1728)
      Warning: `NaN` is an invalid value for the `top` css style property.
[1728](https://github.com/ProjectMirador/mirador/actions/runs/4568010602/jobs/8062531314#step:5:1729)
          at div
[1729](https://github.com/ProjectMirador/mirador/actions/runs/4568010602/jobs/8062531314#step:5:1730)
          at ThumbnailCanvasGrouping (/home/runner/work/mirador/mirador/src/components/ThumbnailCanvasGrouping.js:11:5)
[1730](https://github.com/ProjectMirador/mirador/actions/runs/4568010602/jobs/8062531314#step:5:1731)
          at Provider (/home/runner/work/mirador/mirador/node_modules/react-redux/lib/components/Provider.js:19:3)
[1731](https://github.com/ProjectMirador/mirador/actions/runs/4568010602/jobs/8062531314#step:5:1732)
          at children (/home/runner/work/mirador/mirador/__tests__/utils/test-utils.js:23:22)
```