### PR TITLE
Provide the anchorEl prop to the WindowList component under test to s…

### DIFF
--- a/__tests__/src/components/WindowList.test.js
+++ b/__tests__/src/components/WindowList.test.js
@@ -11,8 +11,13 @@ describe('WindowList', () => {
     focusWindow = jest.fn();
     titles = {};
 
+    render(<div data-testid="container" />);
+  });
+
+  it('renders without an error', () => {
     render(
       <WindowList
+        anchorEl={screen.getByTestId('container')}
         open
         titles={titles}
         windowIds={[]}
@@ -20,9 +25,7 @@ describe('WindowList', () => {
         focusWindow={focusWindow}
       />,
     );
-  });
 
-  it('renders without an error', () => {
     expect(screen.getByRole('menu')).toBeInTheDocument();
   });
 
@@ -30,6 +33,7 @@ describe('WindowList', () => {
     beforeEach(() => {
       render(
         <WindowList
+          anchorEl={screen.getByTestId('container')}
           open
           titles={titles}
           windowIds={['xyz']}
@@ -55,6 +59,7 @@ describe('WindowList', () => {
 
       render(
         <WindowList
+          anchorEl={screen.getByTestId('container')}
           open
           titles={titles}
           windowIds={['xyz']}
@@ -75,6 +80,7 @@ describe('WindowList', () => {
 
       render(
         <WindowList
+          anchorEl={screen.getByTestId('container')}
           open
           titles={titles}
           windowIds={['abc', 'xyz']}


### PR DESCRIPTION
…ilence MUI warnings

Fixes
```
Warning: Failed prop type: Material-UI: The `anchorEl` prop provided to the component is invalid.
[1862](https://github.com/ProjectMirador/mirador/actions/runs/4568010602/jobs/8062531314#step:5:1863)
      It should be an Element instance but it's `undefined` instead.
```