### PR TITLE
Allow WorkspaceElasticWindow to focus

### DIFF
--- a/__tests__/src/components/WorkspaceElasticWindow.test.js
+++ b/__tests__/src/components/WorkspaceElasticWindow.test.js
@@ -45,12 +45,20 @@ describe('WorkspaceElasticWindow', () => {
     expect(el).toHaveClass('react-draggable');
     expect(el).toHaveStyle({ height: '200px', transform: 'translate(5040px,5040px)', width: '200px' });
   });
-  describe('focused window', () => {
-    it('adds a class to the focused window', () => {
+  describe('focuses the window', () => {
+    it('adds class to focused window', () => {
       const { container } = createWrapper({ classes: { focused: 'focused-window' }, focused: true, layout });
       const el = container.firstChild;
 
       expect(el).toHaveClass('focused-window');
+    });
+    it('calls focusWindow when clicked', async () => {
+      const user = userEvent.setup();
+      const mockFocusWindow = jest.fn();
+      const { container } = createWrapper({ focusWindow: mockFocusWindow, layout });
+      const el = container.querySelector('.mirador-window-top-bar');
+      await user.click(el);
+      expect(mockFocusWindow).toHaveBeenCalled();
     });
   });
   describe('window behaviour', () => {

--- a/src/components/WorkspaceElasticWindow.js
+++ b/src/components/WorkspaceElasticWindow.js
@@ -17,6 +17,7 @@ class WorkspaceElasticWindow extends Component {
       classes,
       companionWindowDimensions,
       focused,
+      focusWindow,
       layout,
       workspace,
       updateElasticWindowLayout,
@@ -40,6 +41,7 @@ class WorkspaceElasticWindow extends Component {
             { x: d.x - offsetX, y: d.y - offsetY },
           );
         }}
+        onDragStart={focusWindow}
         onResize={(e, direction, ref, delta, position) => {
           updateElasticWindowLayout(layout.windowId, {
             height: Number.parseInt(ref.style.height, 10) - companionWindowDimensions.height,
@@ -69,6 +71,7 @@ WorkspaceElasticWindow.propTypes = {
     width: PropTypes.number,
   }),
   focused: PropTypes.bool,
+  focusWindow: PropTypes.func,
   layout: PropTypes.shape({
     height: PropTypes.number,
     id: PropTypes.string,
@@ -85,6 +88,7 @@ WorkspaceElasticWindow.defaultProps = {
   classes: {},
   companionWindowDimensions: { height: 0, width: 0 },
   focused: false,
+  focusWindow: () => {},
 };
 
 export default WorkspaceElasticWindow;

--- a/src/containers/WorkspaceElasticWindow.js
+++ b/src/containers/WorkspaceElasticWindow.js
@@ -28,6 +28,7 @@ const mapStateToProps = (state, { windowId }) => (
  * @private
  */
 const mapDispatchToProps = (dispatch, props) => ({
+  focusWindow: () => dispatch(actions.focusWindow(props.windowId)),
   updateElasticWindowLayout: (windowId, position) => {
     dispatch(
       actions.updateElasticWindowLayout(windowId, position),


### PR DESCRIPTION
Fixes https://github.com/ProjectMirador/mirador/issues/3752