### PR TITLE
Remove unused icon style; fixes #3761

### DIFF
--- a/src/containers/ErrorContent.js
+++ b/src/containers/ErrorContent.js
@@ -30,9 +30,6 @@ const mapStateToProps = (state, { companionWindowId, windowId }) => ({
  */
 const styles = theme => ({
   alert: {
-    '& $icon': {
-      color: theme.palette.error.main,
-    },
     backgroundColor: theme.palette.error.main,
     color: '#fff',
     fontWeight: theme.typography.fontWeightMedium,


### PR DESCRIPTION
As best I can tell, this was added in #3037 but never targeted anything. I suspect, perhaps, the intent was style the disclosure arrow (but, if it was supposed to do so, the color would be different 🤷 ).
