### PR TITLE
Run CI tests when making PRs against the mui5 branch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, mui5 ]
 
 jobs:
   build:


### PR DESCRIPTION
This will allow us to make PRs to the `mui5` branch and see that we are chipping away at tests passing
Right now if I PR against that branch with my changes to the tests, CI does not run for that PR.
We can delete this after the `mui5` branch is merged; not sure if there is a cleaner way to do it. I would rather not push directly to that branch.
Thanks!