### PR TITLE
Fix double rendering of SearchHit and its placement

### DIFF
--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -158,8 +158,9 @@ export class CompanionWindow extends Component {
               bgcolor: 'shades.light',
               flexWrap: 'wrap',
               justifyContent: 'space-between',
-              minHeight: 'max-content',
+              minHeight: '100%',
               paddingLeft: 2,
+              marginBottom: 10,
             }}
             className={ns('companion-window-header')}
             disableGutters

--- a/src/components/SearchHit.js
+++ b/src/components/SearchHit.js
@@ -136,9 +136,6 @@ export class SearchHit extends Component {
                   verticalAlign: 'inherit',
                 }}
               />
-              <span id={canvasLabelHtmlId}>
-                {canvasLabel}
-              </span>
             </Typography>
             {annotationLabel && (
               <Typography variant="subtitle2">{annotationLabel}</Typography>


### PR DESCRIPTION
before
<img width="306" alt="Screenshot 2023-10-26 at 3 58 27 PM" src="https://github.com/ProjectMirador/mirador/assets/1328900/820ae8ff-35d4-4740-961c-c2d4119fa56b">

after
<img width="274" alt="Screenshot 2023-10-26 at 5 47 21 PM" src="https://github.com/ProjectMirador/mirador/assets/1328900/c7278df4-7eb3-477c-a34c-1eccc4466050">

There may be a better way to style this but it should probably be fixed!
