### PR TITLE
Fix some styling and console errors on mui5 branch

### DIFF
--- a/src/components/AttributionPanel.js
+++ b/src/components/AttributionPanel.js
@@ -47,7 +47,7 @@ export class AttributionPanel extends Component {
         windowId={windowId}
         id={id}
       >
-        <StyledSection>
+        <StyledSection sx={{paddingLeft: 2}}>
           { requiredStatement && (
             <LabelValueMetadata labelValuePairs={requiredStatement} defaultLabel={t('attribution')} />
           )}

--- a/src/components/CanvasAnnotations.js
+++ b/src/components/CanvasAnnotations.js
@@ -71,7 +71,6 @@ export class CanvasAnnotations extends Component {
         <MenuList autoFocusItem variant="selectedMenu">
           {annotations.map((annotation) => (
             <MenuItem
-              button
               component={listContainerComponent}
               sx={{
                 '&:hover,&:focus': {

--- a/src/components/SidebarIndexList.js
+++ b/src/components/SidebarIndexList.js
@@ -51,13 +51,10 @@ export class SidebarIndexList extends Component {
               <MenuItem
                 key={canvas.id}
                 sx={{
-                  borderBottom: '0.5px',
-                  borderBottomColor: 'divider',
                   paddingRight: 1,
                 }}
-                alignItems="flex-start"
+                divider="true"
                 onClick={onClick}
-                button
                 component="li"
                 selected={selectedCanvasIds.includes(canvas.id)}
               >

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -31,7 +31,7 @@ export class WindowTopBar extends Component {
     } = this.props;
 
     return (
-      <AppBar position="relative" color="default" enableColorOnDark>
+      <AppBar position="relative" color="default" enableColorOnDark sx={{zIndex: 1100}} >
         <nav aria-label={t('windowNavigation')}>
           <Toolbar
             disableGutters


### PR DESCRIPTION
### Fix attribution panel padding:
<img width="600" alt="Screenshot 2023-11-10 at 2 53 31 PM" src="https://github.com/ProjectMirador/mirador/assets/1328900/ab42ea6d-d498-4edd-ae85-832e8a761ba3">

<img width="600" alt="Screenshot 2023-11-10 at 2 53 20 PM" src="https://github.com/ProjectMirador/mirador/assets/1328900/9512fcd0-06d1-40bd-96b8-ca013b7ca602">


### Restore divider

<img width="600" alt="Screenshot 2023-11-10 at 2 47 42 PM" src="https://github.com/ProjectMirador/mirador/assets/1328900/6671cd41-ee20-4d2d-ac94-b828fbebee24">

<img width="600" alt="Screenshot 2023-11-10 at 3 04 36 PM" src="https://github.com/ProjectMirador/mirador/assets/1328900/47ca2982-d4f3-479d-9600-3228e10a92da">


### Restore shadow to app top bar using zindex. 
I'm not sure exactly how it was removed in the mui5 work, but in the current version of Mirador it was a z-index of 1100.


### Remove invalid props
`alignItems` and `button` were causing a console errors
I removed `button` from `MuiListItem`. Visually I can't tell any difference but not sure the history here. [According to MUI, `MuiListItem` also has access to props of `ButtonBase`](https://mui.com/material-ui/api/menu-item/#props) -- so it can act like a button inherently. ?