### PR TITLE
[MUI5] Reduce Window top menu button margin

### DIFF
--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -61,7 +61,7 @@ export class WindowTopMenuButton extends Component {
           aria-owns={open ? menuId : undefined}
           className={open ? classes.ctrlBtnSelected : undefined}
           sx={{
-            margin: 1,
+            margin: 0.25,
             ...(open && {
               backgroundColor: 'action.selected',
             }),


### PR DESCRIPTION
Before:
<img width="556" alt="Screenshot 2023-11-21 at 07 53 22" src="https://github.com/ProjectMirador/mirador/assets/111218/634da80b-734e-4921-9975-b409a962bd12">

After:
<img width="575" alt="Screenshot 2023-11-21 at 07 52 33" src="https://github.com/ProjectMirador/mirador/assets/111218/c0484d5a-51c0-41d2-aea8-303469d79bd7">
