### PR TITLE
[MUI5] Center collapse icon in the container

### DIFF
--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -19,9 +19,12 @@ const StyledWrapper = styled('div')({
 });
 
 const StyledToggle = styled('div')(({ theme }) => ({
+  alignItems: 'center',
   backgroundColor: theme.palette.background.paper,
   border: `1px solid ${theme.palette.mode === 'dark' ? theme.palette.divider : theme.palette.shades?.dark}`,
+  borderInlineStart: 0,
   borderRadius: 0,
+  display: 'inline-flex',
   height: '48px',
   left: '100%',
   marginTop: '1rem',


### PR DESCRIPTION
After:
<img width="208" alt="Screenshot 2023-11-21 at 08 11 10" src="https://github.com/ProjectMirador/mirador/assets/111218/5c20964b-aebd-42fd-bb9f-a88bf000ac26">
