### PR TITLE
[MUI5] Add a custom background color for annotation + search chips in the gallery view

### DIFF
--- a/src/components/GalleryViewThumbnail.js
+++ b/src/components/GalleryViewThumbnail.js
@@ -172,9 +172,7 @@ export class GalleryViewThumbnail extends Component {
                   )}
                   label={searchAnnotationsCount}
                   sx={{
-                    '&.Mui-selected .MuiAvatar-circle': {
-                      bgcolor: 'highlights.primary',
-                    },
+                    backgroundColor: 'annotations.chipBackground',
                     marginTop: 2,
                     typography: 'caption',
                   }}
@@ -198,9 +196,7 @@ export class GalleryViewThumbnail extends Component {
                   )}
                   label={annotationsCount}
                   sx={{
-                    '&.Mui-selected .MuiAvatar-circle': {
-                      bgcolor: 'highlights.primary',
-                    },
+                    backgroundColor: 'annotations.chipBackground',
                     typography: 'caption',
                   }}
                   size="small"

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -61,6 +61,7 @@ export default {
       },
       section_divider: 'rgba(0, 0, 0, 0.25)',
       annotations: {
+        chipBackground: '#e0e0e0',
         hidden: { globalAlpha: 0 },
         default: { strokeStyle: '#00BFFF', globalAlpha: 1 },
         hovered: { strokeStyle: '#BF00FF', globalAlpha: 1 },


### PR DESCRIPTION
After:
<img width="313" alt="Screenshot 2023-11-21 at 09 30 44" src="https://github.com/ProjectMirador/mirador/assets/111218/40b902ed-f7b7-4b92-b407-9e506625873f">

I couldn't figure out if the mui-selected style ever was supposed to do anything, but I suspect it might be copy/pasta from the annotations companion window.