### PR TITLE
[MUI5] Always give the title controls some space

### DIFF
--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -217,9 +217,8 @@ export class CompanionWindow extends Component {
               titleControls && (
                 <StyledTitleControls
                   sx={{
-                    ...(!isBottom && {
-                      flexGrow: 1,
-                    }),
+                    flexGrow: 1,
+                    justifyContent: isBottom ? 'flex-end' : 'flex-start',
                     order: isBottom || size.width < 370 ? 'unset' : 1000,
                   }}
                   className={ns('companion-window-title-controls')}


### PR DESCRIPTION
When positioned at the bottom, the title controls were squished by the flex-grow on the companion window title. We should always let them grow.

After:
<img width="1966" alt="Screenshot 2023-11-22 at 07 35 11" src="https://github.com/ProjectMirador/mirador/assets/111218/6d387c41-cf79-44a7-9732-b4eabbc47fb8">
