### PR TITLE
Restyle the WorkspaceExport form

### DIFF
--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -93,14 +93,13 @@ export class WorkspaceExport extends Component {
         </DialogTitle>
 
         <DialogContent>
-          <Accordion elevation={0}>
+          <Accordion elevation={2}>
             <AccordionSummary
-              sx={{ padding: 0 }}
               expandIcon={<ExpandMoreIcon />}
             >
               <Typography variant="h4">{t('viewWorkspaceConfiguration')}</Typography>
             </AccordionSummary>
-            <AccordionDetails>
+            <AccordionDetails sx={{ overflow: 'scroll' }}>
               {children}
               <pre>
                 {this.exportedState()}


### PR DESCRIPTION
I think it's a little less weird to have the output contained in a visible accordion vs having the dialog itself scroll?

Before:
![Screenshot 2023-11-30 at 09 28 34](https://github.com/ProjectMirador/mirador/assets/111218/a4f71e9b-5c60-4e48-b791-4558bbceff85)


After:
![Screenshot 2023-11-30 at 09 27 59](https://github.com/ProjectMirador/mirador/assets/111218/52b8f5a8-6c07-48c7-9eb1-50fd31e9dc1e)
