### PR TITLE
Remove deprecated @mui/styles package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@mui/utils": "^5.13.1",
     "@mui/x-tree-view": "^6.17.0",
     "@react-aria/live-announcer": "^3.1.2",
+    "@redux-devtools/extension": "^3.3.0",
     "classnames": "^2.2.6",
     "clsx": "^1.0.4",
     "deepmerge": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/lab": "^5.0.0-alpha.134",
     "@mui/material": "^5.13.5",
-    "@mui/styles": "^5.13.2",
     "@mui/utils": "^5.13.1",
     "@mui/x-tree-view": "^6.17.0",
     "@react-aria/live-announcer": "^3.1.2",

--- a/src/components/AppProviders.js
+++ b/src/components/AppProviders.js
@@ -5,8 +5,6 @@ import { I18nextProvider } from 'react-i18next';
 import {
   ThemeProvider, StyledEngineProvider, createTheme,
 } from '@mui/material/styles';
-import StylesProvider from '@mui/styles/StylesProvider';
-import createGenerateClassName from '@mui/styles/createGenerateClassName';
 import { DndContext, DndProvider } from 'react-dnd';
 import { MultiBackend } from 'react-dnd-multi-backend';
 import { HTML5toTouch } from 'rdndmb-html5-to-touch';
@@ -96,12 +94,10 @@ export class AppProviders extends Component {
   /** */
   render() {
     const {
-      children, createGenerateClassNameOptions,
+      children,
       theme, translations,
       dndManager,
     } = this.props;
-
-    const generateClassName = createGenerateClassName(createGenerateClassNameOptions);
 
     /**
      * Create rtl emotion cache
@@ -128,11 +124,9 @@ export class AppProviders extends Component {
           <StyledEngineProvider injectFirst>
             <CacheProvider value={theme.direction === 'rtl' ? cacheRtl : cacheDefault}>
               <ThemeProvider theme={createTheme((theme))}>
-                <StylesProvider generateClassName={generateClassName}>
-                  <MaybeDndProvider dndManager={dndManager}>
-                    {children}
-                  </MaybeDndProvider>
-                </StylesProvider>
+                <MaybeDndProvider dndManager={dndManager}>
+                  {children}
+                </MaybeDndProvider>
               </ThemeProvider>
             </CacheProvider>
           </StyledEngineProvider>
@@ -144,7 +138,6 @@ export class AppProviders extends Component {
 
 AppProviders.propTypes = {
   children: PropTypes.node,
-  createGenerateClassNameOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   dndManager: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   language: PropTypes.string.isRequired,
   theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
@@ -153,6 +146,5 @@ AppProviders.propTypes = {
 
 AppProviders.defaultProps = {
   children: null,
-  createGenerateClassNameOptions: {},
   dndManager: undefined,
 };

--- a/src/containers/AppProviders.js
+++ b/src/containers/AppProviders.js
@@ -11,7 +11,6 @@ import { AppProviders } from '../components/AppProviders';
  */
 const mapStateToProps = state => (
   {
-    createGenerateClassNameOptions: getConfig(state).createGenerateClassNameOptions,
     language: getConfig(state).language,
     theme: getTheme(state),
     translations: getConfig(state).translations,

--- a/src/state/createStore.js
+++ b/src/state/createStore.js
@@ -6,7 +6,7 @@
 import thunkMiddleware from 'redux-thunk';
 import createSagaMiddleware from 'redux-saga';
 import { combineReducers, createStore, applyMiddleware } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension';
+import { composeWithDevTools } from '@redux-devtools/extension';
 import createRootReducer from './reducers/rootReducer';
 import getRootSaga from './sagas';
 import settings from '../config/settings';


### PR DESCRIPTION
I'm not seeing where we consume the provided styles, and it's a blocker to upgrading to React 18.