### PR TITLE
chore: remove unused paramater of maximizeWindow action

### DIFF
--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -112,7 +112,7 @@ export function updateWindow(id, payload) {
  * @param  {String} windowId
  * @memberof ActionCreators
  */
-export function maximizeWindow(windowId, layout) {
+export function maximizeWindow(windowId) {
   return { type: ActionTypes.MAXIMIZE_WINDOW, windowId };
 }
 


### PR DESCRIPTION
I just found a unused parameter and removed it.