### PR TITLE
Remove tReady from WindowList props

### DIFF
--- a/src/components/WindowList.js
+++ b/src/components/WindowList.js
@@ -25,8 +25,9 @@ export class WindowList extends Component {
   render() {
     const {
       container, handleClose, windowIds, focusWindow, focusedWindowId, t,
-      ...menuProps
+      ...rest
     } = this.props;
+    const { tReady, ...menuProps } = rest;
 
     return (
       <Menu


### PR DESCRIPTION
This change just removes the console warning about passing `tReady` (which is passed as prop via `withTranslation()`) as a property to a DOM element. We don't do something like that in `WindowList` directly, and all components within `WindowList` are from MUI, so there might be a MUI component passing all props to a native element. There might also be more occurrences of that issue in other components.

I'm neither sure if this is even noticable in non-dev builds nor if we should file this as an issue with MaterialUI.