### PR TITLE
Remove extra slash from import

### DIFF
--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import Menu from '@mui/material//Menu';
+import Menu from '@mui/material/Menu';
 import ListSubheader from '@mui/material/ListSubheader';
 import PropTypes from 'prop-types';
 import WindowThumbnailSettings from '../containers/WindowThumbnailSettings';


### PR DESCRIPTION
This threw an error while testing the new release M4-alpha with `mirador-integration`