### PR TITLE
Fix #3783 and #3897, omit OpenSeadragon 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.11",
     "manifesto.js": "^4.2.0",
     "normalize-url": "^4.5.0",
-    "openseadragon": "^2.4.2 || ^3.0.0 || ^4.0.0",
+    "openseadragon": "^2.4.2 || ^3.0.0 || 4.0.x || ^4.1.1",
     "prop-types": "^15.6.2",
     "rdndmb-html5-to-touch": "^8.0.0",
     "re-reselect": "^5.0.0",


### PR DESCRIPTION
As suggested by @mbklein in [#3897](https://github.com/ProjectMirador/mirador/issues/3897#issuecomment-2030389270) the OpenSeadragon version range will exclude version 4.1.0.

I guess `^2.4.2 || ^3.0.0 || ^4.1.1` would also be fine; keeping `4.0.x` might only be useful if dependent projects have explicitly specified a 4.0.x version. 