### PR TITLE
Include OpenSeadragon v5

### DIFF
--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -172,9 +172,9 @@ describe('OpenSeadragonViewer', () => {
     });
 
     it('calls addNonTileSource for every nonTiledImage and then zoomsToWorld', async () => {
-      const { component, rerender, viewer } = createWrapper({ nonTiledImages: [] });
+      const { component, rerender, viewer } = createWrapper({ infoResponses: [], nonTiledImages: [] });
 
-      const mockAddNonTiledImage = jest.spyOn(viewer, 'addSimpleImage');
+      const mockAddNonTiledImage = jest.spyOn(viewer, 'addSimpleImage').mockImplementation(() => true);
       const mockFitBounds = jest.spyOn(viewer.viewport, 'fitBounds');
 
       rerender(cloneElement(component, {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.11",
     "manifesto.js": "^4.2.0",
     "normalize-url": "^4.5.0",
-    "openseadragon": "^2.4.2 || ^3.0.0 || 4.0.x || ^4.1.1",
+    "openseadragon": "^2.4.2 || ^3.0.0 || 4.0.x || ^4.1.1 || ^5.0.0",
     "prop-types": "^15.6.2",
     "rdndmb-html5-to-touch": "^8.0.0",
     "re-reselect": "^5.0.0",


### PR DESCRIPTION
Just noticed that OpenSeadragon [v5.0.0](https://github.com/openseadragon/openseadragon/releases/tag/v5.0.0) dropped yesterday. Breaking change is dropped support for IE11. Mirador already dropped IE11 support since at least #3612.