### PR TITLE
Pin to ubuntu-22 to avoid CI failure

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Pin to ubuntu-22 until a solution is found for this issue:
+    # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [18.x, 20.x]


### PR DESCRIPTION
Initially tried to use recommended puppeteer settings to fix this failure, but nothing was working (see closed PR https://github.com/ProjectMirador/mirador/pull/3937). 

ubuntu-22 is supported til 2032 so this should be OK for now.