### PR TITLE
Add node 22.x to the test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Needed to upgrade canvas to a git rev due to https://github.com/Automattic/node-canvas/issues/2377