### PR TITLE
Fix warnings about usage of i18n

### DIFF
--- a/__tests__/src/components/CanvasAnnotations.test.js
+++ b/__tests__/src/components/CanvasAnnotations.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from 'test-utils';
 import userEvent from '@testing-library/user-event';
-import i18next from 'i18next';
+import { t } from 'i18next';
 
 import { CanvasAnnotations } from '../../../src/components/CanvasAnnotations';
 import { ScrollTo } from '../../../src/components/ScrollTo';
@@ -15,7 +15,7 @@ function createWrapper(props) {
       index={0}
       label="A Canvas Label"
       selectAnnotation={() => {}}
-      t={i18next.t}
+      t={t}
       totalSize={1}
       windowId="abc"
       {...props}

--- a/__tests__/src/components/ErrorContent.test.js
+++ b/__tests__/src/components/ErrorContent.test.js
@@ -1,4 +1,4 @@
-import i18next from 'i18next';
+import { t } from 'i18next';
 import { render, screen } from 'test-utils';
 
 import { ErrorContent } from '../../../src/components/ErrorContent';
@@ -11,7 +11,7 @@ describe('ErrorContent', () => {
         windowId="xyz"
         manifestId="foo"
         classes={{}}
-        t={i18next.t}
+        t={t}
       />,
       {
         preloadedState: {
@@ -42,7 +42,7 @@ describe('ErrorContent', () => {
         manifestId="foo"
         showJsError={false}
         classes={{}}
-        t={i18next.t}
+        t={t}
       />,
       {
         preloadedState: {

--- a/__tests__/src/components/SearchPanel.test.js
+++ b/__tests__/src/components/SearchPanel.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from 'test-utils';
 import userEvent from '@testing-library/user-event';
-import i18next from 'i18next';
+import { t } from 'i18next';
 
 import { SearchPanel } from '../../../src/components/SearchPanel';
 
@@ -68,7 +68,7 @@ describe('SearchPanel', () => {
     const user = userEvent.setup();
     const fetchSearch = jest.fn();
     createWrapper({
-      fetchSearch, query: '', suggestedSearches: ['abc'], t: i18next.t,
+      fetchSearch, query: '', suggestedSearches: ['abc'], t,
     });
 
     expect(screen.getByRole('button', { name: 'Search this document for "abc"' })).toBeInTheDocument();

--- a/__tests__/src/components/WindowSideBarAnnotationsPanel.test.js
+++ b/__tests__/src/components/WindowSideBarAnnotationsPanel.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from 'test-utils';
-import i18next from 'i18next';
+import { t } from 'i18next';
 
 import CanvasAnnotations from '../../../src/containers/CanvasAnnotations';
 import { WindowSideBarAnnotationsPanel } from '../../../src/components/WindowSideBarAnnotationsPanel';
@@ -11,7 +11,7 @@ function createWrapper(props, state) {
       annotationCount={4}
       classes={{}}
       id="xyz"
-      t={i18next.t}
+      t={t}
       windowId="abc"
       {...props}
     />,

--- a/__tests__/src/components/WindowSideBarButtons.test.js
+++ b/__tests__/src/components/WindowSideBarButtons.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from 'test-utils';
 import userEvent from '@testing-library/user-event';
-import i18next from 'i18next';
+import { t } from 'i18next';
 import { WindowSideBarButtons } from '../../../src/components/WindowSideBarButtons';
 
 /** create wrapper */
@@ -8,7 +8,7 @@ function createWrapper(props) {
   return render(
     <WindowSideBarButtons
       addCompanionWindow={() => {}}
-      t={i18next.t}
+      t={t}
       {...props}
       panels={{
         annotations: true,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,4 +1,4 @@
-import i18n from 'i18next';
+import { createInstance } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import ar from './locales/ar/translation.json';
 import de from './locales/de/translation.json';
@@ -50,7 +50,7 @@ function createI18nInstance() {
     'zh-TW': zhTw,
   };
 
-  const instance = i18n.createInstance();
+  const instance = createInstance();
   instance.use(initReactI18next).init({
     fallbackLng: 'en',
     interpolation: {


### PR DESCRIPTION
```
Caution: `i18n` also has a named export `createInstance`. Check if you meant to write `import {createInstance} from 'i18next'` instead
```