### PR TITLE
Use ES6 default arguments to avoid deprecated defaultProps on function components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,9 @@
     }],
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
-    "react/require-default-props": "off",
+    "react/require-default-props": [2, {
+      "functions": "defaultArguments"
+    }],
     "react-hooks/exhaustive-deps": "error",
     "testing-library/render-result-naming-convention": "off",
     "testing-library/no-render-in-lifecycle": [

--- a/__tests__/src/components/ThumbnailNavigation.test.js
+++ b/__tests__/src/components/ThumbnailNavigation.test.js
@@ -28,7 +28,7 @@ function Subject({ fixture = manifestJson, ...props }) {
 }
 
 Subject.propTypes = {
-  fixture: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  fixture: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 jest.mock(

--- a/setupJest.js
+++ b/setupJest.js
@@ -44,10 +44,12 @@ jest.mock('react-i18next', () => ({
     type: '3rdParty',
   },
   // this mock makes sure any components using the translate HoC receive the t function as a prop
-  withTranslation: () => (Component) => {
-    Component.defaultProps = { // eslint-disable-line no-param-reassign
-      ...Component.defaultProps, t: k => k,
-    };
-    return Component;
+  withTranslation: () => (WrappedComponent) => {
+    /**
+     *
+     */
+    const I18nAwareComponent = ({ t = (k => k), ...props }) => <WrappedComponent t={t} {...props} />; // eslint-disable-line react/prop-types
+
+    return I18nAwareComponent;
   },
 }));

--- a/src/components/AudioViewer.js
+++ b/src/components/AudioViewer.js
@@ -13,12 +13,8 @@ const StyledAudio = styled('audio')({
 });
 
 /** */
-export function AudioViewer(props) {
+export function AudioViewer({ audioOptions = {}, audioResources = [], captions = [] }) {
   /* eslint-disable jsx-a11y/media-has-caption */
-  /** */
-  const {
-    captions, audioOptions, audioResources,
-  } = props;
 
   return (
     <StyledContainer>
@@ -43,10 +39,4 @@ AudioViewer.propTypes = {
   audioOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   audioResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   captions: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
-};
-
-AudioViewer.defaultProps = {
-  audioOptions: {},
-  audioResources: [],
-  captions: [],
 };

--- a/src/components/BackgroundPluginArea.js
+++ b/src/components/BackgroundPluginArea.js
@@ -3,16 +3,12 @@ import ns from '../config/css-ns';
 import { PluginHook } from './PluginHook';
 
 /** invisible area where background plugins can add to */
-export const BackgroundPluginArea = props => (
+export const BackgroundPluginArea = ({ PluginComponents = [], ...props }) => (
   <div className={ns('background-plugin-area')} style={{ display: 'none' }}>
-    <PluginHook {...props} />
+    <PluginHook PluginComponents={PluginComponents} {...props} />
   </div>
 );
 
 BackgroundPluginArea.propTypes = {
   PluginComponents: PropTypes.array, // eslint-disable-line react/forbid-prop-types
-};
-
-BackgroundPluginArea.defaultProps = {
-  PluginComponents: [],
 };

--- a/src/components/CompanionWindow.js
+++ b/src/components/CompanionWindow.js
@@ -23,17 +23,18 @@ const StyledCloseButton = styled(MiradorMenuButton, { name: 'CompanionWindow', s
 /**
  * CompanionWindow
  */
-export function CompanionWindow(props) {
-  /** */
-  const openInNewStyle = () => {
-    const { direction } = props;
-    if (direction === 'rtl') return { transform: 'scale(-1, 1)' };
-    return {};
-  };
+export function CompanionWindow(props) { // eslint-disable-line react/require-default-props
+  const {
+    ariaLabel = undefined, classes = {}, direction, paperClassName = '', onCloseClick = () => {}, updateCompanionWindow = undefined, isDisplayed = false,
+    position = null, t = key => key, title = null, children = undefined, titleControls = null, size = {},
+    defaultSidebarPanelWidth = 235, defaultSidebarPanelHeight = 201, innerRef = undefined,
+  } = props;
 
   /** */
-  const resizeHandles = () => {
-    const { direction, position } = props;
+  const openInNewStyle = direction === 'rtl' ? { transform: 'scale(-1, 1)' } : {};
+
+  /** */
+  const resizeHandles = (() => {
     const positions = {
       ltr: {
         default: 'left',
@@ -69,12 +70,7 @@ export function CompanionWindow(props) {
     }
 
     return base;
-  };
-  const {
-    ariaLabel, classes, paperClassName, onCloseClick, updateCompanionWindow, isDisplayed,
-    position, t, title, children, titleControls, size,
-    defaultSidebarPanelWidth, defaultSidebarPanelHeight, innerRef,
-  } = props;
+  })();
 
   const isBottom = (position === 'bottom' || position === 'far-bottom');
 
@@ -111,7 +107,7 @@ export function CompanionWindow(props) {
           width: isBottom ? 'auto' : defaultSidebarPanelWidth,
         }}
         disableDragging
-        enableResizing={resizeHandles()}
+        enableResizing={resizeHandles}
         minHeight={50}
         minWidth={position === 'left' ? 235 : 100}
       >
@@ -130,7 +126,7 @@ export function CompanionWindow(props) {
                   aria-label={t('openInCompanionWindow')}
                   onClick={() => { updateCompanionWindow({ position: 'right' }); }}
                 >
-                  <OpenInNewIcon style={openInNewStyle()} />
+                  <OpenInNewIcon style={openInNewStyle} />
                 </MiradorMenuButton>
               )
               : (
@@ -207,22 +203,4 @@ CompanionWindow.propTypes = {
   ]),
   titleControls: PropTypes.node,
   updateCompanionWindow: PropTypes.func,
-};
-
-CompanionWindow.defaultProps = {
-  ariaLabel: undefined,
-  children: undefined,
-  classes: {},
-  defaultSidebarPanelHeight: 201,
-  defaultSidebarPanelWidth: 235,
-  innerRef: undefined,
-  isDisplayed: false,
-  onCloseClick: () => { },
-  paperClassName: '',
-  position: null,
-  size: {},
-  t: key => key,
-  title: null,
-  titleControls: null,
-  updateCompanionWindow: undefined,
 };

--- a/src/components/IIIFIFrameCommunication.js
+++ b/src/components/IIIFIFrameCommunication.js
@@ -1,10 +1,20 @@
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
+const IIIFIFrameCommunicationDefaultProps = {
+  'aria-hidden': true,
+  frameBorder: 0,
+  height: 1,
+  name: undefined,
+  scrolling: undefined,
+  style: { visibility: 'hidden' },
+  width: 1,
+};
+
 /**
  *  Handle IIIF Auth token validation using iframe message events
  */
-export function IIIFIFrameCommunication({ handleReceiveMessage, ...props }) {
+export function IIIFIFrameCommunication({ handleReceiveMessage = undefined, ...props }) {
   // Attaches the 'message' event listener to the window.
   useEffect(() => {
     if (!handleReceiveMessage) return undefined;
@@ -19,6 +29,7 @@ export function IIIFIFrameCommunication({ handleReceiveMessage, ...props }) {
     // iframe "title" attribute is passed in via props for accessibility
     // eslint-disable-next-line jsx-a11y/iframe-has-title
     <iframe
+      {...IIIFIFrameCommunicationDefaultProps}
       {...props}
     />
   );
@@ -34,15 +45,4 @@ IIIFIFrameCommunication.propTypes = {
   src: PropTypes.string.isRequired,
   style: PropTypes.shape({}),
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
-
-IIIFIFrameCommunication.defaultProps = {
-  'aria-hidden': true,
-  frameBorder: 0,
-  handleReceiveMessage: undefined,
-  height: 1,
-  name: undefined,
-  scrolling: undefined,
-  style: { visibility: 'hidden' },
-  width: 1,
 };

--- a/src/components/IIIFThumbnail.js
+++ b/src/components/IIIFThumbnail.js
@@ -22,7 +22,8 @@ const Image = styled('img', { name: 'IIIFThumbnail', slot: 'image' })(() => ({
  * try to load the image (or even calculate that the image url/height/width are)
  */
 const LazyLoadedImage = ({
-  border, placeholder, style = {}, thumbnail, resource, maxHeight, maxWidth, thumbnailsConfig, ...props
+  border = false, placeholder, style = {}, thumbnail = null,
+  resource, maxHeight, maxWidth, thumbnailsConfig = {}, ...props
 }) => {
   const { ref, inView } = useInView();
   const [loaded, setLoaded] = useState(false);
@@ -127,13 +128,6 @@ LazyLoadedImage.propTypes = {
     width: PropTypes.number,
   }),
   thumbnailsConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-};
-
-LazyLoadedImage.defaultProps = {
-  border: false,
-  style: {},
-  thumbnail: null,
-  thumbnailsConfig: {},
 };
 
 /**

--- a/src/components/MiradorMenuButton.js
+++ b/src/components/MiradorMenuButton.js
@@ -16,23 +16,22 @@ const Root = styled(IconButton, { name: 'MiradorMenuButton', slot: 'root' })(({ 
  * This shares the passed in aria-label w/ the Tooltip (as title) and the IconButton
  * All props besides icon are spread to the IconButton component
 */
-export function MiradorMenuButton(props) {
-  const { 'aria-label': ariaLabel } = props;
-  const {
-    badge,
-    children,
-    container,
-    dispatch,
-    selected,
-    BadgeProps,
-    TooltipProps,
-    sx,
-    ...iconButtonProps
-  } = props;
-
+export function MiradorMenuButton({
+  'aria-label': ariaLabel,
+  badge = false,
+  children,
+  container = null,
+  dispatch = () => {},
+  selected = false,
+  BadgeProps = {},
+  TooltipProps = {},
+  sx = {},
+  ...iconButtonProps
+}) {
   const button = (
     <Root
       selected={selected}
+      aria-label={ariaLabel}
       {...iconButtonProps}
       sx={sx}
       size="large"
@@ -75,14 +74,4 @@ MiradorMenuButton.propTypes = {
   selected: PropTypes.bool,
   sx: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   TooltipProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-};
-
-MiradorMenuButton.defaultProps = {
-  badge: false,
-  BadgeProps: {},
-  container: null,
-  dispatch: () => {},
-  selected: false,
-  sx: {},
-  TooltipProps: {},
 };

--- a/src/components/MosaicRenderPreview.js
+++ b/src/components/MosaicRenderPreview.js
@@ -7,7 +7,7 @@ import MinimalWindow from '../containers/MinimalWindow';
 export function MosaicRenderPreview({
   t = k => k,
   title = '',
-  windowId = '',
+  windowId,
 }) {
   return (
     <MinimalWindow

--- a/src/components/ScrollIndicatedDialogContent.js
+++ b/src/components/ScrollIndicatedDialogContent.js
@@ -49,8 +49,7 @@ const Root = styled(DialogContent, { name: 'ScrollIndicatedDialogContent', slot:
  * ScrollIndicatedDialogContent ~ Inject a style into the DialogContent component
  *                                to indicate there is scrollable content
 */
-export function ScrollIndicatedDialogContent(props) {
-  const { classes, className, ...otherProps } = props;
+export function ScrollIndicatedDialogContent({ classes = {}, className = '', ...otherProps }) {
   const ourClassName = [className, classes.shadowScrollDialog].join(' ');
 
   return (
@@ -66,9 +65,4 @@ ScrollIndicatedDialogContent.propTypes = {
     shadowScrollDialog: PropTypes.string,
   }),
   className: PropTypes.string,
-};
-
-ScrollIndicatedDialogContent.defaultProps = {
-  classes: {},
-  className: '',
 };

--- a/src/extend/PluginProvider.js
+++ b/src/extend/PluginProvider.js
@@ -8,8 +8,7 @@ import {
 } from './pluginMapping';
 
 /**  */
-export default function PluginProvider(props) {
-  const { plugins, children } = props;
+export default function PluginProvider({ plugins = [], children = null }) {
   const [pluginMap, setPluginMap] = useState({});
 
   useEffect(() => {
@@ -28,9 +27,4 @@ export default function PluginProvider(props) {
 PluginProvider.propTypes = {
   children: PropTypes.node,
   plugins: PropTypes.array, // eslint-disable-line react/forbid-prop-types
-};
-
-PluginProvider.defaultProps = {
-  children: null,
-  plugins: [],
 };


### PR DESCRIPTION
… and update the eslint rules accordingly.