### PR TITLE
Use a function mock ref instead of a string.

### DIFF
--- a/__tests__/src/components/ManifestListItem.test.js
+++ b/__tests__/src/components/ManifestListItem.test.js
@@ -20,7 +20,7 @@ function createWrapper(props) {
 
 describe('ManifestListItem', () => {
   it('renders without an error', () => {
-    createWrapper({ buttonRef: 'ref' });
+    createWrapper({ buttonRef: jest.fn() });
 
     expect(screen.getByRole('listitem')).toHaveAttribute('data-manifestid', 'http://example.com');
     expect(screen.getByRole('listitem')).toHaveClass('MuiListItem-root');


### PR DESCRIPTION
Fixes:
>       Warning: Component "div" contains the string ref "ref".