### PR TITLE
Don't forward the focused prop. It isn't valid on Rnd.

### DIFF
--- a/src/components/WorkspaceElasticWindow.js
+++ b/src/components/WorkspaceElasticWindow.js
@@ -5,7 +5,7 @@ import { Rnd } from 'react-rnd';
 import Window from '../containers/Window';
 import ns from '../config/css-ns';
 
-const StyledRnd = styled(Rnd)(({ focused, theme }) => ({
+const StyledRnd = styled(Rnd, { shouldForwardProp: prop => prop !== 'focused' })(({ focused, theme }) => ({
   zIndex: focused ? theme.zIndex.modal - 1 : 'auto',
 }));
 


### PR DESCRIPTION
Fixes: 

> Warning: Received `false` for a non-boolean attribute `focused`
