### PR TITLE
Refactor MiradorViewer initialize to avoid act() warning.

### DIFF
--- a/__tests__/src/lib/MiradorViewer.test.js
+++ b/__tests__/src/lib/MiradorViewer.test.js
@@ -19,11 +19,15 @@ describe('MiradorViewer', () => {
   });
   describe('constructor', () => {
     it('returns viewer store', () => {
-      const instance = new MiradorViewer({ id: 'mirador' });
+      const instance = new MiradorViewer({});
+
+      act(() => { instance.renderInto(document.getElementById('mirador')); }); // eslint-disable-line testing-library/no-unnecessary-act
       expect(instance.store.dispatch).toBeDefined();
     });
     it('renders via ReactDOM', () => {
-      act(() => { new MiradorViewer({ id: 'mirador' }); }); // eslint-disable-line no-new
+      const instance = new MiradorViewer({});
+
+      act(() => { instance.renderInto(document.getElementById('mirador')); }); // eslint-disable-line testing-library/no-unnecessary-act
 
       expect(screen.getByTestId('container')).not.toBeEmptyDOMElement();
     });
@@ -35,7 +39,6 @@ describe('MiradorViewer', () => {
           catalog: [
             { manifestId: 'http://media.nga.gov/public/manifests/nga_highlights.json', provider: 'National Gallery of Art' },
           ],
-          id: 'mirador',
           windows: [
             {
               canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
@@ -59,6 +62,8 @@ describe('MiradorViewer', () => {
           }],
         },
       );
+
+      act(() => { instance.renderInto(document.getElementById('mirador')); }); // eslint-disable-line testing-library/no-unnecessary-act
 
       const { windows, catalog, config } = instance.store.getState();
       const windowIds = Object.keys(windows);

--- a/src/lib/MiradorViewer.js
+++ b/src/lib/MiradorViewer.js
@@ -18,12 +18,18 @@ class MiradorViewer {
     this.store = viewerConfig.store
       || createPluggableStore(this.config, this.plugins);
 
-    if (config.id) {
-      this.container = document.getElementById(config.id);
-      this.root = createRoot(this.container);
+    if (config.id) this.renderInto(document.getElementById(config.id));
+  }
 
-      this.root.render(this.render());
-    }
+  /**
+   * @private
+   * @param {*} container
+   */
+  renderInto(container) {
+    this.container = container;
+    this.root = createRoot(this.container);
+
+    this.root.render(this.render());
   }
 
   /**


### PR DESCRIPTION
Fixes:

> Warning: An update to Root inside a test was not wrapped in act(...).