### PR TITLE
Fix MUI5 menu focus styles.

### DIFF
--- a/src/components/WindowThumbnailSettings.js
+++ b/src/components/WindowThumbnailSettings.js
@@ -15,7 +15,15 @@ const ThumbnailOption = styled(MenuItem, { name: 'WindowThumbnailSettings', slot
       borderBottomColor: theme.palette.secondary.main,
     }),
   },
-  backgroundColor: 'transparent !important',
+  '&.Mui-selected': {
+    backgroundColor: 'transparent !important',
+  },
+  '&.Mui-selected.Mui-focusVisible': {
+    backgroundColor: `${(theme.vars || theme).palette.action.focus} !important`,
+  },
+  '&:focused': {
+    backgroundColor: `${(theme.vars || theme).palette.action.focus} !important`,
+  },
   color: selected ? theme.palette.secondary.main : undefined,
   display: 'inline-block',
 }));

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -16,7 +16,15 @@ const ViewOption = styled(MenuItem, { name: 'WindowViewSettings', slot: 'option'
       borderBottomColor: theme.palette.secondary.main,
     }),
   },
-  backgroundColor: 'transparent !important',
+  '&.Mui-selected': {
+    backgroundColor: 'transparent !important',
+  },
+  '&.Mui-selected.Mui-focusVisible': {
+    backgroundColor: `${(theme.vars || theme).palette.action.focus} !important`,
+  },
+  '&:focused': {
+    backgroundColor: `${(theme.vars || theme).palette.action.focus} !important`,
+  },
   color: selected ? theme.palette.secondary.main : undefined,
   display: 'inline-block',
 }));


### PR DESCRIPTION
This PR restores the expected focus styling for the window top menu items:
<img width="356" alt="Screenshot 2024-11-08 at 10 29 19" src="https://github.com/user-attachments/assets/ff3377a4-5479-4684-81a8-8d65a13f9f91">
