### PR TITLE
Allow externally updated props to change the viewer even if OSD is still animating a change.

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -36,7 +36,6 @@ export class OpenSeadragonViewer extends Component {
     this.onCanvasMouseMove = debounce(this.onCanvasMouseMove.bind(this), 10);
     this.onViewportChange = this.onViewportChange.bind(this);
     this.zoomToWorld = this.zoomToWorld.bind(this);
-    this.osdUpdating = false;
   }
 
   /**
@@ -72,14 +71,7 @@ export class OpenSeadragonViewer extends Component {
       this.setState({ grabbing: false });
     });
 
-    // Set a flag when OSD starts animating (so that viewer updates are not used)
-    viewer.addHandler('animation-start', () => {
-      this.osdUpdating = true;
-    });
     viewer.addHandler('animation-finish', this.onViewportChange);
-    viewer.addHandler('animation-finish', () => {
-      this.osdUpdating = false;
-    });
 
     if (viewer.innerTracker) {
       viewer.innerTracker.moveHandler = this.onCanvasMouseMove;
@@ -127,7 +119,7 @@ export class OpenSeadragonViewer extends Component {
       }
     } else if (!isEqual(canvasWorld.layers, prevProps.canvasWorld.layers)) {
       this.refreshTileProperties();
-    } else if (viewerConfig && !this.osdUpdating) {
+    } else if (viewerConfig !== prevProps.viewerConfig) {
       const { viewport } = viewer;
 
       if (viewerConfig.x !== viewport.centerSpringX.target.value


### PR DESCRIPTION
This fixes some UX latency, especially visible if you spam the zoom in/zoom out buttons.