### PR TITLE
Use a double-click handler for OSD to handle zooming instead of click-to-zoom

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -63,6 +63,12 @@ export class OpenSeadragonViewer extends Component {
 
     this.setState({ viewer });
 
+    viewer.addHandler('canvas-double-click', ({ position, shift }) => {
+      const currentZoom = viewer.viewport.getZoom();
+      const zoomRatio = (shift ? 1.0 / osdConfig.zoomPerDoubleClick : osdConfig.zoomPerDoubleClick);
+      viewer.viewport.zoomTo(currentZoom * zoomRatio, viewer.viewport.pointFromPixel(position), false);
+    });
+
     viewer.addHandler('canvas-drag', () => {
       this.setState({ grabbing: true });
     });

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -524,7 +524,7 @@ export default {
     isWorkspaceAddVisible: false, // Catalog/Workspace add window feature visible by default
     exposeModeOn: false, // unused?
     height: 5000, // height of the elastic mode's virtual canvas
-    showZoomControls: false, // Configure if zoom controls should be displayed by default
+    showZoomControls: true, // Configure if zoom controls should be displayed by default
     type: 'mosaic', // Which workspace type to load by default. Other possible values are "elastic". If "mosaic" or "elastic" are not selected no worksapce type will be used.
     viewportPosition: { // center coordinates for the elastic mode workspace
       x: 0,
@@ -545,6 +545,8 @@ export default {
     preserveImageSizeOnResize: true,
     preserveViewport: true,
     showNavigationControl: false,
+    zoomPerClick: 1, // disable zoom-to-click
+    zoomPerDoubleClick: 2.0
   },
   export: {
     catalog: true,


### PR DESCRIPTION
Fixes #3516
Fixes #3191
etc.

