### PR TITLE
Convert some class components to functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-dnd-html5-backend": "^16.0.0",
     "react-dnd-multi-backend": "^8.0.0",
     "react-dnd-touch-backend": "^16.0.0",
+    "react-error-boundary": "^4.1.2",
     "react-full-screen": "^1.1.1",
     "react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0",
     "react-image": "^4.0.1",

--- a/src/components/AccessTokenSender.js
+++ b/src/components/AccessTokenSender.js
@@ -1,48 +1,31 @@
-import { Component } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { IIIFIFrameCommunication } from './IIIFIFrameCommunication';
 
 /**
  * Opens a new window for click
  */
-export class AccessTokenSender extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-
-    this.onReceiveAccessTokenMessage = this.onReceiveAccessTokenMessage.bind(this);
-  }
-
-  /** @private */
-  onReceiveAccessTokenMessage(e) {
-    const { handleAccessTokenMessage, url } = this.props;
+export function AccessTokenSender({ handleAccessTokenMessage, url = undefined }) {
+  const onReceiveAccessTokenMessage = useCallback((e) => {
     if (e.data && e.data.messageId && e.data.messageId === url) handleAccessTokenMessage(e.data);
-  }
+  }, [handleAccessTokenMessage, url]);
 
-  /** */
-  render() {
-    const { url } = this.props;
-    if (!url) return null;
+  if (!url) return null;
 
-    /**
-    login, clickthrough/kiosk open @id, wait for close
-    external, no-op
-    */
-    return (
-      <IIIFIFrameCommunication
-        src={`${url}?origin=${window.origin}&messageId=${url}`}
-        title="AccessTokenSender"
-        handleReceiveMessage={this.onReceiveAccessTokenMessage}
-      />
-    );
-  }
+  /**
+  login, clickthrough/kiosk open @id, wait for close
+  external, no-op
+  */
+  return (
+    <IIIFIFrameCommunication
+      src={`${url}?origin=${window.origin}&messageId=${url}`}
+      title="AccessTokenSender"
+      handleReceiveMessage={onReceiveAccessTokenMessage}
+    />
+  );
 }
 
 AccessTokenSender.propTypes = {
   handleAccessTokenMessage: PropTypes.func.isRequired,
   url: PropTypes.string,
-};
-
-AccessTokenSender.defaultProps = {
-  url: undefined,
 };

--- a/src/components/AnnotationSettings.js
+++ b/src/components/AnnotationSettings.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import VisibilityIcon from '@mui/icons-material/VisibilitySharp';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOffSharp';
@@ -8,26 +7,19 @@ import MiradorMenuButton from '../containers/MiradorMenuButton';
  * AnnotationSettings is a component to handle various annotation
  * display settings in the Annotation companion window
 */
-export class AnnotationSettings extends Component {
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      displayAll, displayAllDisabled, t, toggleAnnotationDisplay,
-    } = this.props;
-
-    return (
-      <MiradorMenuButton
-        aria-label={t(displayAll ? 'displayNoAnnotations' : 'highlightAllAnnotations')}
-        onClick={toggleAnnotationDisplay}
-        disabled={displayAllDisabled}
-        size="small"
-      >
-        { displayAll ? <VisibilityIcon /> : <VisibilityOffIcon /> }
-      </MiradorMenuButton>
-    );
-  }
+export function AnnotationSettings({
+  displayAll, displayAllDisabled, t, toggleAnnotationDisplay,
+}) {
+  return (
+    <MiradorMenuButton
+      aria-label={t(displayAll ? 'displayNoAnnotations' : 'highlightAllAnnotations')}
+      onClick={toggleAnnotationDisplay}
+      disabled={displayAllDisabled}
+      size="small"
+    >
+      { displayAll ? <VisibilityIcon /> : <VisibilityOffIcon /> }
+    </MiradorMenuButton>
+  );
 }
 
 AnnotationSettings.propTypes = {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import {
-  createRef, Component, lazy, Suspense,
+  createRef, lazy, Suspense,
 } from 'react';
 import PropTypes from 'prop-types';
 import PluginProvider from '../extend/PluginProvider';
@@ -12,45 +12,27 @@ const WorkspaceArea = lazy(() => import('../containers/WorkspaceArea'));
  * This is the top level Mirador component.
  * @prop {Object} manifests
  */
-export class App extends Component {
-  /** */
-  constructor(props) {
-    super(props);
+export function App({ dndManager = undefined, plugins = [] }) {
+  const areaRef = createRef();
 
-    this.areaRef = createRef();
-  }
-
-  /**
-   * render
-   * @return {String} - HTML markup for the component
-   */
-  render() {
-    const { dndManager, plugins } = this.props;
-
-    return (
-      <PluginProvider plugins={plugins}>
-        <AppProviders dndManager={dndManager}>
-          <WorkspaceContext.Provider value={this.areaRef}>
-            <Suspense
-              fallback={<div />}
-            >
-              <WorkspaceArea areaRef={this.areaRef} />
-            </Suspense>
-          </WorkspaceContext.Provider>
-        </AppProviders>
-      </PluginProvider>
-    );
-  }
+  return (
+    <PluginProvider plugins={plugins}>
+      <AppProviders dndManager={dndManager}>
+        <WorkspaceContext.Provider value={areaRef}>
+          <Suspense
+            fallback={<div />}
+          >
+            <WorkspaceArea areaRef={areaRef} />
+          </Suspense>
+        </WorkspaceContext.Provider>
+      </AppProviders>
+    </PluginProvider>
+  );
 }
 
 App.propTypes = {
   dndManager: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   plugins: PropTypes.array, // eslint-disable-line react/forbid-prop-types
-};
-
-App.defaultProps = {
-  dndManager: undefined,
-  plugins: [],
 };
 
 export default App;

--- a/src/components/AttributionPanel.js
+++ b/src/components/AttributionPanel.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
@@ -22,33 +21,28 @@ const StyledPlaceholder = styled(Skeleton)(({ theme }) => ({
 /**
  * WindowSideBarInfoPanel
  */
-export class AttributionPanel extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      manifestLogo,
-      requiredStatement,
-      rights,
-      windowId,
-      id,
-      t,
-    } = this.props;
+export function AttributionPanel({
+  manifestLogo = null,
+  requiredStatement = null,
+  rights = null,
+  windowId,
+  id,
+  t = k => k,
+}) {
+  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
 
-    return (
-      <CompanionWindow
-        title={t('attributionTitle')}
-        paperClassName={ns('attribution-panel')}
-        windowId={windowId}
-        id={id}
-      >
-        <CompanionWindowSection>
-          { requiredStatement && (
-            <LabelValueMetadata labelValuePairs={requiredStatement} defaultLabel={t('attribution')} />
-          )}
-          {
+  return (
+    <CompanionWindow
+      title={t('attributionTitle')}
+      paperClassName={ns('attribution-panel')}
+      windowId={windowId}
+      id={id}
+    >
+      <CompanionWindowSection>
+        { requiredStatement && (
+        <LabelValueMetadata labelValuePairs={requiredStatement} defaultLabel={t('attribution')} />
+        )}
+        {
             rights && rights.length > 0 && (
               <dl className={ns('label-value-metadata')}>
                 <Typography variant="subtitle2" component="dt">{t('rights')}</Typography>
@@ -62,25 +56,24 @@ export class AttributionPanel extends Component {
               </dl>
             )
           }
-        </CompanionWindowSection>
+      </CompanionWindowSection>
 
-        { manifestLogo && (
-          <CompanionWindowSection>
-            <StyledLogo
-              src={[manifestLogo]}
-              alt=""
-              role="presentation"
-              unloader={
-                <StyledPlaceholder variant="rectangular" height={60} width={60} />
+      { manifestLogo && (
+      <CompanionWindowSection>
+        <StyledLogo
+          src={[manifestLogo]}
+          alt=""
+          role="presentation"
+          unloader={
+            <StyledPlaceholder variant="rectangular" height={60} width={60} />
               }
-            />
-          </CompanionWindowSection>
-        )}
+        />
+      </CompanionWindowSection>
+      )}
 
-        <PluginHook {...this.props} />
-      </CompanionWindow>
-    );
-  }
+      <PluginHook {...pluginProps} />
+    </CompanionWindow>
+  );
 }
 
 AttributionPanel.propTypes = {
@@ -93,11 +86,4 @@ AttributionPanel.propTypes = {
   rights: PropTypes.arrayOf(PropTypes.string),
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
-};
-
-AttributionPanel.defaultProps = {
-  manifestLogo: null,
-  requiredStatement: null,
-  rights: null,
-  t: key => key,
 };

--- a/src/components/Branding.js
+++ b/src/components/Branding.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
@@ -8,40 +7,30 @@ import MiradorIcon from './icons/MiradorIcon';
 /**
  * Display a branding icon
  */
-export class Branding extends Component {
-  /** */
-  render() {
-    const { t, variant, ...ContainerProps } = this.props;
-
-    return (
-      <Stack alignItems="center" {...ContainerProps}>
-        { variant === 'wide' && (
-        <div>
-          <Typography align="center" component="p" variant="h3">{t('mirador')}</Typography>
-        </div>
-        )}
-        <Typography align="center">
-          <IconButton
-            component="a"
-            href="https://projectmirador.org"
-            target="_blank"
-            rel="noopener"
-            size="large"
-          >
-            <MiradorIcon aria-label={t('aboutMirador')} titleAccess={t('aboutMirador')} fontSize="large" />
-          </IconButton>
-        </Typography>
-      </Stack>
-    );
-  }
+export function Branding({ t = k => k, variant = 'default', ...ContainerProps }) {
+  return (
+    <Stack alignItems="center" {...ContainerProps}>
+      { variant === 'wide' && (
+      <div>
+        <Typography align="center" component="p" variant="h3">{t('mirador')}</Typography>
+      </div>
+      )}
+      <Typography align="center">
+        <IconButton
+          component="a"
+          href="https://projectmirador.org"
+          target="_blank"
+          rel="noopener"
+          size="large"
+        >
+          <MiradorIcon aria-label={t('aboutMirador')} titleAccess={t('aboutMirador')} fontSize="large" />
+        </IconButton>
+      </Typography>
+    </Stack>
+  );
 }
 
 Branding.propTypes = {
   t: PropTypes.func,
   variant: PropTypes.oneOf(['default', 'wide']),
-};
-
-Branding.defaultProps = {
-  t: k => k,
-  variant: 'default',
 };

--- a/src/components/CanvasInfo.js
+++ b/src/components/CanvasInfo.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import CollapsibleSection from '../containers/CollapsibleSection';
@@ -9,53 +8,47 @@ import { PluginHook } from './PluginHook';
 /**
  * CanvasInfo
  */
-export class CanvasInfo extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      canvasDescription,
-      canvasLabel,
-      canvasMetadata,
-      id,
-      index,
-      t,
-      totalSize,
-    } = this.props;
+export function CanvasInfo({
+  canvasDescription = null,
+  canvasLabel = null,
+  canvasMetadata = [],
+  id,
+  index = 1,
+  t = k => k,
+  totalSize = 1,
+}) {
+  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
 
-    return (
-      <CollapsibleSection
-        id={`${id}-currentItem-${index}`}
-        label={t('currentItem', { context: `${index + 1}/${totalSize}` })}
-      >
-        {canvasLabel && (
-          <Typography
-            aria-labelledby={
-              `${id}-currentItem-${index} ${id}-currentItem-${index}-heading`
-            }
-            id={`${id}-currentItem-${index}-heading`}
-            variant="h4"
-            component="h5"
-          >
-            {canvasLabel}
-          </Typography>
-        )}
+  return (
+    <CollapsibleSection
+      id={`${id}-currentItem-${index}`}
+      label={t('currentItem', { context: `${index + 1}/${totalSize}` })}
+    >
+      {canvasLabel && (
+        <Typography
+          aria-labelledby={
+            `${id}-currentItem-${index} ${id}-currentItem-${index}-heading`
+          }
+          id={`${id}-currentItem-${index}-heading`}
+          variant="h4"
+          component="h5"
+        >
+          {canvasLabel}
+        </Typography>
+      )}
 
-        {canvasDescription && (
-          <Typography variant="body1">
-            <SanitizedHtml htmlString={canvasDescription} ruleSet="iiif" />
-          </Typography>
-        )}
+      {canvasDescription && (
+        <Typography variant="body1">
+          <SanitizedHtml htmlString={canvasDescription} ruleSet="iiif" />
+        </Typography>
+      )}
 
-        {canvasMetadata && canvasMetadata.length > 0 && (
-          <LabelValueMetadata labelValuePairs={canvasMetadata} />
-        )}
-        <PluginHook {...this.props} />
-      </CollapsibleSection>
-    );
-  }
+      {canvasMetadata && canvasMetadata.length > 0 && (
+        <LabelValueMetadata labelValuePairs={canvasMetadata} />
+      )}
+      <PluginHook {...pluginProps} />
+    </CollapsibleSection>
+  );
 }
 
 CanvasInfo.propTypes = {
@@ -66,13 +59,4 @@ CanvasInfo.propTypes = {
   index: PropTypes.number,
   t: PropTypes.func,
   totalSize: PropTypes.number,
-};
-
-CanvasInfo.defaultProps = {
-  canvasDescription: null,
-  canvasLabel: null,
-  canvasMetadata: [],
-  index: 1,
-  t: key => key,
-  totalSize: 1,
 };

--- a/src/components/ChangeThemeDialog.js
+++ b/src/components/ChangeThemeDialog.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useCallback } from 'react';
 import {
   DialogTitle,
   ListItemIcon,
@@ -19,59 +19,39 @@ const ThemeIcon = styled(PaletteIcon, { name: 'ThemeIcon', slot: 'icon' })(({ th
 /**
  * a simple dialog providing the possibility to switch the theme
  */
-export class ChangeThemeDialog extends Component {
-  /**
-  */
-  constructor(props) {
-    super(props);
-    this.handleThemeChange = this.handleThemeChange.bind(this);
-  }
-
-  /**
-   * Propagate theme palette type selection into the global state
-   */
-  handleThemeChange(theme) {
-    const { setSelectedTheme, handleClose } = this.props;
-
+export function ChangeThemeDialog({
+  handleClose, open = false, selectedTheme, setSelectedTheme, t, themeIds = [],
+}) {
+  const handleThemeChange = useCallback((theme) => {
     setSelectedTheme(theme);
     handleClose();
-  }
+  }, [handleClose, setSelectedTheme]);
 
-  /** */
-  render() {
-    const {
-      handleClose,
-      open,
-      selectedTheme,
-      t,
-      themeIds,
-    } = this.props;
-    return (
-      <WorkspaceDialog onClose={handleClose} open={open} variant="menu">
-        <DialogTitle>
-          {t('changeTheme')}
-        </DialogTitle>
-        <DialogContent>
-          <MenuList autoFocusItem>
-            {themeIds.map((value) => (
-              <MenuItem
-                key={value}
-                className="listitem"
-                onClick={() => this.handleThemeChange(value)}
-                selected={value === selectedTheme}
-                value={value}
-              >
-                <ListItemIcon>
-                  <ThemeIcon ownerState={{ value }} />
-                </ListItemIcon>
-                <ListItemText>{t(value)}</ListItemText>
-              </MenuItem>
-            ))}
-          </MenuList>
-        </DialogContent>
-      </WorkspaceDialog>
-    );
-  }
+  return (
+    <WorkspaceDialog onClose={handleClose} open={open} variant="menu">
+      <DialogTitle>
+        {t('changeTheme')}
+      </DialogTitle>
+      <DialogContent>
+        <MenuList autoFocusItem>
+          {themeIds.map((value) => (
+            <MenuItem
+              key={value}
+              className="listitem"
+              onClick={() => handleThemeChange(value)}
+              selected={value === selectedTheme}
+              value={value}
+            >
+              <ListItemIcon>
+                <ThemeIcon ownerState={{ value }} />
+              </ListItemIcon>
+              <ListItemText>{t(value)}</ListItemText>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </DialogContent>
+    </WorkspaceDialog>
+  );
 }
 
 ChangeThemeDialog.propTypes = {
@@ -81,9 +61,4 @@ ChangeThemeDialog.propTypes = {
   setSelectedTheme: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   themeIds: PropTypes.arrayOf(PropTypes.string),
-};
-
-ChangeThemeDialog.defaultProps = {
-  open: false,
-  themeIds: [],
 };

--- a/src/components/CollapsibleSection.js
+++ b/src/components/CollapsibleSection.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import Accordion from '@mui/material/Accordion';
@@ -9,42 +9,27 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 /**
  * CollapsableSection ~
 */
-export class CollapsibleSection extends Component {
-  /** */
-  constructor(props) {
-    super(props);
+export function CollapsibleSection({
+  children, id, label, t,
+}) {
+  const [open, setOpen] = useState(true);
 
-    this.state = { open: true };
-    this.handleChange = this.handleChange.bind(this);
-  }
+  const handleChange = useCallback((_event, isExpanded) => {
+    setOpen(isExpanded);
+  }, [setOpen]);
 
-  /** Control the accordion state so we can provide aria labeling */
-  handleChange(event, isExpanded) {
-    this.setState({ open: isExpanded });
-  }
-
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      children, id, label, t,
-    } = this.props;
-    const { open } = this.state;
-
-    return (
-      <Accordion id={id} elevation={0} expanded={open} onChange={this.handleChange} disableGutters square variant="compact">
-        <AccordionSummary id={`${id}-header`} aria-controls={`${id}-content`} aria-label={t(open ? 'collapseSection' : 'expandSection', { section: label })} expandIcon={<ExpandMoreIcon />}>
-          <Typography variant="overline" component="h4">
-            {label}
-          </Typography>
-        </AccordionSummary>
-        <AccordionDetails>
-          {children}
-        </AccordionDetails>
-      </Accordion>
-    );
-  }
+  return (
+    <Accordion id={id} elevation={0} expanded={open} onChange={handleChange} disableGutters square variant="compact">
+      <AccordionSummary id={`${id}-header`} aria-controls={`${id}-content`} aria-label={t(open ? 'collapseSection' : 'expandSection', { section: label })} expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="overline" component="h4">
+          {label}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        {children}
+      </AccordionDetails>
+    </Accordion>
+  );
 }
 
 CollapsibleSection.propTypes = {

--- a/src/components/CollectionInfo.js
+++ b/src/components/CollectionInfo.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -6,64 +5,46 @@ import ViewListIcon from '@mui/icons-material/ViewListSharp';
 import CollapsibleSection from '../containers/CollapsibleSection';
 
 /**
- * ManifestInfo
+ * CollectionInfo
  */
-export class CollectionInfo extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-
-    this.openCollectionDialog = this.openCollectionDialog.bind(this);
-  }
-
-  /** */
-  openCollectionDialog() {
-    const { collectionPath, showCollectionDialog, windowId } = this.props;
-
+export function CollectionInfo({
+  collectionLabel = null, collectionPath = [], id, showCollectionDialog, t = k => k, windowId = null,
+}) {
+  /**
+   * Show the containing collection.
+   */
+  const openCollectionDialog = () => {
     const manifestId = collectionPath[collectionPath.length - 1];
 
     showCollectionDialog(manifestId, collectionPath.slice(0, -1), windowId);
-  }
+  };
 
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      collectionLabel,
-      collectionPath,
-      id,
-      t,
-    } = this.props;
+  if (collectionPath.length === 0) return null;
 
-    if (collectionPath.length === 0) return null;
-
-    return (
-      <CollapsibleSection
-        id={`${id}-collection`}
-        label={t('collection')}
-      >
-        {collectionLabel && (
-          <Typography
-            aria-labelledby={`${id}-resource ${id}-resource-heading`}
-            id={`${id}-resource-heading`}
-            variant="h4"
-          >
-            {collectionLabel}
-          </Typography>
-        )}
-
-        <Button
-          color="primary"
-          onClick={this.openCollectionDialog}
-          startIcon={<ViewListIcon />}
+  return (
+    <CollapsibleSection
+      id={`${id}-collection`}
+      label={t('collection')}
+    >
+      {collectionLabel && (
+        <Typography
+          aria-labelledby={`${id}-resource ${id}-resource-heading`}
+          id={`${id}-resource-heading`}
+          variant="h4"
         >
-          {t('showCollection')}
-        </Button>
-      </CollapsibleSection>
-    );
-  }
+          {collectionLabel}
+        </Typography>
+      )}
+
+      <Button
+        color="primary"
+        onClick={openCollectionDialog}
+        startIcon={<ViewListIcon />}
+      >
+        {t('showCollection')}
+      </Button>
+    </CollapsibleSection>
+  );
 }
 
 CollectionInfo.propTypes = {
@@ -73,11 +54,4 @@ CollectionInfo.propTypes = {
   showCollectionDialog: PropTypes.func.isRequired,
   t: PropTypes.func,
   windowId: PropTypes.string,
-};
-
-CollectionInfo.defaultProps = {
-  collectionLabel: null,
-  collectionPath: [],
-  t: key => key,
-  windowId: null,
 };

--- a/src/components/CompanionArea.js
+++ b/src/components/CompanionArea.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Slide from '@mui/material/Slide';
@@ -49,17 +48,16 @@ const StyledToggle = styled('div', { name: 'CompanionArea', slot: 'toggle' })(({
 }));
 
 /** */
-export class CompanionArea extends Component {
+export function CompanionArea({
+  classes = {}, className = undefined, direction,
+  companionWindowIds, companionAreaOpen, setCompanionAreaOpen = () => {},
+  position, sideBarOpen = false, t, windowId,
+}) {
   /** */
-  areaLayoutClass() {
-    const { classes, position } = this.props;
-
-    return (position === 'bottom' || position === 'far-bottom') ? classes.horizontal : null;
-  }
+  const areaLayoutClass = (position === 'bottom' || position === 'far-bottom') ? classes.horizontal : null;
 
   /** */
-  collapseIcon() {
-    const { companionAreaOpen, direction } = this.props;
+  const collapseIcon = (() => {
     if (direction === 'rtl') {
       if (companionAreaOpen) return <ArrowRightIcon />;
       return <ArrowLeftIcon />;
@@ -67,11 +65,10 @@ export class CompanionArea extends Component {
 
     if (companionAreaOpen) return <ArrowLeftIcon />;
     return <ArrowRightIcon />;
-  }
+  })();
 
-  /** @private */
-  slideDirection() {
-    const { direction, position } = this.props;
+  /** */
+  const slideDirection = (() => {
     const defaultPosition = direction === 'rtl' ? 'left' : 'right';
     const oppositePosition = direction === 'rtl' ? 'right' : 'left';
 
@@ -85,44 +82,38 @@ export class CompanionArea extends Component {
       default:
         return defaultPosition;
     }
-  }
+  })();
 
-  /** */
-  render() {
-    const {
-      className,
-      companionWindowIds, companionAreaOpen, setCompanionAreaOpen,
-      position, sideBarOpen, t, windowId,
-    } = this.props;
-    const classes = classNames(this.areaLayoutClass(), ns(`companion-area-${position}`), className);
-    return (
-      <Root ownerState={this.props} className={classes}>
-        <Slide in={companionAreaOpen} direction={this.slideDirection()}>
-          <Container
-            ownerState={this.props}
-            className={`${ns('companion-windows')}`}
-          >
-            {companionWindowIds.map((id) => (
-              <CompanionWindowFactory id={id} key={id} windowId={windowId} />
-            ))}
-          </Container>
-        </Slide>
-        {setCompanionAreaOpen && position === 'left' && sideBarOpen && companionWindowIds.length > 0 && (
-        <StyledToggle>
-          <MiradorMenuButton
-            aria-expanded={companionAreaOpen}
-            aria-label={companionAreaOpen ? t('collapseSidePanel') : t('expandSidePanel')}
-            edge="start"
-            onClick={() => { setCompanionAreaOpen(windowId, !companionAreaOpen); }}
-            TooltipProps={{ placement: 'right' }}
-          >
-            {this.collapseIcon()}
-          </MiradorMenuButton>
-        </StyledToggle>
-        )}
-      </Root>
-    );
-  }
+  const rootClasses = classNames(areaLayoutClass, ns(`companion-area-${position}`), className);
+  const ownerState = arguments[0]; // eslint-disable-line prefer-rest-params
+
+  return (
+    <Root ownerState={ownerState} className={rootClasses}>
+      <Slide in={companionAreaOpen} direction={slideDirection}>
+        <Container
+          ownerState={ownerState}
+          className={`${ns('companion-windows')}`}
+        >
+          {companionWindowIds.map((id) => (
+            <CompanionWindowFactory id={id} key={id} windowId={windowId} />
+          ))}
+        </Container>
+      </Slide>
+      {setCompanionAreaOpen && position === 'left' && sideBarOpen && companionWindowIds.length > 0 && (
+      <StyledToggle>
+        <MiradorMenuButton
+          aria-expanded={companionAreaOpen}
+          aria-label={companionAreaOpen ? t('collapseSidePanel') : t('expandSidePanel')}
+          edge="start"
+          onClick={() => { setCompanionAreaOpen(windowId, !companionAreaOpen); }}
+          TooltipProps={{ placement: 'right' }}
+        >
+          {collapseIcon}
+        </MiradorMenuButton>
+      </StyledToggle>
+      )}
+    </Root>
+  );
 }
 
 CompanionArea.propTypes = {
@@ -136,11 +127,4 @@ CompanionArea.propTypes = {
   sideBarOpen: PropTypes.bool,
   t: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-CompanionArea.defaultProps = {
-  classes: {},
-  className: undefined,
-  setCompanionAreaOpen: () => {},
-  sideBarOpen: false,
 };

--- a/src/components/CustomPanel.js
+++ b/src/components/CustomPanel.js
@@ -1,33 +1,21 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import CompanionWindow from '../containers/CompanionWindow';
 
 /**
  * a custom panel that can be used for anything
  */
-export class CustomPanel extends Component {
-  /**
-   * render
-   */
-  render() {
-    const {
-      id,
-      children,
-      t,
-      title,
-      windowId,
-    } = this.props;
-
-    return (
-      <CompanionWindow
-        title={t(title)}
-        id={id}
-        windowId={windowId}
-      >
-        {children}
-      </CompanionWindow>
-    );
-  }
+export function CustomPanel({
+  id, children = null, t, title, windowId,
+}) {
+  return (
+    <CompanionWindow
+      title={t(title)}
+      id={id}
+      windowId={windowId}
+    >
+      {children}
+    </CompanionWindow>
+  );
 }
 
 CustomPanel.propTypes = {
@@ -36,8 +24,4 @@ CustomPanel.propTypes = {
   t: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-CustomPanel.defaultProps = {
-  children: null,
 };

--- a/src/components/ErrorContent.js
+++ b/src/components/ErrorContent.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Accordion from '@mui/material/Accordion';
@@ -25,38 +24,34 @@ const InlineAccordion = styled(Accordion, { name: 'ErrorContent', slot: 'accordi
 });
 
 /** */
-export class ErrorContent extends Component {
-  /** */
-  render() {
-    const {
-      error,
-      metadata,
-      showJsError,
-      t,
-    } = this.props;
+export function ErrorContent({
+  error, metadata = null, showJsError = true, t = k => k, ...rest
+}) {
+  if (!showJsError) return null;
 
-    if (!showJsError) return null;
+  const pluginProps = {
+    error, metadata, showJsError, t, ...rest,
+  };
 
-    return (
-      <Alert elevation={6} variant="filled" severity="error">
-        {t('errorDialogTitle')}
-        {showJsError && (
-          <InlineAccordion elevation={2} square>
-            <AccordionSummary sx={{ marginInlineStart: '-1rem' }} expandIcon={<ExpandMoreIcon sx={{ color: '#fff' }} />}>
-              {t('jsError', { message: error.message, name: error.name })}
-            </AccordionSummary>
-            <AccordionDetails>
-              <Stack>
-                <ErrorStackTrace>{t('jsStack', { stack: error.stack })}</ErrorStackTrace>
-                {metadata && <ErrorMetadata>{JSON.stringify(metadata, null, 2)}</ErrorMetadata>}
-              </Stack>
-            </AccordionDetails>
-          </InlineAccordion>
-        )}
-        <PluginHook {...this.props} />
-      </Alert>
-    );
-  }
+  return (
+    <Alert elevation={6} variant="filled" severity="error">
+      {t('errorDialogTitle')}
+      {showJsError && (
+        <InlineAccordion elevation={2} square>
+          <AccordionSummary sx={{ marginInlineStart: '-1rem' }} expandIcon={<ExpandMoreIcon sx={{ color: '#fff' }} />}>
+            {t('jsError', { message: error.message, name: error.name })}
+          </AccordionSummary>
+          <AccordionDetails>
+            <Stack>
+              <ErrorStackTrace>{t('jsStack', { stack: error.stack })}</ErrorStackTrace>
+              {metadata && <ErrorMetadata>{JSON.stringify(metadata, null, 2)}</ErrorMetadata>}
+            </Stack>
+          </AccordionDetails>
+        </InlineAccordion>
+      )}
+      <PluginHook {...pluginProps} />
+    </Alert>
+  );
 }
 
 ErrorContent.propTypes = {
@@ -64,10 +59,4 @@ ErrorContent.propTypes = {
   metadata: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   showJsError: PropTypes.bool,
   t: PropTypes.func,
-};
-
-ErrorContent.defaultProps = {
-  metadata: null,
-  showJsError: true,
-  t: key => key,
 };

--- a/src/components/ErrorDialog.js
+++ b/src/components/ErrorDialog.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -9,41 +8,33 @@ import { isUndefined } from 'lodash';
 
 /**
  */
-export class ErrorDialog extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      error, removeError, t,
-    } = this.props;
+export function ErrorDialog({ error = null, removeError = () => {}, t = k => k }) {
+  const hasError = !isUndefined(error);
 
-    const hasError = !isUndefined(error);
+  if (!error) return null;
 
-    return error ? (
-      <Dialog
-        aria-labelledby="error-dialog-title"
-        id="error-dialog"
-        onClose={() => removeError(error.id)}
-        open={hasError}
-      >
-        <DialogTitle id="error-dialog-title">
-          {t('errorDialogTitle')}
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText variant="body2" noWrap color="inherit">
-            {`${error.message}`}
-          </DialogContentText>
-          <DialogActions>
-            <Button onClick={() => removeError(error.id)} variant="contained">
-              {t('errorDialogConfirm')}
-            </Button>
-          </DialogActions>
-        </DialogContent>
-      </Dialog>
-    ) : null;
-  }
+  return (
+    <Dialog
+      aria-labelledby="error-dialog-title"
+      id="error-dialog"
+      onClose={() => removeError(error.id)}
+      open={hasError}
+    >
+      <DialogTitle id="error-dialog-title">
+        {t('errorDialogTitle')}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText variant="body2" noWrap color="inherit">
+          {`${error.message}`}
+        </DialogContentText>
+        <DialogActions>
+          <Button onClick={() => removeError(error.id)} variant="contained">
+            {t('errorDialogConfirm')}
+          </Button>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 ErrorDialog.propTypes = {
@@ -53,10 +44,4 @@ ErrorDialog.propTypes = {
   }),
   removeError: PropTypes.func,
   t: PropTypes.func,
-};
-
-ErrorDialog.defaultProps = {
-  error: null,
-  removeError: () => {},
-  t: key => key,
 };

--- a/src/components/FullScreenButton.js
+++ b/src/components/FullScreenButton.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useContext } from 'react';
 import FullscreenIcon from '@mui/icons-material/FullscreenSharp';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExitSharp';
 import PropTypes from 'prop-types';
@@ -7,37 +7,21 @@ import FullScreenContext from '../contexts/FullScreenContext';
 
 /**
  */
-export class FullScreenButton extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      className, t,
-    } = this.props;
-    return (
-      <FullScreenContext.Consumer>
-        { handle => (handle && (
-          <MiradorMenuButton
-            className={className}
-            aria-label={handle.active ? t('exitFullScreen') : t('workspaceFullScreen')}
-            onClick={handle.active ? handle.exit : handle.enter}
-          >
-            {handle.active ? <FullscreenExitIcon /> : <FullscreenIcon />}
-          </MiradorMenuButton>
-        ))}
-      </FullScreenContext.Consumer>
-    );
+export function FullScreenButton({ className = undefined, t = k => k }) {
+  const handle = useContext(FullScreenContext);
+
+  if (handle && handle.active) {
+    return <MiradorMenuButton className={className} aria-label={t('exitFullScreen')} onClick={handle.exit}><FullscreenExitIcon /></MiradorMenuButton>;
   }
+
+  if (handle) {
+    return <MiradorMenuButton className={className} aria-label={t('workspaceFullScreen')} onClick={handle.enter}><FullscreenIcon /></MiradorMenuButton>;
+  }
+
+  return null;
 }
 
 FullScreenButton.propTypes = {
   className: PropTypes.string,
   t: PropTypes.func,
-};
-
-FullScreenButton.defaultProps = {
-  className: undefined,
-  t: key => key,
 };

--- a/src/components/GalleryView.js
+++ b/src/components/GalleryView.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Paper from '@mui/material/Paper';
@@ -18,44 +17,32 @@ const Root = styled(Paper, { name: 'GalleryView', slot: 'root' })(({ theme }) =>
 /**
  * Renders a GalleryView overview of the manifest.
  */
-export class GalleryView extends Component {
-  /**
-   * Renders things
-   */
-  render() {
-    const {
-      canvases, viewingDirection, windowId,
-    } = this.props;
-    const htmlDir = viewingDirection === 'right-to-left' ? 'rtl' : 'ltr';
-    return (
-      <Root
-        component="section"
-        aria-label="gallery section"
-        dir={htmlDir}
-        square
-        elevation={0}
-        id={`${windowId}-gallery`}
-      >
-        {
-          canvases.map(canvas => (
-            <GalleryViewThumbnail
-              key={canvas.id}
-              windowId={windowId}
-              canvas={canvas}
-            />
-          ))
-        }
-      </Root>
-    );
-  }
+export function GalleryView({ canvases, viewingDirection = '', windowId }) {
+  const htmlDir = viewingDirection === 'right-to-left' ? 'rtl' : 'ltr';
+  return (
+    <Root
+      component="section"
+      aria-label="gallery section"
+      dir={htmlDir}
+      square
+      elevation={0}
+      id={`${windowId}-gallery`}
+    >
+      {
+        canvases.map(canvas => (
+          <GalleryViewThumbnail
+            key={canvas.id}
+            windowId={windowId}
+            canvas={canvas}
+          />
+        ))
+      }
+    </Root>
+  );
 }
 
 GalleryView.propTypes = {
   canvases: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   viewingDirection: PropTypes.string,
   windowId: PropTypes.string.isRequired,
-};
-
-GalleryView.defaultProps = {
-  viewingDirection: '',
 };

--- a/src/components/IIIFThumbnail.js
+++ b/src/components/IIIFThumbnail.js
@@ -1,5 +1,5 @@
 import {
-  Component, useMemo, useEffect, useState,
+  useMemo, useEffect, useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
@@ -129,65 +129,56 @@ LazyLoadedImage.propTypes = {
   }),
   thumbnailsConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
+/** */
+function getUseableLabel(resource, index) {
+  return (resource
+    && resource.getLabel
+    && resource.getLabel().length > 0)
+    ? resource.getLabel().getValue()
+    : String(index + 1);
+}
+
+const defaultPlaceholder = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mMMDQmtBwADgwF/Op8FmAAAAABJRU5ErkJggg==';
 
 /**
  * Uses InteractionObserver to "lazy" load canvas thumbnails that are in view.
  */
-export class IIIFThumbnail extends Component {
-  /** */
-  static getUseableLabel(resource, index) {
-    return (resource
-      && resource.getLabel
-      && resource.getLabel().length > 0)
-      ? resource.getLabel().getValue()
-      : String(index + 1);
-  }
+export function IIIFThumbnail({
+  border = false,
+  children = null,
+  imagePlaceholder = defaultPlaceholder,
+  label = undefined,
+  labelled = false,
+  maxHeight = null,
+  maxWidth = null,
+  resource,
+  style = {},
+  thumbnail = null,
+  thumbnailsConfig = {},
+}) {
+  const ownerState = arguments[0]; // eslint-disable-line prefer-rest-params
 
-  /** */
-  label() {
-    const { label, resource } = this.props;
+  return (
+    <Root ownerState={ownerState}>
+      <LazyLoadedImage
+        placeholder={imagePlaceholder}
+        thumbnail={thumbnail}
+        resource={resource}
+        maxHeight={maxHeight}
+        maxWidth={maxWidth}
+        thumbnailsConfig={thumbnailsConfig}
+        style={style}
+        border={border}
+      />
 
-    return label || IIIFThumbnail.getUseableLabel(resource);
-  }
-
-  /**
-   */
-  render() {
-    const {
-      border,
-      children,
-      imagePlaceholder,
-      labelled,
-      maxHeight,
-      maxWidth,
-      resource,
-      style,
-      thumbnail,
-      thumbnailsConfig,
-    } = this.props;
-
-    return (
-      <Root ownerState={this.props}>
-        <LazyLoadedImage
-          placeholder={imagePlaceholder}
-          thumbnail={thumbnail}
-          resource={resource}
-          maxHeight={maxHeight}
-          maxWidth={maxWidth}
-          thumbnailsConfig={thumbnailsConfig}
-          style={style}
-          border={border}
-        />
-
-        { labelled && (
-          <Label ownerState={this.props}>
-            {this.label()}
-          </Label>
-        )}
-        {children}
-      </Root>
-    );
-  }
+      { labelled && (
+        <Label ownerState={ownerState}>
+          {label || getUseableLabel(resource)}
+        </Label>
+      )}
+      {children}
+    </Root>
+  );
 }
 
 IIIFThumbnail.propTypes = {
@@ -207,19 +198,4 @@ IIIFThumbnail.propTypes = {
   }),
   thumbnailsConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   variant: PropTypes.oneOf(['inside', 'outside']), // eslint-disable-line react/no-unused-prop-types
-};
-
-IIIFThumbnail.defaultProps = {
-  border: false,
-  children: null,
-  // Transparent "gray"
-  imagePlaceholder: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mMMDQmtBwADgwF/Op8FmAAAAABJRU5ErkJggg==',
-  label: undefined,
-  labelled: false,
-  maxHeight: null,
-  maxWidth: null,
-  style: {},
-  thumbnail: null,
-  thumbnailsConfig: {},
-  variant: null,
 };

--- a/src/components/LabelValueMetadata.js
+++ b/src/components/LabelValueMetadata.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import SanitizedHtml from '../containers/SanitizedHtml';
@@ -8,34 +7,25 @@ import ns from '../config/css-ns';
  * Renders label/value pair metadata in a dl
  * @prop {object} labelValuePair
  */
-export class LabelValueMetadata extends Component {
-  /**
-   * render
-   * @return {String} - HTML markup for the component
-   */
-  render() {
-    const { defaultLabel, labelValuePairs } = this.props;
-
-    if (labelValuePairs.length === 0) {
-      return null;
-    }
-
-    /* eslint-disable react/no-array-index-key */
-    // Disabling array index key for dt/dd elements as
-    // they are intended to display metadata that will not
-    // need to be re-rendered internally in any meaningful way
-    return (
-      <dl className={ns('label-value-metadata')}>
-        {labelValuePairs.reduce((acc, labelValuePair, i) => acc.concat([
-          <Typography component="dt" key={`label-${i}`} variant="subtitle2">{labelValuePair.label || defaultLabel}</Typography>,
-          <Typography style={{ marginBottom: '.5em', marginLeft: '0px' }} component="dd" key={`value-${i}`} variant="body1">
-            <SanitizedHtml htmlString={labelValuePair.values.join(', ')} ruleSet="iiif" />
-          </Typography>,
-        ]), [])}
-      </dl>
-    );
-    /* eslint-enable react/no-array-index-key */
+export function LabelValueMetadata({ defaultLabel = undefined, labelValuePairs }) {
+  if (labelValuePairs.length === 0) {
+    return null;
   }
+
+  /* eslint-disable react/no-array-index-key */
+  // Disabling array index key for dt/dd elements as
+  // they are intended to display metadata that will not
+  // need to be re-rendered internally in any meaningful way
+  return (
+    <dl className={ns('label-value-metadata')}>
+      {labelValuePairs.reduce((acc, labelValuePair, i) => acc.concat([
+        <Typography component="dt" key={`label-${i}`} variant="subtitle2">{labelValuePair.label || defaultLabel}</Typography>,
+        <Typography style={{ marginBottom: '.5em', marginLeft: '0px' }} component="dd" key={`value-${i}`} variant="body1">
+          <SanitizedHtml htmlString={labelValuePair.values.join(', ')} ruleSet="iiif" />
+        </Typography>,
+      ]), [])}
+    </dl>
+  );
 }
 
 LabelValueMetadata.propTypes = {
@@ -44,8 +34,4 @@ LabelValueMetadata.propTypes = {
     label: PropTypes.string,
     values: PropTypes.arrayOf(PropTypes.string),
   })).isRequired,
-};
-
-LabelValueMetadata.defaultProps = {
-  defaultLabel: undefined,
 };

--- a/src/components/LanguageSettings.js
+++ b/src/components/LanguageSettings.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import MenuItem from '@mui/material/MenuItem';
@@ -9,37 +8,28 @@ import PropTypes from 'prop-types';
  * LanguageSettings ~ the workspace sub menu to change the language
  * of the application
 */
-export class LanguageSettings extends Component {
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      handleClick, languages,
-    } = this.props;
-
-    return (
-      <>
-        {
-          languages.map(language => (
-            <MenuItem
-              key={language.locale}
-              onClick={() => { handleClick(language.locale); }}
-            >
-              <ListItemIcon>
-                {
-                  language.current && <CheckIcon />
-                }
-              </ListItemIcon>
-              <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
-                {language.label}
-              </ListItemText>
-            </MenuItem>
-          ))
-        }
-      </>
-    );
-  }
+export function LanguageSettings({ handleClick, languages }) {
+  return (
+    <>
+      {
+        languages.map(language => (
+          <MenuItem
+            key={language.locale}
+            onClick={() => { handleClick(language.locale); }}
+          >
+            <ListItemIcon>
+              {
+                language.current && <CheckIcon />
+              }
+            </ListItemIcon>
+            <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
+              {language.label}
+            </ListItemText>
+          </MenuItem>
+        ))
+      }
+    </>
+  );
 }
 
 LanguageSettings.propTypes = {

--- a/src/components/LayersPanel.js
+++ b/src/components/LayersPanel.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import CompanionWindow from '../containers/CompanionWindow';
 import CanvasLayers from '../containers/CanvasLayers';
@@ -6,36 +5,26 @@ import CanvasLayers from '../containers/CanvasLayers';
 /**
  * a panel showing the canvases for a given manifest
  */
-export class LayersPanel extends Component {
-  /**
-   * render
-   */
-  render() {
-    const {
-      canvasIds,
-      id,
-      t,
-      windowId,
-    } = this.props;
-
-    return (
-      <CompanionWindow
-        title={t('layers')}
-        id={id}
-        windowId={windowId}
-      >
-        {canvasIds.map((canvasId, index) => (
-          <CanvasLayers
-            canvasId={canvasId}
-            index={index}
-            key={canvasId}
-            totalSize={canvasIds.length}
-            windowId={windowId}
-          />
-        ))}
-      </CompanionWindow>
-    );
-  }
+export function LayersPanel({
+  canvasIds = [], id, t, windowId,
+}) {
+  return (
+    <CompanionWindow
+      title={t('layers')}
+      id={id}
+      windowId={windowId}
+    >
+      {canvasIds.map((canvasId, index) => (
+        <CanvasLayers
+          canvasId={canvasId}
+          index={index}
+          key={canvasId}
+          totalSize={canvasIds.length}
+          windowId={windowId}
+        />
+      ))}
+    </CompanionWindow>
+  );
 }
 
 LayersPanel.propTypes = {
@@ -43,8 +32,4 @@ LayersPanel.propTypes = {
   id: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-LayersPanel.defaultProps = {
-  canvasIds: [],
 };

--- a/src/components/LocalePicker.js
+++ b/src/components/LocalePicker.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
@@ -8,52 +7,35 @@ import Typography from '@mui/material/Typography';
 /**
  * Provide a locale picker
  */
-export class LocalePicker extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      availableLocales,
-      locale,
-      setLocale,
-    } = this.props;
+export function LocalePicker({ availableLocales = [], locale = '', setLocale = undefined }) {
+  if (!setLocale || availableLocales.length < 2) return null;
 
-    if (!setLocale || availableLocales.length < 2) return null;
-    return (
-      <FormControl>
-        <Select
-          MenuProps={{
-            anchorOrigin: {
-              horizontal: 'left',
-              vertical: 'bottom',
-            },
-          }}
-          displayEmpty
-          value={locale}
-          onChange={(e) => { setLocale(e.target.value); }}
-          name="locale"
-        >
-          {
-            availableLocales.map(l => (
-              <MenuItem key={l} value={l}><Typography variant="body2">{ l }</Typography></MenuItem>
-            ))
-          }
-        </Select>
-      </FormControl>
-    );
-  }
+  return (
+    <FormControl>
+      <Select
+        MenuProps={{
+          anchorOrigin: {
+            horizontal: 'left',
+            vertical: 'bottom',
+          },
+        }}
+        displayEmpty
+        value={locale}
+        onChange={(e) => { setLocale(e.target.value); }}
+        name="locale"
+      >
+        {
+          availableLocales.map(l => (
+            <MenuItem key={l} value={l}><Typography variant="body2">{ l }</Typography></MenuItem>
+          ))
+        }
+      </Select>
+    </FormControl>
+  );
 }
 
 LocalePicker.propTypes = {
   availableLocales: PropTypes.arrayOf(PropTypes.string),
   locale: PropTypes.string,
   setLocale: PropTypes.func,
-};
-
-LocalePicker.defaultProps = {
-  availableLocales: [],
-  locale: '',
-  setLocale: undefined,
 };

--- a/src/components/ManifestForm.js
+++ b/src/components/ManifestForm.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
@@ -8,115 +8,76 @@ import TextField from '@mui/material/TextField';
  * Provides a form for user input of a manifest url
  * @prop {Function} fetchManifest
  */
-export class ManifestForm extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      formValue: '',
-    };
+export function ManifestForm({
+  addResourcesOpen, addResource, onSubmit = () => {}, onCancel = null, t = k => k,
+}) {
+  const [formValue, setFormValue] = useState('');
 
-    this.formSubmit = this.formSubmit.bind(this);
-    this.handleCancel = this.handleCancel.bind(this);
-    this.handleInputChange = this.handleInputChange.bind(this);
-  }
-
-  /**
-   * Reset the form state
-   */
-  handleCancel() {
-    const { onCancel } = this.props;
-
+  /** */
+  const handleCancel = () => {
     onCancel();
-    this.setState({ formValue: '' });
-  }
+    setFormValue('');
+  };
 
-  /**
-   * handleInputChange - sets state based on input change.
-   * @param  {Event} event
-   * @private
-   */
-  handleInputChange(event) {
-    const that = this;
+  /** */
+  const handleInputChange = (event) => {
     event.preventDefault();
-    that.setState({
-      formValue: event.target.value,
-    });
-  }
+    setFormValue(event.target.value);
+  };
 
-  /**
-   * formSubmit - triggers manifest update and sets lastRequested
-   * @param  {Event} event
-   * @private
-   */
-  formSubmit(event) {
-    const { addResource, onSubmit } = this.props;
-    const { formValue } = this.state;
+  /** */
+  const formSubmit = (event) => {
     event.preventDefault();
-    onSubmit();
     addResource(formValue);
-    this.setState({ formValue: '' });
-  }
+    onSubmit();
+    setFormValue('');
+  };
 
-  /**
-   * render
-   * @return {String} - HTML markup for the component
-   */
-  render() {
-    const { formValue } = this.state;
-    const {
-      addResourcesOpen,
-      onCancel,
-      t,
-    } = this.props;
-    if (!addResourcesOpen) return null;
+  if (!addResourcesOpen) return null;
 
-    return (
-      <form onSubmit={this.formSubmit}>
-        <Grid container spacing={2}>
-          <Grid item xs={12} sm={8} md={9}>
-            <TextField
-              autoFocus
-              fullWidth
-              value={formValue}
-              id="manifestURL"
-              type="text"
-              onChange={this.handleInputChange}
-              variant="filled"
-              label={t('addManifestUrl')}
-              helperText={t('addManifestUrlHelp')}
-              InputLabelProps={{
-                shrink: true,
-              }}
-              InputProps={{
-                style: { typography: 'body1' },
-              }}
-            />
-          </Grid>
-          <Grid
-            item
-            xs={12}
-            sm={4}
-            md={3}
-            sx={{
-              textAlign: { sm: 'inherit', xs: 'right' },
+  return (
+    <form onSubmit={formSubmit}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={8} md={9}>
+          <TextField
+            autoFocus
+            fullWidth
+            value={formValue}
+            id="manifestURL"
+            type="text"
+            onChange={handleInputChange}
+            variant="filled"
+            label={t('addManifestUrl')}
+            helperText={t('addManifestUrlHelp')}
+            InputLabelProps={{
+              shrink: true,
             }}
-          >
-            { onCancel && (
-              <Button onClick={this.handleCancel}>
-                {t('cancel')}
-              </Button>
-            )}
-            <Button id="fetchBtn" type="submit" variant="contained" color="primary">
-              {t('fetchManifest')}
-            </Button>
-          </Grid>
+            InputProps={{
+              style: { typography: 'body1' },
+            }}
+          />
         </Grid>
-      </form>
-    );
-  }
+        <Grid
+          item
+          xs={12}
+          sm={4}
+          md={3}
+          sx={{
+            textAlign: { sm: 'inherit', xs: 'right' },
+          }}
+        >
+          { onCancel && (
+            <Button onClick={handleCancel}>
+              {t('cancel')}
+            </Button>
+          )}
+          <Button id="fetchBtn" type="submit" variant="contained" color="primary">
+            {t('fetchManifest')}
+          </Button>
+        </Grid>
+      </Grid>
+    </form>
+  );
 }
 
 ManifestForm.propTypes = {
@@ -125,10 +86,4 @@ ManifestForm.propTypes = {
   onCancel: PropTypes.func,
   onSubmit: PropTypes.func,
   t: PropTypes.func,
-};
-
-ManifestForm.defaultProps = {
-  onCancel: null,
-  onSubmit: () => {},
-  t: key => key,
 };

--- a/src/components/ManifestInfo.js
+++ b/src/components/ManifestInfo.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import CollapsibleSection from '../containers/CollapsibleSection';
@@ -9,57 +8,48 @@ import { PluginHook } from './PluginHook';
 /**
  * ManifestInfo
  */
-export class ManifestInfo extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      manifestDescription,
-      manifestSummary,
-      manifestLabel,
-      manifestMetadata,
-      id,
-      t,
-    } = this.props;
+export function ManifestInfo({
+  manifestDescription = null, manifestLabel = null, manifestMetadata = [], manifestSummary = null, id, t = k => k,
+}) {
+  const pluginProps = {
+    id, manifestDescription, manifestLabel, manifestMetadata, manifestSummary,
+  };
 
-    return (
-      <CollapsibleSection
-        id={`${id}-resource`}
-        label={t('resource')}
-      >
-        {manifestLabel && (
-          <Typography
-            aria-labelledby={`${id}-resource ${id}-resource-heading`}
-            id={`${id}-resource-heading`}
-            variant="h4"
-            component="h5"
-          >
-            {manifestLabel}
-          </Typography>
-        )}
+  return (
+    <CollapsibleSection
+      id={`${id}-resource`}
+      label={t('resource')}
+    >
+      {manifestLabel && (
+        <Typography
+          aria-labelledby={`${id}-resource ${id}-resource-heading`}
+          id={`${id}-resource-heading`}
+          variant="h4"
+          component="h5"
+        >
+          {manifestLabel}
+        </Typography>
+      )}
 
-        {manifestDescription && (
-          <Typography variant="body1">
-            <SanitizedHtml htmlString={manifestDescription} ruleSet="iiif" />
-          </Typography>
-        )}
+      {manifestDescription && (
+        <Typography variant="body1">
+          <SanitizedHtml htmlString={manifestDescription} ruleSet="iiif" />
+        </Typography>
+      )}
 
-        {manifestSummary && (
-          <Typography variant="body1">
-            <SanitizedHtml htmlString={manifestSummary} ruleSet="iiif" />
-          </Typography>
-        )}
+      {manifestSummary && (
+        <Typography variant="body1">
+          <SanitizedHtml htmlString={manifestSummary} ruleSet="iiif" />
+        </Typography>
+      )}
 
-        {manifestMetadata.length > 0 && (
-          <LabelValueMetadata labelValuePairs={manifestMetadata} />
-        )}
+      {manifestMetadata.length > 0 && (
+        <LabelValueMetadata labelValuePairs={manifestMetadata} />
+      )}
 
-        <PluginHook {...this.props} />
-      </CollapsibleSection>
-    );
-  }
+      <PluginHook {...pluginProps} />
+    </CollapsibleSection>
+  );
 }
 
 ManifestInfo.propTypes = {
@@ -69,12 +59,4 @@ ManifestInfo.propTypes = {
   manifestMetadata: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   manifestSummary: PropTypes.string,
   t: PropTypes.func,
-};
-
-ManifestInfo.defaultProps = {
-  manifestDescription: null,
-  manifestLabel: null,
-  manifestMetadata: [],
-  manifestSummary: null,
-  t: key => key,
 };

--- a/src/components/ManifestListItem.js
+++ b/src/components/ManifestListItem.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import ListItem from '@mui/material/ListItem';
@@ -37,184 +37,165 @@ const StyledLogo = styled(Img, { name: 'ManifestListItem', slot: 'logo' })(({ th
   paddingRight: 1,
 }));
 
+/** */
+const Placeholder = () => (
+  <Grid container className={ns('manifest-list-item')} spacing={2}>
+    <Grid item xs={3} sm={2}>
+      <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />
+    </Grid>
+    <Grid item xs={9} sm={6}>
+      <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
+    </Grid>
+    <Grid item xs={8} sm={2}>
+      <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
+      <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
+    </Grid>
+    <Grid item xs={4} sm={2}>
+      <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={60} width={60} />
+    </Grid>
+  </Grid>
+);
+
 /**
  * Represents an item in a list of currently-loaded or loading manifests
  * @param {object} props
  * @param {object} [props.manifest = string]
  */
-
-/** */
-export class ManifestListItem extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-    this.handleOpenButtonClick = this.handleOpenButtonClick.bind(this);
-  }
-
-  /** */
-  componentDidMount() {
-    const {
-      fetchManifest, manifestId, ready, isFetching, error, provider,
-    } = this.props;
-
+export function ManifestListItem({
+  fetchManifest,
+  isFetching = false,
+  addWindow,
+  handleClose = () => { },
+  active = false,
+  buttonRef = undefined,
+  manifestId,
+  ready = false,
+  title = null,
+  thumbnail = null,
+  manifestLogo = null,
+  size = 0,
+  provider = null,
+  t = k => k,
+  error = null,
+  isCollection = false,
+  isMultipart = false,
+}) {
+  useEffect(() => {
     if (!ready && !error && !isFetching && provider !== 'file') fetchManifest(manifestId);
-  }
+  }, [manifestId, provider, fetchManifest, ready, error, isFetching]);
 
-  /**
-   * Handling open button click
-   */
-  handleOpenButtonClick() {
-    const {
-      addWindow,
-      handleClose,
-      manifestId,
-    } = this.props;
+  const ownerState = arguments[0]; // eslint-disable-line prefer-rest-params
 
+  /** */
+  const handleOpenButtonClick = () => {
     addWindow({ manifestId });
     handleClose();
-  }
+  };
 
-  /** */
-  render() {
-    const {
-      active,
-      buttonRef,
-      manifestId,
-      ready,
-      title,
-      thumbnail,
-      manifestLogo,
-      size,
-      provider,
-      t,
-      error,
-      isCollection,
-      isMultipart,
-    } = this.props;
-
-    const placeholder = (
-      <Grid container className={ns('manifest-list-item')} spacing={2}>
-        <Grid item xs={3} sm={2}>
-          <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />
-        </Grid>
-        <Grid item xs={9} sm={6}>
-          <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
-        </Grid>
-        <Grid item xs={8} sm={2}>
-          <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
-          <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
-        </Grid>
-        <Grid item xs={4} sm={2}>
-          <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={60} width={60} />
-        </Grid>
-      </Grid>
-    );
-
-    if (error) {
-      return (
-        <Root
-          ownerState={this.props}
-          divider
-          selected={active}
-          className={active ? 'active' : ''}
-          data-manifestid={manifestId}
-        >
-          <ManifestListItemError manifestId={manifestId} />
-        </Root>
-      );
-    }
-
+  if (error) {
     return (
       <Root
+        ownerState={ownerState}
         divider
         selected={active}
         className={active ? 'active' : ''}
         data-manifestid={manifestId}
-        data-active={active}
       >
-        {ready ? (
-          <Grid container className={ns('manifest-list-item')} spacing={2}>
-            <Grid item xs={12} sm={6}>
-              <ButtonBase
-                ref={buttonRef}
-                className={ns('manifest-list-item-title')}
-                style={{ width: '100%' }}
-                onClick={this.handleOpenButtonClick}
-              >
-                <Grid
-                  container
-                  spacing={2}
-                  sx={{
-                    textAlign: 'left',
-                    textTransform: 'initial',
-                  }}
-                  component="span"
-                >
-                  <Grid item xs={4} sm={3} component="span">
-                    { thumbnail
-                      ? (
-                        <StyledThumbnail
-                          className={[ns('manifest-list-item-thumb')]}
-                          src={[thumbnail]}
-                          alt=""
-                          height="80"
-                          unloader={(
-                            <Skeleton
-                              variant="rectangular"
-                              animation={false}
-                              sx={{ bgcolor: 'grey[300]' }}
-                              height={80}
-                              width={120}
-                            />
-                          )}
-                        />
-                      )
-                      : <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />}
-                  </Grid>
-                  <Grid item xs={8} sm={9} component="span">
-                    { isCollection && (
-                      <Typography component="div" variant="overline">
-                        { t(isMultipart ? 'multipartCollection' : 'collection') }
-                      </Typography>
-                    )}
-                    <Typography component="span" variant="h6">
-                      {title || manifestId}
-                    </Typography>
-                  </Grid>
-                </Grid>
-              </ButtonBase>
-            </Grid>
-            <Grid item xs={8} sm={4}>
-              <Typography className={ns('manifest-list-item-provider')}>{provider}</Typography>
-              <Typography>{t('numItems', { count: size, number: size })}</Typography>
-            </Grid>
-
-            <Grid item xs={4} sm={2}>
-              { manifestLogo
-                && (
-                <StyledLogo
-                  src={[manifestLogo]}
-                  alt=""
-                  role="presentation"
-                  unloader={(
-                    <Skeleton
-                      variant="rectangular"
-                      animation={false}
-                      sx={{ bgcolor: 'grey[300]' }}
-                      height={60}
-                      width={60}
-                    />
-                  )}
-                />
-                )}
-            </Grid>
-          </Grid>
-        ) : (
-          placeholder
-        )}
+        <ManifestListItemError manifestId={manifestId} />
       </Root>
     );
   }
+
+  return (
+    <Root
+      divider
+      selected={active}
+      className={active ? 'active' : ''}
+      data-manifestid={manifestId}
+      data-active={active}
+    >
+      {ready ? (
+        <Grid container className={ns('manifest-list-item')} spacing={2}>
+          <Grid item xs={12} sm={6}>
+            <ButtonBase
+              ref={buttonRef}
+              className={ns('manifest-list-item-title')}
+              style={{ width: '100%' }}
+              onClick={handleOpenButtonClick}
+            >
+              <Grid
+                container
+                spacing={2}
+                sx={{
+                  textAlign: 'left',
+                  textTransform: 'initial',
+                }}
+                component="span"
+              >
+                <Grid item xs={4} sm={3} component="span">
+                  { thumbnail
+                    ? (
+                      <StyledThumbnail
+                        className={[ns('manifest-list-item-thumb')]}
+                        src={[thumbnail]}
+                        alt=""
+                        height="80"
+                        unloader={(
+                          <Skeleton
+                            variant="rectangular"
+                            animation={false}
+                            sx={{ bgcolor: 'grey[300]' }}
+                            height={80}
+                            width={120}
+                          />
+                        )}
+                      />
+                    )
+                    : <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />}
+                </Grid>
+                <Grid item xs={8} sm={9} component="span">
+                  { isCollection && (
+                    <Typography component="div" variant="overline">
+                      { t(isMultipart ? 'multipartCollection' : 'collection') }
+                    </Typography>
+                  )}
+                  <Typography component="span" variant="h6">
+                    {title || manifestId}
+                  </Typography>
+                </Grid>
+              </Grid>
+            </ButtonBase>
+          </Grid>
+          <Grid item xs={8} sm={4}>
+            <Typography className={ns('manifest-list-item-provider')}>{provider}</Typography>
+            <Typography>{t('numItems', { count: size, number: size })}</Typography>
+          </Grid>
+
+          <Grid item xs={4} sm={2}>
+            { manifestLogo
+              && (
+              <StyledLogo
+                src={[manifestLogo]}
+                alt=""
+                role="presentation"
+                unloader={(
+                  <Skeleton
+                    variant="rectangular"
+                    animation={false}
+                    sx={{ bgcolor: 'grey[300]' }}
+                    height={60}
+                    width={60}
+                  />
+                )}
+              />
+              )}
+          </Grid>
+        </Grid>
+      ) : (
+        <Placeholder />
+      )}
+    </Root>
+  );
 }
 
 ManifestListItem.propTypes = {
@@ -235,21 +216,4 @@ ManifestListItem.propTypes = {
   t: PropTypes.func,
   thumbnail: PropTypes.string,
   title: PropTypes.string,
-};
-
-ManifestListItem.defaultProps = {
-  active: false,
-  buttonRef: undefined,
-  error: null,
-  handleClose: () => {},
-  isCollection: false,
-  isFetching: false,
-  isMultipart: false,
-  manifestLogo: null,
-  provider: null,
-  ready: false,
-  size: 0,
-  t: key => key,
-  thumbnail: null,
-  title: null,
 };

--- a/src/components/ManifestListItemError.js
+++ b/src/components/ManifestListItemError.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import ErrorIcon from '@mui/icons-material/ErrorOutlineSharp';
@@ -9,51 +8,44 @@ import Typography from '@mui/material/Typography';
  * ManifestListItemError renders a component displaying a
  * message to the user about a problem loading a manifest
 */
-export class ManifestListItemError extends Component {
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      manifestId, onDismissClick, onTryAgainClick, t,
-    } = this.props;
-
-    return (
+export function ManifestListItemError({
+  manifestId, onDismissClick, onTryAgainClick, t,
+}) {
+  return (
+    <Grid container>
       <Grid container>
-        <Grid container>
-          <Grid container item xs={12} sm={6}>
-            <Grid item xs={4} sm={3}>
-              <Grid container justifyContent="center">
-                <ErrorIcon sx={{
-                  color: 'error.main',
-                  height: '2rem',
-                  width: '2rem',
-                }}
-                />
-              </Grid>
-            </Grid>
-            <Grid item xs={8} sm={9}>
-              <Typography>{t('manifestError')}</Typography>
-              <Typography sx={{ wordBreak: 'break-all' }}>{manifestId}</Typography>
+        <Grid container item xs={12} sm={6}>
+          <Grid item xs={4} sm={3}>
+            <Grid container justifyContent="center">
+              <ErrorIcon sx={{
+                color: 'error.main',
+                height: '2rem',
+                width: '2rem',
+              }}
+              />
             </Grid>
           </Grid>
-        </Grid>
-
-        <Grid container>
-          <Grid container item xs={12} sm={6} justifyContent="flex-end">
-            <Grid item>
-              <Button onClick={() => { onDismissClick(manifestId); }}>
-                {t('dismiss')}
-              </Button>
-              <Button onClick={() => { onTryAgainClick(manifestId); }}>
-                {t('tryAgain')}
-              </Button>
-            </Grid>
+          <Grid item xs={8} sm={9}>
+            <Typography>{t('manifestError')}</Typography>
+            <Typography sx={{ wordBreak: 'break-all' }}>{manifestId}</Typography>
           </Grid>
         </Grid>
       </Grid>
-    );
-  }
+
+      <Grid container>
+        <Grid container item xs={12} sm={6} justifyContent="flex-end">
+          <Grid item>
+            <Button onClick={() => { onDismissClick(manifestId); }}>
+              {t('dismiss')}
+            </Button>
+            <Button onClick={() => { onTryAgainClick(manifestId); }}>
+              {t('tryAgain')}
+            </Button>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
 }
 
 ManifestListItemError.propTypes = {

--- a/src/components/ManifestRelatedLinks.js
+++ b/src/components/ManifestRelatedLinks.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
@@ -14,116 +13,113 @@ const StyledDl = styled('dl')(({ theme }) => ({
     marginLeft: '0',
   },
 }));
+
 /**
  * ManifestRelatedLinks
  */
-export class ManifestRelatedLinks extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      homepage,
-      manifestUrl,
-      related,
-      renderings,
-      seeAlso,
-      id,
-      t,
-    } = this.props;
+export function ManifestRelatedLinks({
+  homepage = null,
+  id,
+  manifestUrl = null,
+  related = null,
+  renderings = null,
+  seeAlso = null,
+  t = k => k,
+}) {
+  const pluginProps = {
+    homepage, id, manifestUrl, related, renderings, seeAlso, t,
+  };
 
-    return (
-      <CollapsibleSection
-        id={`${id}-related`}
-        label={t('related')}
+  return (
+    <CollapsibleSection
+      id={`${id}-related`}
+      label={t('related')}
+    >
+      <Typography
+        aria-labelledby={`${id}-related ${id}-related-heading`}
+        id={`${id}-related-heading`}
+        variant="h4"
+        component="h5"
       >
-        <Typography
-          aria-labelledby={`${id}-related ${id}-related-heading`}
-          id={`${id}-related-heading`}
-          variant="h4"
-          component="h5"
-        >
-          {t('links')}
-        </Typography>
-        <StyledDl className={classNames(ns('label-value-metadata'))}>
-          { homepage && (
-            <>
-              <Typography variant="subtitle2" component="dt">{t('iiif_homepage')}</Typography>
-              {
-                homepage.map(page => (
-                  <Typography key={page.value} variant="body1" component="dd">
-                    <Link target="_blank" rel="noopener noreferrer" href={page.value}>
-                      {page.label || page.value}
-                    </Link>
-                  </Typography>
-                ))
-              }
-            </>
-          )}
-          { renderings && renderings.length > 0 && (
-            <>
-              <Typography variant="subtitle2" component="dt">{t('iiif_renderings')}</Typography>
-              {
-                renderings.map(rendering => (
-                  <Typography key={rendering.value} variant="body1" component="dd">
-                    <Link target="_blank" rel="noopener noreferrer" href={rendering.value}>
-                      {rendering.label || rendering.value}
-                    </Link>
-                  </Typography>
-                ))
-              }
-            </>
-          )}
-          { related && (
-            <>
-              <Typography variant="subtitle2" component="dt">{t('iiif_related')}</Typography>
-              {
-                related.map(relatedItem => (
-                  <Typography key={relatedItem.value} variant="body1" component="dd">
-                    <Link target="_blank" rel="noopener noreferrer" href={relatedItem.value}>
-                      {relatedItem.label || relatedItem.value}
-                    </Link>
-                    { relatedItem.format && (
-                      <Typography component="span">{` (${relatedItem.format})`}</Typography>
-                    )}
-                  </Typography>
-                ))
-              }
-            </>
-          )}
-          { seeAlso && (
-            <>
-              <Typography variant="subtitle2" component="dt">{t('iiif_seeAlso')}</Typography>
-              {
-                seeAlso.map(seeAlsoItem => (
-                  <Typography key={seeAlsoItem.value} variant="body1" component="dd">
-                    <Link target="_blank" rel="noopener noreferrer" href={seeAlsoItem.value}>
-                      {seeAlsoItem.label || seeAlsoItem.value}
-                    </Link>
-                    { seeAlsoItem.format && (
-                      <Typography component="span">{` (${seeAlsoItem.format})`}</Typography>
-                    )}
-                  </Typography>
-                ))
-              }
-            </>
-          )}
-          { manifestUrl && (
-            <>
-              <Typography variant="subtitle2" component="dt">{t('iiif_manifest')}</Typography>
-              <Typography variant="body1" component="dd">
-                <Link target="_blank" rel="noopener noreferrer" href={manifestUrl}>
-                  {manifestUrl}
-                </Link>
-              </Typography>
-            </>
-          )}
-        </StyledDl>
-        <PluginHook {...this.props} />
-      </CollapsibleSection>
-    );
-  }
+        {t('links')}
+      </Typography>
+      <StyledDl className={classNames(ns('label-value-metadata'))}>
+        { homepage && (
+          <>
+            <Typography variant="subtitle2" component="dt">{t('iiif_homepage')}</Typography>
+            {
+              homepage.map(page => (
+                <Typography key={page.value} variant="body1" component="dd">
+                  <Link target="_blank" rel="noopener noreferrer" href={page.value}>
+                    {page.label || page.value}
+                  </Link>
+                </Typography>
+              ))
+            }
+          </>
+        )}
+        { renderings && renderings.length > 0 && (
+          <>
+            <Typography variant="subtitle2" component="dt">{t('iiif_renderings')}</Typography>
+            {
+              renderings.map(rendering => (
+                <Typography key={rendering.value} variant="body1" component="dd">
+                  <Link target="_blank" rel="noopener noreferrer" href={rendering.value}>
+                    {rendering.label || rendering.value}
+                  </Link>
+                </Typography>
+              ))
+            }
+          </>
+        )}
+        { related && (
+          <>
+            <Typography variant="subtitle2" component="dt">{t('iiif_related')}</Typography>
+            {
+              related.map(relatedItem => (
+                <Typography key={relatedItem.value} variant="body1" component="dd">
+                  <Link target="_blank" rel="noopener noreferrer" href={relatedItem.value}>
+                    {relatedItem.label || relatedItem.value}
+                  </Link>
+                  { relatedItem.format && (
+                    <Typography component="span">{` (${relatedItem.format})`}</Typography>
+                  )}
+                </Typography>
+              ))
+            }
+          </>
+        )}
+        { seeAlso && (
+          <>
+            <Typography variant="subtitle2" component="dt">{t('iiif_seeAlso')}</Typography>
+            {
+              seeAlso.map(seeAlsoItem => (
+                <Typography key={seeAlsoItem.value} variant="body1" component="dd">
+                  <Link target="_blank" rel="noopener noreferrer" href={seeAlsoItem.value}>
+                    {seeAlsoItem.label || seeAlsoItem.value}
+                  </Link>
+                  { seeAlsoItem.format && (
+                    <Typography component="span">{` (${seeAlsoItem.format})`}</Typography>
+                  )}
+                </Typography>
+              ))
+            }
+          </>
+        )}
+        { manifestUrl && (
+          <>
+            <Typography variant="subtitle2" component="dt">{t('iiif_manifest')}</Typography>
+            <Typography variant="body1" component="dd">
+              <Link target="_blank" rel="noopener noreferrer" href={manifestUrl}>
+                {manifestUrl}
+              </Link>
+            </Typography>
+          </>
+        )}
+      </StyledDl>
+      <PluginHook {...pluginProps} />
+    </CollapsibleSection>
+  );
 }
 
 ManifestRelatedLinks.propTypes = {
@@ -148,13 +144,4 @@ ManifestRelatedLinks.propTypes = {
     value: PropTypes.string,
   })),
   t: PropTypes.func,
-};
-
-ManifestRelatedLinks.defaultProps = {
-  homepage: null,
-  manifestUrl: null,
-  related: null,
-  renderings: null,
-  seeAlso: null,
-  t: key => key,
 };

--- a/src/components/MinimalWindow.js
+++ b/src/components/MinimalWindow.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/MenuSharp';
@@ -14,92 +13,88 @@ import ns from '../config/css-ns';
 const StyledMiradorMenuButton = styled(MiradorMenuButton)(() => ({
   marginLeft: 'auto',
 }));
-/** */
-export class MinimalWindow extends Component {
-  /** */
-  render() {
-    const {
-      allowClose,
-      allowWindowSideBar,
-      ariaLabel,
-      children,
-      label,
-      removeWindow,
-      t,
-      windowId,
-    } = this.props;
 
-    return (
-      <Paper
-        component="section"
-        elevation={1}
-        id={windowId}
-        className={
-          cn(ns('placeholder-window'))
-        }
-        sx={{
-          backgroundColor: 'shades.dark',
-          borderRadius: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          minHeight: 0,
-          overflow: 'hidden',
-          width: '100%',
-        }}
-        aria-label={label && ariaLabel ? t('window', { label }) : null}
-      >
-        <AppBar position="relative" color="default" enableColorOnDark>
-          <Toolbar
-            disableGutters
-            className={cn(ns('window-top-bar'))}
+/** */
+export function MinimalWindow({
+  allowClose = true,
+  allowWindowSideBar = true,
+  ariaLabel = true,
+  children = null,
+  label = '',
+  removeWindow = () => {},
+  t = k => k,
+  windowId,
+}) {
+  return (
+    <Paper
+      component="section"
+      elevation={1}
+      id={windowId}
+      className={
+        cn(ns('placeholder-window'))
+      }
+      sx={{
+        backgroundColor: 'shades.dark',
+        borderRadius: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minHeight: 0,
+        overflow: 'hidden',
+        width: '100%',
+      }}
+      aria-label={label && ariaLabel ? t('window', { label }) : null}
+    >
+      <AppBar position="relative" color="default" enableColorOnDark>
+        <Toolbar
+          disableGutters
+          className={cn(ns('window-top-bar'))}
+          sx={{
+            backgroundColor: 'shades.main',
+            borderTop: '2px solid transparent',
+            minHeight: 32,
+            paddingLeft: 0.5,
+            paddingRight: 0.5,
+          }}
+          variant="dense"
+        >
+          {allowWindowSideBar && (
+            <MiradorMenuButton
+              aria-label={t('toggleWindowSideBar')}
+              disabled
+            >
+              <MenuIcon />
+            </MiradorMenuButton>
+          )}
+          <Typography
+            variant="h2"
+            noWrap
+            color="inherit"
             sx={{
-              backgroundColor: 'shades.main',
-              borderTop: '2px solid transparent',
-              minHeight: 32,
+              flexGrow: 1,
               paddingLeft: 0.5,
-              paddingRight: 0.5,
+              typography: 'h6',
             }}
-            variant="dense"
           >
-            {allowWindowSideBar && (
-              <MiradorMenuButton
-                aria-label={t('toggleWindowSideBar')}
-                disabled
-              >
-                <MenuIcon />
-              </MiradorMenuButton>
-            )}
-            <Typography
-              variant="h2"
-              noWrap
-              color="inherit"
-              sx={{
-                flexGrow: 1,
-                paddingLeft: 0.5,
-                typography: 'h6',
+            {label}
+          </Typography>
+          {allowClose && removeWindow && (
+            <StyledMiradorMenuButton
+              aria-label={t('closeWindow')}
+              className={cn(ns('window-close'))}
+              onClick={removeWindow}
+              TooltipProps={{
+                tabIndex: ariaLabel ? 0 : -1,
               }}
             >
-              {label}
-            </Typography>
-            {allowClose && removeWindow && (
-              <StyledMiradorMenuButton
-                aria-label={t('closeWindow')}
-                className={cn(ns('window-close'))}
-                onClick={removeWindow}
-                TooltipProps={{
-                  tabIndex: ariaLabel ? 0 : -1,
-                }}
-              >
-                <CloseIcon />
-              </StyledMiradorMenuButton>
-            )}
-          </Toolbar>
-        </AppBar>
-        {children}
-      </Paper>
-    );
-  }
+              <CloseIcon />
+            </StyledMiradorMenuButton>
+          )}
+        </Toolbar>
+      </AppBar>
+      {children}
+    </Paper>
+  );
 }
 
 MinimalWindow.propTypes = {
@@ -111,14 +106,4 @@ MinimalWindow.propTypes = {
   removeWindow: PropTypes.func,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
-};
-
-MinimalWindow.defaultProps = {
-  allowClose: true,
-  allowWindowSideBar: true,
-  ariaLabel: true,
-  children: null,
-  label: '',
-  removeWindow: () => {},
-  t: key => key,
 };

--- a/src/components/NestedMenu.js
+++ b/src/components/NestedMenu.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -10,64 +10,35 @@ import ExpandMore from '@mui/icons-material/ExpandMoreSharp';
  * NestedMenu ~ A presentation component to render a menu item and have
  * it control the visibility of the MUI List passed in as the children
 */
-export class NestedMenu extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
+export function NestedMenu({
+  children, icon = null, label, ...otherProps
+}) {
+  const [nestedMenuIsOpen, setNestedMenuIsOpen] = useState(false);
 
-    this.state = {
-      nestedMenuIsOpen: false,
-    };
+  const handleMenuClick = useCallback(() => {
+    setNestedMenuIsOpen(!nestedMenuIsOpen);
+  }, [nestedMenuIsOpen, setNestedMenuIsOpen]);
 
-    this.handleMenuClick = this.handleMenuClick.bind(this);
-  }
-
-  /**
-   * handleMenuClick toggles the nestedMenuIsOpen state
-   */
-  handleMenuClick() {
-    const { nestedMenuIsOpen } = this.state;
-
-    this.setState({
-      nestedMenuIsOpen: !nestedMenuIsOpen,
-    });
-  }
-
-  /**
-   * Returns the rendered component.  Spreads unused props to MenuItem
-  */
-  render() {
-    const { nestedMenuIsOpen } = this.state;
-    const {
-      children, icon, label, ...otherProps
-    } = this.props;
-    return (
-      <>
-        <MenuItem onClick={this.handleMenuClick} divider={nestedMenuIsOpen} {...otherProps}>
-          {icon && (<ListItemIcon>{icon}</ListItemIcon>)}
-          <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
-            {label}
-          </ListItemText>
-          {
-            nestedMenuIsOpen
-              ? <ExpandLess />
-              : <ExpandMore />
-          }
-        </MenuItem>
-        {nestedMenuIsOpen && children}
-      </>
-    );
-  }
+  return (
+    <>
+      <MenuItem onClick={handleMenuClick} divider={nestedMenuIsOpen} {...otherProps}>
+        {icon && (<ListItemIcon>{icon}</ListItemIcon>)}
+        <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
+          {label}
+        </ListItemText>
+        {
+          nestedMenuIsOpen
+            ? <ExpandLess />
+            : <ExpandMore />
+        }
+      </MenuItem>
+      {nestedMenuIsOpen && children}
+    </>
+  );
 }
 
 NestedMenu.propTypes = {
   children: PropTypes.element.isRequired,
   icon: PropTypes.element,
   label: PropTypes.string.isRequired,
-};
-
-NestedMenu.defaultProps = {
-  icon: null,
 };

--- a/src/components/PrimaryWindow.js
+++ b/src/components/PrimaryWindow.js
@@ -1,4 +1,4 @@
-import { Component, lazy, Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import classNames from 'classnames';
@@ -23,78 +23,85 @@ const Root = styled('div', { name: 'PrimaryWindow', slot: 'root' })(() => ({
   position: 'relative',
 }));
 
+/**  */
+const TypeSpecificViewer = ({
+  audioResources = [], isCollection = false,
+  isFetching = false, videoResources = [], view = undefined, windowId,
+}) => {
+  if (isCollection) {
+    return (
+      <SelectCollection
+        windowId={windowId}
+      />
+    );
+  }
+  if (isFetching === false) {
+    if (view === 'gallery') {
+      return (
+        <GalleryView
+          windowId={windowId}
+        />
+      );
+    }
+    if (videoResources.length > 0) {
+      return (
+        <VideoViewer
+          windowId={windowId}
+        />
+      );
+    }
+    if (audioResources.length > 0) {
+      return (
+        <AudioViewer
+          windowId={windowId}
+        />
+      );
+    }
+    return (
+      <WindowViewer
+        windowId={windowId}
+      />
+    );
+  }
+  return null;
+};
+
+TypeSpecificViewer.propTypes = {
+  audioResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
+  isCollection: PropTypes.bool,
+  isFetching: PropTypes.bool,
+  videoResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
+  view: PropTypes.string,
+  windowId: PropTypes.string.isRequired,
+};
+
 /**
  * PrimaryWindow - component that renders the primary content of a Mirador
  * window. Right now this differentiates between a Image, Video, or Audio viewer.
  */
-export class PrimaryWindow extends Component {
-  /**
-   * renderViewer - logic used to determine what type of view to show
-   *
-   * @return {(String|null)}
-   */
-  renderViewer() {
-    const {
-      audioResources, isCollection,
-      isFetching, videoResources, view, windowId,
-    } = this.props;
-    if (isCollection) {
-      return (
-        <SelectCollection
-          windowId={windowId}
-        />
-      );
-    }
-    if (isFetching === false) {
-      if (view === 'gallery') {
-        return (
-          <GalleryView
-            windowId={windowId}
-          />
-        );
-      }
-      if (videoResources.length > 0) {
-        return (
-          <VideoViewer
-            windowId={windowId}
-          />
-        );
-      }
-      if (audioResources.length > 0) {
-        return (
-          <AudioViewer
-            windowId={windowId}
-          />
-        );
-      }
-      return (
-        <WindowViewer
-          windowId={windowId}
-        />
-      );
-    }
-    return null;
-  }
+export function PrimaryWindow({
+  audioResources = undefined, isCollection = false, isFetching = false, videoResources = undefined,
+  view = undefined, windowId, isCollectionDialogVisible = false, children = null, className = undefined,
+}) {
+  const viewerProps = {
+    audioResources,
+    isCollection,
+    isFetching,
+    videoResources,
+    view,
+    windowId,
+  };
 
-  /**
-   * Render the component
-   */
-  render() {
-    const {
-      isCollectionDialogVisible, windowId, children, className,
-    } = this.props;
-
-    return (
-      <Root data-testid="test-window" className={classNames(ns('primary-window'), className)}>
-        <WindowSideBar windowId={windowId} />
-        <CompanionArea windowId={windowId} position="left" />
-        { isCollectionDialogVisible && <CollectionDialog windowId={windowId} /> }
-        <Suspense fallback={<div />}>
-          {children || this.renderViewer()}
-        </Suspense>
-      </Root>
-    );
-  }
+  return (
+    <Root data-testid="test-window" className={classNames(ns('primary-window'), className)}>
+      <WindowSideBar windowId={windowId} />
+      <CompanionArea windowId={windowId} position="left" />
+      { isCollectionDialogVisible && <CollectionDialog windowId={windowId} /> }
+      <Suspense fallback={<div />}>
+        {children || <TypeSpecificViewer {...viewerProps} />}
+      </Suspense>
+    </Root>
+  );
 }
 
 PrimaryWindow.propTypes = {
@@ -107,15 +114,4 @@ PrimaryWindow.propTypes = {
   videoResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   view: PropTypes.string,
   windowId: PropTypes.string.isRequired,
-};
-
-PrimaryWindow.defaultProps = {
-  audioResources: [],
-  children: undefined,
-  className: undefined,
-  isCollection: false,
-  isCollectionDialogVisible: false,
-  isFetching: false,
-  videoResources: [],
-  view: undefined,
 };

--- a/src/components/SanitizedHtml.js
+++ b/src/components/SanitizedHtml.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import DOMPurify from 'dompurify';
@@ -7,44 +6,34 @@ import htmlRules from '../lib/htmlRules';
 
 const Root = styled('span', { name: 'IIIFHtmlContent', slot: 'root' })({});
 
+// Add a hook to make all links open a new window
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  // set all elements owning target to target=_blank
+  if ('target' in node) {
+    node.setAttribute('target', '_blank');
+    // prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
 */
-export class SanitizedHtml extends Component {
-  /**
-  */
-  render() {
-    const {
-      classes, htmlString, ruleSet, ...props
-    } = this.props;
-
-    // Add a hook to make all links open a new window
-    DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-      // set all elements owning target to target=_blank
-      if ('target' in node) {
-        node.setAttribute('target', '_blank');
-        // prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
-        node.setAttribute('rel', 'noopener noreferrer');
-      }
-    });
-
-    return (
-      <Root
-        className={[ns('third-party-html'), classes.root].join(' ')}
-        dangerouslySetInnerHTML={{ // eslint-disable-line react/no-danger
-          __html: DOMPurify.sanitize(htmlString, htmlRules[ruleSet]),
-        }}
-        {...props}
-      />
-    );
-  }
+export function SanitizedHtml({
+  classes = {}, htmlString, ruleSet, ...rest
+}) {
+  return (
+    <Root
+      className={[ns('third-party-html'), classes.root].join(' ')}
+      dangerouslySetInnerHTML={{ // eslint-disable-line react/no-danger
+        __html: DOMPurify.sanitize(htmlString, htmlRules[ruleSet]),
+      }}
+      {...rest}
+    />
+  );
 }
 
 SanitizedHtml.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
   htmlString: PropTypes.string.isRequired,
   ruleSet: PropTypes.string.isRequired,
-};
-
-SanitizedHtml.defaultProps = {
-  classes: {},
 };

--- a/src/components/SearchPanel.js
+++ b/src/components/SearchPanel.js
@@ -1,4 +1,4 @@
-import { createRef, Component } from 'react';
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -8,76 +8,59 @@ import SearchPanelControls from '../containers/SearchPanelControls';
 import SearchResults from '../containers/SearchResults';
 
 /** */
-export class SearchPanel extends Component {
-  /** */
-  constructor(props) {
-    super(props);
+export function SearchPanel({
+  fetchSearch = undefined, id, query = '', removeSearch, searchService, suggestedSearches = [], t = k => k, windowId,
+}) {
+  const containerRef = useRef(null);
 
-    this.containerRef = createRef();
-  }
-
-  /** */
-  render() {
-    const {
-      fetchSearch,
-      windowId,
-      id,
-      query,
-      removeSearch,
-      searchService,
-      suggestedSearches,
-      t,
-    } = this.props;
-
-    return (
-      <CompanionWindow
-        ariaLabel={t('searchTitle')}
-        title={(
-          <>
-            {t('searchTitle')}
-            {
-              query && query !== '' && (
-                <Chip
-                  role="button"
-                  sx={{ marginLeft: 1 }}
-                  color="secondary"
-                  label={t('clearSearch')}
-                  onClick={removeSearch}
-                  onDelete={removeSearch}
-                  size="small"
-                  tabIndex={0}
-                  variant="outlined"
-                />
-              )
-            }
-          </>
-        )}
-        windowId={windowId}
-        id={id}
-        titleControls={<SearchPanelControls companionWindowId={id} windowId={windowId} />}
-        ref={this.containerRef}
-      >
-        <SearchResults
-          containerRef={this.containerRef}
-          companionWindowId={id}
-          windowId={windowId}
-        />
-        {
-          fetchSearch && suggestedSearches && query === '' && suggestedSearches.map(search => (
-            <Typography component="p" key={search} variant="body1" sx={{ margin: 2 }}>
-              <Button
-                variant="inlineText"
+  return (
+    <CompanionWindow
+      ariaLabel={t('searchTitle')}
+      title={(
+        <>
+          {t('searchTitle')}
+          {
+            query && query !== '' && (
+              <Chip
+                role="button"
+                sx={{ marginLeft: 1 }}
                 color="secondary"
-                onClick={() => fetchSearch(`${searchService.id}?q=${search}`, search)}
-              >
-                {t('suggestSearch', { query: search })}
-              </Button>
-            </Typography>
-          ))
-        }
-      </CompanionWindow>
-    );
-  }
+                label={t('clearSearch')}
+                onClick={removeSearch}
+                onDelete={removeSearch}
+                size="small"
+                tabIndex={0}
+                variant="outlined"
+              />
+            )
+          }
+        </>
+      )}
+      windowId={windowId}
+      id={id}
+      titleControls={<SearchPanelControls companionWindowId={id} windowId={windowId} />}
+      ref={containerRef}
+    >
+      <SearchResults
+        containerRef={containerRef}
+        companionWindowId={id}
+        windowId={windowId}
+      />
+      {
+        fetchSearch && suggestedSearches && query === '' && suggestedSearches.map(search => (
+          <Typography component="p" key={search} variant="body1" sx={{ margin: 2 }}>
+            <Button
+              variant="inlineText"
+              color="secondary"
+              onClick={() => fetchSearch(`${searchService.id}?q=${search}`, search)}
+            >
+              {t('suggestSearch', { query: search })}
+            </Button>
+          </Typography>
+        ))
+      }
+    </CompanionWindow>
+  );
 }
 
 SearchPanel.propTypes = {
@@ -91,11 +74,4 @@ SearchPanel.propTypes = {
   suggestedSearches: PropTypes.arrayOf(PropTypes.string),
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
-};
-
-SearchPanel.defaultProps = {
-  fetchSearch: undefined,
-  query: '',
-  suggestedSearches: [],
-  t: key => key,
 };

--- a/src/components/SearchPanelNavigation.js
+++ b/src/components/SearchPanelNavigation.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeftSharp';
 import ChevronRightIcon from '@mui/icons-material/ChevronRightSharp';
@@ -8,77 +7,67 @@ import MiradorMenuButton from '../containers/MiradorMenuButton';
 /**
  * SearchPanelNavigation ~
 */
-export class SearchPanelNavigation extends Component {
+export function SearchPanelNavigation({
+  numTotal = undefined, searchHits = [], selectedContentSearchAnnotation, t = k => k, direction, selectAnnotation,
+}) {
   /** */
-  nextSearchResult(currentHitIndex) {
-    const { searchHits, selectAnnotation } = this.props;
+  const nextSearchResult = (currentHitIndex) => {
     selectAnnotation(searchHits[currentHitIndex + 1].annotations[0]);
-  }
+  };
 
   /** */
-  previousSearchResult(currentHitIndex) {
-    const { searchHits, selectAnnotation } = this.props;
+  const previousSearchResult = (currentHitIndex) => {
     selectAnnotation(searchHits[currentHitIndex - 1].annotations[0]);
-  }
+  };
 
   /** */
-  hasNextResult(currentHitIndex) {
-    const { searchHits } = this.props;
+  const hasNextResult = (currentHitIndex) => {
     if (searchHits.length === 0) return false;
     if (currentHitIndex < searchHits.length - 1) return true;
     return false;
-  }
+  };
 
   /** */
-  hasPreviousResult(currentHitIndex) {
-    const { searchHits } = this.props;
+  const hasPreviousResult = (currentHitIndex) => {
     if (searchHits.length === 0) return false;
     if (currentHitIndex > 0) return true;
     return false;
+  };
+
+  const iconStyle = direction === 'rtl' ? { transform: 'rotate(180deg)' } : {};
+
+  const currentHitIndex = searchHits
+    .findIndex(val => val.annotations.includes(selectedContentSearchAnnotation[0]));
+  let lengthText = searchHits.length;
+  if (searchHits.length < numTotal) {
+    lengthText += '+';
   }
 
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      numTotal, searchHits, selectedContentSearchAnnotation, t, direction,
-    } = this.props;
+  if (searchHits.length === 0) return null;
 
-    const iconStyle = direction === 'rtl' ? { transform: 'rotate(180deg)' } : {};
-
-    const currentHitIndex = searchHits
-      .findIndex(val => val.annotations.includes(selectedContentSearchAnnotation[0]));
-    let lengthText = searchHits.length;
-    if (searchHits.length < numTotal) {
-      lengthText += '+';
-    }
-
-    if (searchHits.length === 0) return null;
-
-    return (
-      <Typography variant="body2" align="center">
-        <MiradorMenuButton
-          aria-label={t('searchPreviousResult')}
-          disabled={!this.hasPreviousResult(currentHitIndex)}
-          onClick={() => this.previousSearchResult(currentHitIndex)}
-        >
-          <ChevronLeftIcon style={iconStyle} />
-        </MiradorMenuButton>
-        <span style={{ unicodeBidi: 'plaintext' }}>
-          {t('pagination', { current: currentHitIndex + 1, total: lengthText })}
-        </span>
-        <MiradorMenuButton
-          aria-label={t('searchNextResult')}
-          disabled={!this.hasNextResult(currentHitIndex)}
-          onClick={() => this.nextSearchResult(currentHitIndex)}
-        >
-          <ChevronRightIcon style={iconStyle} />
-        </MiradorMenuButton>
-      </Typography>
-    );
-  }
+  return (
+    <Typography variant="body2" align="center">
+      <MiradorMenuButton
+        aria-label={t('searchPreviousResult')}
+        disabled={!hasPreviousResult(currentHitIndex)}
+        onClick={() => previousSearchResult(currentHitIndex)}
+      >
+        <ChevronLeftIcon style={iconStyle} />
+      </MiradorMenuButton>
+      <span style={{ unicodeBidi: 'plaintext' }}>
+        {t('pagination', { current: currentHitIndex + 1, total: lengthText })}
+      </span>
+      <MiradorMenuButton
+        aria-label={t('searchNextResult')}
+        disabled={!hasNextResult(currentHitIndex)}
+        onClick={() => nextSearchResult(currentHitIndex)}
+      >
+        <ChevronRightIcon style={iconStyle} />
+      </MiradorMenuButton>
+    </Typography>
+  );
 }
+
 SearchPanelNavigation.propTypes = {
   direction: PropTypes.string.isRequired,
   numTotal: PropTypes.number,
@@ -90,9 +79,4 @@ SearchPanelNavigation.propTypes = {
   selectedContentSearchAnnotation: PropTypes.arrayOf(PropTypes.string).isRequired,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
-};
-SearchPanelNavigation.defaultProps = {
-  numTotal: undefined,
-  searchHits: [],
-  t: key => key,
 };

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import List from '@mui/material/List';
@@ -8,135 +8,120 @@ import { announce } from '@react-aria/live-announcer';
 import SearchHit from '../containers/SearchHit';
 import { ScrollTo } from './ScrollTo';
 
-/** */
-export class SearchResults extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-
-    this.state = { focused: false };
-
-    this.toggleFocus = this.toggleFocus.bind(this);
-  }
-
-  /** */
-  toggleFocus() {
-    const {
-      focused,
-    } = this.state;
-
-    this.setState({ focused: !focused });
-  }
-
-  /**
-   * Return SearchHits for every hit in the response
-   * Return SearchHits for every annotation in the response if there are no hits
-   */
-  renderSearchHitsAndAnnotations() {
-    const {
-      companionWindowId,
-      containerRef,
-      searchAnnotations,
-      searchHits,
-      windowId,
-    } = this.props;
-    const {
-      focused,
-    } = this.state;
-
-    if (searchHits.length === 0 && searchAnnotations.length > 0) {
-      return searchAnnotations.map((anno, index) => (
-        <SearchHit
-          announcer={announce}
-          annotationId={anno.id}
-          companionWindowId={companionWindowId}
-          containerRef={containerRef}
-          key={anno.id}
-          focused={focused}
-          index={index}
-          total={searchAnnotations.length}
-          windowId={windowId}
-          showDetails={this.toggleFocus}
-        />
-      ));
-    }
-
-    return searchHits.map((hit, index) => (
+/**
+ * Return SearchHits for every hit in the response
+ * Return SearchHits for every annotation in the response if there are no hits
+ */
+function SearchHitsAndAnnotations({
+  companionWindowId,
+  containerRef,
+  searchAnnotations,
+  searchHits,
+  windowId,
+  focused,
+  toggleFocus,
+}) {
+  if (searchHits.length === 0 && searchAnnotations.length > 0) {
+    return searchAnnotations.map((anno, index) => (
       <SearchHit
         announcer={announce}
-        containerRef={containerRef}
+        annotationId={anno.id}
         companionWindowId={companionWindowId}
-        key={hit.annotations[0]}
+        containerRef={containerRef}
+        key={anno.id}
         focused={focused}
-        hit={hit}
         index={index}
-        total={searchHits.length}
+        total={searchAnnotations.length}
         windowId={windowId}
-        showDetails={this.toggleFocus}
+        showDetails={toggleFocus}
       />
     ));
   }
 
+  return searchHits.map((hit, index) => (
+    <SearchHit
+      announcer={announce}
+      containerRef={containerRef}
+      companionWindowId={companionWindowId}
+      key={hit.annotations[0]}
+      focused={focused}
+      hit={hit}
+      index={index}
+      total={searchHits.length}
+      windowId={windowId}
+      showDetails={toggleFocus}
+    />
+  ));
+}
+
+/** */
+export function SearchResults({
+  companionWindowId,
+  containerRef = undefined,
+  isFetching = false,
+  fetchSearch,
+  nextSearch = undefined,
+  query = undefined,
+  searchAnnotations = [],
+  searchHits = [],
+  searchNumTotal = undefined,
+  t = k => k,
+  windowId,
+}) {
+  const [focused, setFocused] = useState(false);
+
   /** */
-  render() {
-    const {
-      companionWindowId,
-      containerRef,
-      isFetching,
-      fetchSearch,
-      nextSearch,
-      query,
-      searchAnnotations,
-      searchHits,
-      searchNumTotal,
-      t,
-      windowId,
-    } = this.props;
+  const toggleFocus = useCallback(() => {
+    setFocused(!focused);
+  }, [setFocused, focused]);
 
-    const {
-      focused,
-    } = this.state;
+  const noResultsState = (
+    query && !isFetching && searchHits.length === 0 && searchAnnotations.length === 0
+  );
 
-    const noResultsState = (
-      query && !isFetching && searchHits.length === 0 && searchAnnotations.length === 0
-    );
-
-    return (
-      <>
-        { focused && (
-          <ScrollTo containerRef={containerRef} offsetTop={96} scrollTo>
-            <Button onClick={this.toggleFocus} sx={{ textTransform: 'none' }} size="small">
-              <BackIcon />
-              {t('backToResults')}
-            </Button>
-          </ScrollTo>
-        )}
-        {noResultsState && (
-          <Typography sx={{
-            padding: 2,
-            typography: 'h6',
-          }}
-          >
-            {t('searchNoResults')}
-          </Typography>
-        )}
-        <List disablePadding>
-          { this.renderSearchHitsAndAnnotations() }
-        </List>
-        { nextSearch && (
-          <Button
-            sx={{ width: '100%' }}
-            color="secondary"
-            onClick={() => fetchSearch(windowId, companionWindowId, nextSearch, query)}
-          >
-            {t('moreResults')}
-            <br />
-            {`(${t('searchResultsRemaining', { numLeft: searchNumTotal - searchHits.length })})`}
+  return (
+    <>
+      { focused && (
+        <ScrollTo containerRef={containerRef} offsetTop={96} scrollTo>
+          <Button onClick={toggleFocus} sx={{ textTransform: 'none' }} size="small">
+            <BackIcon />
+            {t('backToResults')}
           </Button>
-        )}
-      </>
-    );
-  }
+        </ScrollTo>
+      )}
+      {noResultsState && (
+        <Typography sx={{
+          padding: 2,
+          typography: 'h6',
+        }}
+        >
+          {t('searchNoResults')}
+        </Typography>
+      )}
+      <List disablePadding>
+        <SearchHitsAndAnnotations
+          companionWindowId={companionWindowId}
+          containerRef={containerRef}
+          searchAnnotations={searchAnnotations}
+          searchHits={searchHits}
+          windowId={windowId}
+          focused={focused}
+          toggleFocus={toggleFocus}
+        />
+      </List>
+      { nextSearch && (
+        <Button
+          sx={{ width: '100%' }}
+          color="secondary"
+          onClick={() => fetchSearch(windowId, companionWindowId, nextSearch, query)}
+        >
+          {t('moreResults')}
+          <br />
+          {`(${t('searchResultsRemaining', { numLeft: searchNumTotal - searchHits.length })})`}
+        </Button>
+      )}
+    </>
+  );
 }
 
 SearchResults.propTypes = {
@@ -154,15 +139,4 @@ SearchResults.propTypes = {
   searchNumTotal: PropTypes.number,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
-};
-
-SearchResults.defaultProps = {
-  containerRef: undefined,
-  isFetching: false,
-  nextSearch: undefined,
-  query: undefined,
-  searchAnnotations: [],
-  searchHits: [],
-  searchNumTotal: undefined,
-  t: k => k,
 };

--- a/src/components/SelectCollection.js
+++ b/src/components/SelectCollection.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
@@ -8,48 +8,33 @@ import ListSharpIcon from '@mui/icons-material/ListSharp';
 /**
  *
  */
-export class SelectCollection extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-
-    this.openCollectionDialog = this.openCollectionDialog.bind(this);
-  }
-
-  /** */
-  openCollectionDialog() {
-    const {
-      collectionPath, manifestId, showCollectionDialog, windowId,
-    } = this.props;
+export function SelectCollection({
+  collectionPath = [], manifestId = null, showCollectionDialog, t = k => k, windowId = null,
+}) {
+  const openCollectionDialog = useCallback(() => {
     showCollectionDialog(manifestId, collectionPath.slice(0, -1), windowId);
-  }
+  }, [collectionPath, manifestId, showCollectionDialog, windowId]);
 
-  /** */
-  render() {
-    const {
-      t,
-    } = this.props;
-    return (
-      <Grid container justifyContent="center" alignItems="center">
-        <Grid container direction="column" alignItems="center">
-          <Typography variant="h4" paragraph>
-            <em>
-              {t('noItemSelected')}
-            </em>
-          </Typography>
-          <Button
-            aria-label="show collection"
-            color="primary"
-            variant="contained"
-            onClick={this.openCollectionDialog}
-            startIcon={<ListSharpIcon />}
-          >
-            {t('showCollection')}
-          </Button>
-        </Grid>
+  return (
+    <Grid container justifyContent="center" alignItems="center">
+      <Grid container direction="column" alignItems="center">
+        <Typography variant="h4" paragraph>
+          <em>
+            {t('noItemSelected')}
+          </em>
+        </Typography>
+        <Button
+          aria-label="show collection"
+          color="primary"
+          variant="contained"
+          onClick={openCollectionDialog}
+          startIcon={<ListSharpIcon />}
+        >
+          {t('showCollection')}
+        </Button>
       </Grid>
-    );
-  }
+    </Grid>
+  );
 }
 
 SelectCollection.propTypes = {
@@ -58,11 +43,4 @@ SelectCollection.propTypes = {
   showCollectionDialog: PropTypes.func.isRequired,
   t: PropTypes.func,
   windowId: PropTypes.string,
-};
-
-SelectCollection.defaultProps = {
-  collectionPath: [],
-  manifestId: null,
-  t: () => {},
-  windowId: null,
 };

--- a/src/components/SidebarIndexItem.js
+++ b/src/components/SidebarIndexItem.js
@@ -1,23 +1,15 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 
 /** */
-export class SidebarIndexItem extends Component {
-  /** */
-  render() {
-    const {
-      label,
-    } = this.props;
-
-    return (
-      <Typography
-        variant="body1"
-      >
-        {label}
-      </Typography>
-    );
-  }
+export function SidebarIndexItem({ label }) {
+  return (
+    <Typography
+      variant="body1"
+    >
+      {label}
+    </Typography>
+  );
 }
 
 SidebarIndexItem.propTypes = {

--- a/src/components/SidebarIndexList.js
+++ b/src/components/SidebarIndexList.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
@@ -17,68 +17,61 @@ const StyledItem = styled(MenuItem, { name: 'SidebarIndexList', slot: 'item' })(
 }));
 
 /** */
-export class SidebarIndexList extends Component {
-  /** @private */
-  getIdAndLabelOfCanvases() {
-    const { canvases } = this.props;
+function getIdAndLabelOfCanvases(canvases) {
+  return canvases.map((canvas) => ({
+    id: canvas.id,
+    label: new MiradorCanvas(canvas).getLabel(),
+  }));
+}
 
-    return canvases.map((canvas, index) => ({
-      id: canvas.id,
-      label: new MiradorCanvas(canvas).getLabel(),
-    }));
+/** */
+export function SidebarIndexList({
+  canvases,
+  containerRef,
+  selectedCanvasIds = [],
+  setCanvas,
+  variant = 'item',
+  windowId,
+}) {
+  const canvasesIdAndLabel = useMemo(() => getIdAndLabelOfCanvases(canvases), [canvases]);
+  let Item;
+
+  switch (variant) {
+    case 'thumbnail':
+      Item = SidebarIndexThumbnail;
+      break;
+    default:
+      Item = SidebarIndexItem;
   }
 
-  /** */
-  render() {
-    const {
-      canvases,
-      containerRef,
-      selectedCanvasIds,
-      setCanvas,
-      variant,
-      windowId,
-    } = this.props;
+  return (
+    <MenuList variant="selectedMenu">
+      {
+        canvasesIdAndLabel.map((canvas, canvasIndex) => {
+          const onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
 
-    const canvasesIdAndLabel = this.getIdAndLabelOfCanvases(canvases);
-    let Item;
-
-    switch (variant) {
-      case 'thumbnail':
-        Item = SidebarIndexThumbnail;
-        break;
-      default:
-        Item = SidebarIndexItem;
-    }
-
-    return (
-      <MenuList variant="selectedMenu">
-        {
-          canvasesIdAndLabel.map((canvas, canvasIndex) => {
-            const onClick = () => { setCanvas(windowId, canvas.id); }; // eslint-disable-line require-jsdoc, max-len
-
-            return (
-              <ScrollTo
-                containerRef={containerRef}
-                key={`${canvas.id}-${variant}`}
-                offsetTop={96} // offset for the height of the form above
-                selected={selectedCanvasIds.includes(canvas.id)}
-                scrollTo={selectedCanvasIds.includes(canvas.id)}
+          return (
+            <ScrollTo
+              containerRef={containerRef}
+              key={`${canvas.id}-${variant}`}
+              offsetTop={96} // offset for the height of the form above
+              selected={selectedCanvasIds.includes(canvas.id)}
+              scrollTo={selectedCanvasIds.includes(canvas.id)}
+            >
+              <StyledItem
+                key={canvas.id}
+                divider
+                onClick={onClick}
+                component="li"
               >
-                <StyledItem
-                  key={canvas.id}
-                  divider
-                  onClick={onClick}
-                  component="li"
-                >
-                  <Item label={canvas.label} canvas={canvases[canvasIndex]} />
-                </StyledItem>
-              </ScrollTo>
-            );
-          })
-        }
-      </MenuList>
-    );
-  }
+                <Item label={canvas.label} canvas={canvases[canvasIndex]} />
+              </StyledItem>
+            </ScrollTo>
+          );
+        })
+      }
+    </MenuList>
+  );
 }
 
 SidebarIndexList.propTypes = {
@@ -88,9 +81,4 @@ SidebarIndexList.propTypes = {
   setCanvas: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(['item', 'thumbnail']),
   windowId: PropTypes.string.isRequired,
-};
-
-SidebarIndexList.defaultProps = {
-  selectedCanvasIds: [],
-  variant: 'item',
 };

--- a/src/components/SidebarIndexTableOfContents.js
+++ b/src/components/SidebarIndexTableOfContents.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { alpha, styled } from '@mui/material/styles';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -59,36 +58,26 @@ ScrollToForTreeItem.propTypes = {
 };
 
 /** */
-export class SidebarIndexTableOfContents extends Component {
+export function SidebarIndexTableOfContents({
+  toggleNode, expandNodes, setCanvas, windowId,
+  treeStructure, visibleNodeIds, expandedNodeIds, containerRef, nodeIdToScrollTo,
+}) {
   /** */
-  constructor(props) {
-    super(props);
-    this.handleNodeSelect = this.handleNodeSelect.bind(this);
-    this.handleNodeToggle = this.handleNodeToggle.bind(this);
-  }
-
-  /** */
-  handleNodeSelect(event, nodeId) {
-    const { toggleNode } = this.props;
-
+  const handleNodeSelect = (event, nodeId) => {
     if (event.key === ' ' || event.key === 'Spacebar') {
       toggleNode(nodeId);
     }
 
-    this.selectTreeItem(nodeId);
-  }
+    selectTreeItem(nodeId);
+  };
 
   /** */
-  handleNodeToggle(_event, nodeIds) {
-    const { expandNodes } = this.props;
-
+  const handleNodeToggle = (_event, nodeIds) => {
     expandNodes(nodeIds);
-  }
+  };
 
   /** */
-  selectTreeItem(nodeId) {
-    const { setCanvas, treeStructure, windowId } = this.props;
-
+  const selectTreeItem = (nodeId) => {
     const node = deepFind(treeStructure, nodeId);
 
     // Do not select if there are no canvases listed or it has children
@@ -100,89 +89,82 @@ export class SidebarIndexTableOfContents extends Component {
     const target = getStartCanvasId(node);
     const canvasId = target.indexOf('#') === -1 ? target : target.substr(0, target.indexOf('#'));
     setCanvas(windowId, canvasId);
+  };
+
+  if (!treeStructure) {
+    return null;
   }
 
-  /** */
-  render() {
-    const {
-      treeStructure, visibleNodeIds, expandedNodeIds, containerRef, nodeIdToScrollTo,
-    } = this.props;
-
-    if (!treeStructure) {
-      return null;
-    }
-
-    /** Render the tree structure recursively */
-    const renderTree = (node) => (
-      <ScrollToForTreeItem
-        containerRef={containerRef}
-        key={node.id}
+  /** Render the tree structure recursively */
+  const renderTree = (node) => (
+    <ScrollToForTreeItem
+      containerRef={containerRef}
+      key={node.id}
+      nodeId={node.id}
+      offsetTop={96} // offset for the height of the form above
+      scrollTo={nodeIdToScrollTo === node.id}
+    >
+      <TreeItem
         nodeId={node.id}
-        offsetTop={96} // offset for the height of the form above
-        scrollTo={nodeIdToScrollTo === node.id}
+        sx={{
+          '& .MuiTreeItem-content': {
+            alignItems: 'flex-start',
+            borderLeft: '1px solid transparent',
+            padding: '8px 16px 8px 0',
+            width: 'auto',
+          },
+          '& .MuiTreeItem-group': {
+            borderLeft: '1px solid',
+            borderLeftColor: 'grey.300',
+          },
+          '& .MuiTreeItem-iconContainer': {
+            paddingBlockStart: 0.5,
+          },
+          '& .MuiTreeItem-label': {
+            paddingLeft: 0,
+          },
+          '& .MuiTreeItem-root': {
+            '&:focus > .MuiTreeItem-content': {
+              backgroundColor: 'action.selected',
+            },
+            '&:hover > .MuiTreeItem-content': {
+              backgroundColor: 'action.hover',
+            },
+            '&:hover > .MuiTreeItem-content .MuiTreeItem-label, &:focus > .MuiTreeItem-content .MuiTreeItem-label, &.MuiTreeItem-selected > .MuiTreeItem-content .MuiTreeItem-label, &.MuiTreeItem-selected > .MuiTreeItem-content .MuiTreeItem-label:hover, &.MuiTreeItem-selected:focus > .MuiTreeItem-content .MuiTreeItem-label': {
+              backgroundColor: 'transparent',
+            },
+          },
+        }}
+        label={(
+          <StyledVisibleNode
+            sx={theme => ({
+              backgroundColor: visibleNodeIds.indexOf(node.id) !== -1
+              && alpha(theme.palette.highlights?.primary || theme.palette.action.selected, 0.35),
+              display: visibleNodeIds.indexOf(node.id) !== -1 && 'inline',
+            })}
+          >
+            {node.label}
+          </StyledVisibleNode>
+      )}
       >
-        <TreeItem
-          nodeId={node.id}
-          sx={{
-            '& .MuiTreeItem-content': {
-              alignItems: 'flex-start',
-              borderLeft: '1px solid transparent',
-              padding: '8px 16px 8px 0',
-              width: 'auto',
-            },
-            '& .MuiTreeItem-group': {
-              borderLeft: '1px solid',
-              borderLeftColor: 'grey.300',
-            },
-            '& .MuiTreeItem-iconContainer': {
-              paddingBlockStart: 0.5,
-            },
-            '& .MuiTreeItem-label': {
-              paddingLeft: 0,
-            },
-            '& .MuiTreeItem-root': {
-              '&:focus > .MuiTreeItem-content': {
-                backgroundColor: 'action.selected',
-              },
-              '&:hover > .MuiTreeItem-content': {
-                backgroundColor: 'action.hover',
-              },
-              '&:hover > .MuiTreeItem-content .MuiTreeItem-label, &:focus > .MuiTreeItem-content .MuiTreeItem-label, &.MuiTreeItem-selected > .MuiTreeItem-content .MuiTreeItem-label, &.MuiTreeItem-selected > .MuiTreeItem-content .MuiTreeItem-label:hover, &.MuiTreeItem-selected:focus > .MuiTreeItem-content .MuiTreeItem-label': {
-                backgroundColor: 'transparent',
-              },
-            },
-          }}
-          label={(
-            <StyledVisibleNode
-              sx={theme => ({
-                backgroundColor: visibleNodeIds.indexOf(node.id) !== -1
-                && alpha(theme.palette.highlights?.primary || theme.palette.action.selected, 0.35),
-                display: visibleNodeIds.indexOf(node.id) !== -1 && 'inline',
-              })}
-            >
-              {node.label}
-            </StyledVisibleNode>
-        )}
-        >
-          {Array.isArray(node.nodes) ? node.nodes.map((n) => renderTree(n)) : null}
-        </TreeItem>
-      </ScrollToForTreeItem>
-    );
+        {Array.isArray(node.nodes) ? node.nodes.map((n) => renderTree(n)) : null}
+      </TreeItem>
+    </ScrollToForTreeItem>
+  );
 
-    return (
-      <TreeView
-        sx={{ flexGrow: 1 }}
-        defaultCollapseIcon={<ExpandMoreIcon color="action" />}
-        defaultExpandIcon={<ChevronRightIcon color="action" />}
-        defaultEndIcon={null}
-        onNodeSelect={this.handleNodeSelect}
-        onNodeToggle={this.handleNodeToggle}
-        expanded={expandedNodeIds}
-      >
-        { Array.isArray(treeStructure.nodes) ? treeStructure.nodes.map(n => renderTree(n)) : null }
-      </TreeView>
-    );
-  }
+  return (
+    <TreeView
+      sx={{ flexGrow: 1 }}
+      defaultCollapseIcon={<ExpandMoreIcon color="action" />}
+      defaultExpandIcon={<ChevronRightIcon color="action" />}
+      defaultEndIcon={null}
+      onNodeSelect={handleNodeSelect}
+      onNodeToggle={handleNodeToggle}
+      expanded={expandedNodeIds}
+    >
+      { Array.isArray(treeStructure.nodes) ? treeStructure.nodes.map(n => renderTree(n)) : null }
+    </TreeView>
+  );
 }
 
 SidebarIndexTableOfContents.propTypes = {

--- a/src/components/SidebarIndexThumbnail.js
+++ b/src/components/SidebarIndexThumbnail.js
@@ -1,32 +1,26 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import IIIFThumbnail from '../containers/IIIFThumbnail';
 
 /** */
-export class SidebarIndexThumbnail extends Component {
-  /** */
-  render() {
-    const {
-      canvas, height, label, width,
-    } = this.props;
-
-    return (
-      <>
-        <div style={{ minWidth: 50 }}>
-          <IIIFThumbnail
-            label={label}
-            resource={canvas}
-            maxHeight={height}
-            maxWidth={width}
-          />
-        </div>
-        <Typography>
-          {label}
-        </Typography>
-      </>
-    );
-  }
+export function SidebarIndexThumbnail({
+  canvas, height = undefined, label, width = undefined,
+}) {
+  return (
+    <>
+      <div style={{ minWidth: 50 }}>
+        <IIIFThumbnail
+          label={label}
+          resource={canvas}
+          maxHeight={height}
+          maxWidth={width}
+        />
+      </div>
+      <Typography>
+        {label}
+      </Typography>
+    </>
+  );
 }
 
 SidebarIndexThumbnail.propTypes = {
@@ -34,9 +28,4 @@ SidebarIndexThumbnail.propTypes = {
   height: PropTypes.number,
   label: PropTypes.string.isRequired,
   width: PropTypes.number,
-};
-
-SidebarIndexThumbnail.defaultProps = {
-  height: undefined,
-  width: undefined,
 };

--- a/src/components/VideoViewer.js
+++ b/src/components/VideoViewer.js
@@ -1,4 +1,3 @@
-import { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 
@@ -14,41 +13,23 @@ const StyledVideo = styled('video')(() => ({
 }));
 
 /** */
-export class VideoViewer extends Component {
-  /* eslint-disable jsx-a11y/media-has-caption */
-  /** */
-  render() {
-    const {
-      captions, videoOptions, videoResources,
-    } = this.props;
-    return (
-      <StyledContainer>
-        <StyledVideo {...videoOptions}>
-          {videoResources.map(video => (
-            <Fragment key={video.id}>
-              <source src={video.id} type={video.getFormat()} />
-            </Fragment>
-          ))}
-          {captions.map(caption => (
-            <Fragment key={caption.id}>
-              <track src={caption.id} label={caption.getDefaultLabel()} srcLang={caption.getProperty('language')} />
-            </Fragment>
-          ))}
-        </StyledVideo>
-      </StyledContainer>
-    );
-  }
-  /* eslint-enable jsx-a11y/media-has-caption */
+export function VideoViewer({ captions = [], videoOptions = {}, videoResources = [] }) {
+  return (
+    <StyledContainer>
+      <StyledVideo {...videoOptions}>
+        {videoResources.map(video => (
+          <source key={video.io} src={video.id} type={video.getFormat()} />
+        ))}
+        {captions.map(caption => (
+          <track key={caption.id} src={caption.id} label={caption.getDefaultLabel()} srcLang={caption.getProperty('language')} />
+        ))}
+      </StyledVideo>
+    </StyledContainer>
+  );
 }
 
 VideoViewer.propTypes = {
   captions: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
   videoOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   videoResources: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/forbid-prop-types
-};
-
-VideoViewer.defaultProps = {
-  captions: [],
-  videoOptions: {},
-  videoResources: [],
 };

--- a/src/components/ViewerInfo.js
+++ b/src/components/ViewerInfo.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
@@ -17,33 +16,23 @@ const StyledOsdInfo = styled('div')(() => ({
 /**
  *
  */
-export class ViewerInfo extends Component {
-  /** */
-  render() {
-    const {
-      canvasCount,
-      canvasIndex,
-      canvasLabel,
-      t,
-    } = this.props;
-
-    return (
-      <StyledOsdInfo className={classNames(ns('osd-info'))}>
-        <Typography display="inline" variant="caption" className={ns('canvas-count')}>
-          { t('pagination', { current: canvasIndex + 1, total: canvasCount }) }
-        </Typography>
-        <Typography display="inline" variant="caption" className={ns('canvas-label')}>
-          {canvasLabel && ` • ${canvasLabel}`}
-        </Typography>
-      </StyledOsdInfo>
-    );
-  }
+export function ViewerInfo({
+  canvasCount,
+  canvasIndex,
+  canvasLabel = undefined,
+  t = k => k,
+}) {
+  return (
+    <StyledOsdInfo className={classNames(ns('osd-info'))}>
+      <Typography display="inline" variant="caption" className={ns('canvas-count')}>
+        { t('pagination', { current: canvasIndex + 1, total: canvasCount }) }
+      </Typography>
+      <Typography display="inline" variant="caption" className={ns('canvas-label')}>
+        {canvasLabel && ` • ${canvasLabel}`}
+      </Typography>
+    </StyledOsdInfo>
+  );
 }
-
-ViewerInfo.defaultProps = {
-  canvasLabel: undefined,
-  t: () => {},
-};
 
 ViewerInfo.propTypes = {
   canvasCount: PropTypes.number.isRequired,

--- a/src/components/ViewerNavigation.js
+++ b/src/components/ViewerNavigation.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import NavigationIcon from '@mui/icons-material/PlayCircleOutlineSharp';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -7,62 +6,56 @@ import ns from '../config/css-ns';
 
 /**
  */
-export class ViewerNavigation extends Component {
-  /**
-   * Renders things
-   */
-  render() {
-    const {
-      hasNextCanvas, hasPreviousCanvas, setNextCanvas, setPreviousCanvas, t,
-      viewingDirection,
-    } = this.props;
-
-    let htmlDir = 'ltr';
-    let previousIconStyle = {};
-    let nextIconStyle = {};
-    switch (viewingDirection) {
-      case 'top-to-bottom':
-        previousIconStyle = { transform: 'rotate(270deg)' };
-        nextIconStyle = { transform: 'rotate(90deg)' };
-        break;
-      case 'bottom-to-top':
-        previousIconStyle = { transform: 'rotate(90deg)' };
-        nextIconStyle = { transform: 'rotate(270deg)' };
-        break;
-      case 'right-to-left':
-        htmlDir = 'rtl';
-        previousIconStyle = {};
-        nextIconStyle = { transform: 'rotate(180deg)' };
-        break;
-      default:
-        previousIconStyle = { transform: 'rotate(180deg)' };
-        nextIconStyle = {};
-    }
-
-    return (
-      <div
-        className={classNames(ns('osd-navigation'))}
-        dir={htmlDir}
-      >
-        <MiradorMenuButton
-          aria-label={t('previousCanvas')}
-          className={ns('previous-canvas-button')}
-          disabled={!hasPreviousCanvas}
-          onClick={() => { hasPreviousCanvas && setPreviousCanvas(); }}
-        >
-          <NavigationIcon style={previousIconStyle} />
-        </MiradorMenuButton>
-        <MiradorMenuButton
-          aria-label={t('nextCanvas')}
-          className={ns('next-canvas-button')}
-          disabled={!hasNextCanvas}
-          onClick={() => { hasNextCanvas && setNextCanvas(); }}
-        >
-          <NavigationIcon style={nextIconStyle} />
-        </MiradorMenuButton>
-      </div>
-    );
+export function ViewerNavigation({
+  hasNextCanvas = false, hasPreviousCanvas = false,
+  setNextCanvas = () => {}, setPreviousCanvas = () => {}, t,
+  viewingDirection = '',
+}) {
+  let htmlDir = 'ltr';
+  let previousIconStyle = {};
+  let nextIconStyle = {};
+  switch (viewingDirection) {
+    case 'top-to-bottom':
+      previousIconStyle = { transform: 'rotate(270deg)' };
+      nextIconStyle = { transform: 'rotate(90deg)' };
+      break;
+    case 'bottom-to-top':
+      previousIconStyle = { transform: 'rotate(90deg)' };
+      nextIconStyle = { transform: 'rotate(270deg)' };
+      break;
+    case 'right-to-left':
+      htmlDir = 'rtl';
+      previousIconStyle = {};
+      nextIconStyle = { transform: 'rotate(180deg)' };
+      break;
+    default:
+      previousIconStyle = { transform: 'rotate(180deg)' };
+      nextIconStyle = {};
   }
+
+  return (
+    <div
+      className={classNames(ns('osd-navigation'))}
+      dir={htmlDir}
+    >
+      <MiradorMenuButton
+        aria-label={t('previousCanvas')}
+        className={ns('previous-canvas-button')}
+        disabled={!hasPreviousCanvas}
+        onClick={() => { hasPreviousCanvas && setPreviousCanvas(); }}
+      >
+        <NavigationIcon style={previousIconStyle} />
+      </MiradorMenuButton>
+      <MiradorMenuButton
+        aria-label={t('nextCanvas')}
+        className={ns('next-canvas-button')}
+        disabled={!hasNextCanvas}
+        onClick={() => { hasNextCanvas && setNextCanvas(); }}
+      >
+        <NavigationIcon style={nextIconStyle} />
+      </MiradorMenuButton>
+    </div>
+  );
 }
 
 ViewerNavigation.propTypes = {
@@ -72,12 +65,4 @@ ViewerNavigation.propTypes = {
   setPreviousCanvas: PropTypes.func,
   t: PropTypes.func.isRequired,
   viewingDirection: PropTypes.string,
-};
-
-ViewerNavigation.defaultProps = {
-  hasNextCanvas: false,
-  hasPreviousCanvas: false,
-  setNextCanvas: () => {},
-  setPreviousCanvas: () => {},
-  viewingDirection: '',
 };

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -1,8 +1,9 @@
-import { Component, useContext } from 'react';
+import { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Paper from '@mui/material/Paper';
 import { MosaicWindowContext } from 'react-mosaic-component/lib/contextTypes';
+import { ErrorBoundary } from 'react-error-boundary';
 import ns from '../config/css-ns';
 import WindowTopBar from '../containers/WindowTopBar';
 import PrimaryWindow from '../containers/PrimaryWindow';
@@ -78,43 +79,23 @@ const DraggableNavBar = ({ children, ...props }) => {
  * Represents a Window in the mirador workspace
  * @param {object} window
  */
-export class Window extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
+export function Window({
+  focusWindow = () => {}, label = null, isFetching = false, sideBarOpen = false,
+  view = undefined, windowDraggable = null, windowId, workspaceType = null, t,
+  manifestError = null,
+}) {
+  const ownerState = arguments[0]; // eslint-disable-line prefer-rest-params
+  const ErrorWindow = useCallback(({ error }) => (
+    <MinimalWindow windowId={windowId}>
+      <ErrorContent error={error} windowId={windowId} />
+    </MinimalWindow>
+  ), [windowId]);
 
-  /** */
-  static getDerivedStateFromError(error) {
-    // Update state so the next render will show the fallback UI.
-    return { error, hasError: true };
-  }
-
-  /**
-   * Renders things
-   */
-  render() {
-    const {
-      focusWindow, label, isFetching, sideBarOpen,
-      view, windowDraggable, windowId, workspaceType, t,
-      manifestError,
-    } = this.props;
-
-    const { error, hasError } = this.state;
-
-    if (hasError) {
-      return (
-        <MinimalWindow windowId={windowId}>
-          <ErrorContent error={error} windowId={windowId} />
-        </MinimalWindow>
-      );
-    }
-
-    return (
+  return (
+    <ErrorBoundary FallbackComponent={ErrorWindow}>
       <Root
         onFocus={focusWindow}
-        ownerState={this.props}
+        ownerState={ownerState}
         component="section"
         elevation={1}
         id={windowId}
@@ -144,13 +125,11 @@ export class Window extends Component {
           </StyledCompanionAreaRight>
         </ContentRow>
         <CompanionArea windowId={windowId} position="far-bottom" />
-        <PluginHook {...this.props} />
+        <PluginHook {...ownerState} />
       </Root>
-    );
-  }
+    </ErrorBoundary>
+  );
 }
-
-Window.contextType = MosaicWindowContext;
 
 Window.propTypes = {
   focusWindow: PropTypes.func,
@@ -164,16 +143,4 @@ Window.propTypes = {
   windowDraggable: PropTypes.bool,
   windowId: PropTypes.string.isRequired,
   workspaceType: PropTypes.string,
-};
-
-Window.defaultProps = {
-  focusWindow: () => {},
-  isFetching: false,
-  label: null,
-  manifestError: null,
-  maximized: false,
-  sideBarOpen: false,
-  view: undefined,
-  windowDraggable: null,
-  workspaceType: null,
 };

--- a/src/components/WindowAuthenticationBar.js
+++ b/src/components/WindowAuthenticationBar.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { alpha, styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
@@ -21,141 +21,123 @@ const StyledTopBar = styled('div')(({ theme }) => ({
 const StyledFauxButton = styled('span')(({ theme }) => ({
   marginLeft: theme.spacing(2.5),
 }));
+
 /** */
-export class WindowAuthenticationBar extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-
-    this.state = { open: false };
-    this.setOpen = this.setOpen.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-  }
+export function WindowAuthenticationBar({
+  confirmButton = undefined, continueLabel = undefined,
+  header = undefined, description = undefined, icon = undefined, label, t = k => k,
+  ruleSet = 'iiif', hasLogoutService = true, status = undefined, ConfirmProps = {}, onConfirm,
+}) {
+  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
+  const [open, setOpen] = useState(false);
 
   /** */
-  onSubmit() {
-    const { onConfirm } = this.props;
-    this.setOpen(false);
+  const onSubmit = () => {
+    setOpen(false);
     onConfirm();
-  }
+  };
 
-  /** Toggle the full description */
-  setOpen(open) {
-    this.setState(state => ({ ...state, open }));
-  }
+  if (status === 'ok' && !hasLogoutService) return null;
 
-  /** */
-  render() {
-    const {
-      confirmButton, continueLabel,
-      header, description, icon, label, t,
-      ruleSet, hasLogoutService, status, ConfirmProps,
-    } = this.props;
+  const button = (
+    <Button
+      onClick={onSubmit}
+      color="secondary"
+      sx={(theme) => ({
+        '&:hover': {
+          backgroundColor: alpha(theme.palette.secondary.contrastText, 1 - theme.palette.action.hoverOpacity),
+        },
+        backgroundColor: theme.palette.secondary.contrastText,
+      })}
+      {...ConfirmProps}
+    >
+      {confirmButton || t('login')}
+    </Button>
+  );
 
-    if (status === 'ok' && !hasLogoutService) return null;
-
-    const { open } = this.state;
-
-    const button = (
-      <Button
-        onClick={this.onSubmit}
-        color="secondary"
-        sx={(theme) => ({
-          '&:hover': {
-            backgroundColor: alpha(theme.palette.secondary.contrastText, 1 - theme.palette.action.hoverOpacity),
-          },
-          backgroundColor: theme.palette.secondary.contrastText,
-        })}
-        {...ConfirmProps}
-      >
-        {confirmButton || t('login')}
-      </Button>
-    );
-
-    if (!description && !header) {
-      return (
-        <Paper
-          square
-          elevation={4}
-          color="secondary"
-        >
-          <StyledTopBar>
-            { icon || (
-              <LockIcon sx={{ marginInlineEnd: 1.5 }} />
-            ) }
-            <Typography component="h3" variant="body1" color="inherit">
-              { ruleSet ? <SanitizedHtml htmlString={label} ruleSet={ruleSet} /> : label }
-            </Typography>
-            <PluginHook {...this.props} />
-            { button }
-          </StyledTopBar>
-        </Paper>
-      );
-    }
-
+  if (!description && !header) {
     return (
       <Paper
         square
         elevation={4}
         color="secondary"
       >
-        <Button
-          fullWidth
-          onClick={() => this.setOpen(true)}
-          component="div"
-          color="inherit"
-          sx={(theme) => ({
-            '&:hover': {
-              backgroundColor: theme.palette.secondary.main,
-            },
-            backgroundColor: theme.palette.secondary.main,
-            borderRadius: 0,
-            color: theme.palette.secondary.contrastText,
-            justifyContent: 'start',
-            textTransform: 'none',
-          })}
-        >
+        <StyledTopBar>
           { icon || (
-          <LockIcon sx={{ marginInlineEnd: 1.5 }} />
+            <LockIcon sx={{ marginInlineEnd: 1.5 }} />
           ) }
-          <Typography sx={{ paddingBlockEnd: 1, paddingBlockStart: 1 }} component="h3" variant="body1" color="inherit">
+          <Typography component="h3" variant="body1" color="inherit">
             { ruleSet ? <SanitizedHtml htmlString={label} ruleSet={ruleSet} /> : label }
           </Typography>
-          <PluginHook {...this.props} />
-          <StyledFauxButton>
-            { !open && (
-              <Typography variant="button" color="inherit">
-                { continueLabel || t('continue') }
-              </Typography>
-            )}
-          </StyledFauxButton>
-        </Button>
-        <Collapse
-          sx={(theme) => ({
-            backgroundColor: theme.palette.secondary.main,
-            color: theme.palette.secondary.contrastText,
-            paddingInlineEnd: theme.spacing(1),
-            paddingInlineStart: theme.spacing(1),
-          })}
-          in={open}
-          onClose={() => this.setOpen(false)}
-        >
-          <Typography variant="body1" color="inherit">
-            { ruleSet ? <SanitizedHtml htmlString={header} ruleSet={ruleSet} /> : header }
-            { header && description ? ': ' : '' }
-            { ruleSet ? <SanitizedHtml htmlString={description} ruleSet={ruleSet} /> : description }
-          </Typography>
-          <DialogActions>
-            <Button onClick={() => this.setOpen(false)} color="inherit">
-              { t('cancel') }
-            </Button>
-
-            { button }
-          </DialogActions>
-        </Collapse>
+          <PluginHook {...pluginProps} />
+          { button }
+        </StyledTopBar>
       </Paper>
     );
   }
+
+  return (
+    <Paper
+      square
+      elevation={4}
+      color="secondary"
+    >
+      <Button
+        fullWidth
+        onClick={() => setOpen(true)}
+        component="div"
+        color="inherit"
+        sx={(theme) => ({
+          '&:hover': {
+            backgroundColor: theme.palette.secondary.main,
+          },
+          backgroundColor: theme.palette.secondary.main,
+          borderRadius: 0,
+          color: theme.palette.secondary.contrastText,
+          justifyContent: 'start',
+          textTransform: 'none',
+        })}
+      >
+        { icon || (
+        <LockIcon sx={{ marginInlineEnd: 1.5 }} />
+        ) }
+        <Typography sx={{ paddingBlockEnd: 1, paddingBlockStart: 1 }} component="h3" variant="body1" color="inherit">
+          { ruleSet ? <SanitizedHtml htmlString={label} ruleSet={ruleSet} /> : label }
+        </Typography>
+        <PluginHook {...pluginProps} />
+        <StyledFauxButton>
+          { !open && (
+            <Typography variant="button" color="inherit">
+              { continueLabel || t('continue') }
+            </Typography>
+          )}
+        </StyledFauxButton>
+      </Button>
+      <Collapse
+        sx={(theme) => ({
+          backgroundColor: theme.palette.secondary.main,
+          color: theme.palette.secondary.contrastText,
+          paddingInlineEnd: theme.spacing(1),
+          paddingInlineStart: theme.spacing(1),
+        })}
+        in={open}
+        onClose={() => setOpen(false)}
+      >
+        <Typography variant="body1" color="inherit">
+          { ruleSet ? <SanitizedHtml htmlString={header} ruleSet={ruleSet} /> : header }
+          { header && description ? ': ' : '' }
+          { ruleSet ? <SanitizedHtml htmlString={description} ruleSet={ruleSet} /> : description }
+        </Typography>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)} color="inherit">
+            { t('cancel') }
+          </Button>
+
+          { button }
+        </DialogActions>
+      </Collapse>
+    </Paper>
+  );
 }
 
 WindowAuthenticationBar.propTypes = {
@@ -171,17 +153,4 @@ WindowAuthenticationBar.propTypes = {
   ruleSet: PropTypes.string,
   status: PropTypes.string,
   t: PropTypes.func,
-};
-
-WindowAuthenticationBar.defaultProps = {
-  confirmButton: undefined,
-  ConfirmProps: {},
-  continueLabel: undefined,
-  description: undefined,
-  hasLogoutService: true,
-  header: undefined,
-  icon: undefined,
-  ruleSet: 'iiif',
-  status: undefined,
-  t: k => k,
 };

--- a/src/components/WindowCanvasNavigationControls.js
+++ b/src/components/WindowCanvasNavigationControls.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { alpha, styled } from '@mui/material/styles';
 import classNames from 'classnames';
@@ -31,49 +30,41 @@ const Root = styled(Paper, { name: 'WindowCanvasNavigationControls', slot: 'root
 /**
  * Represents the viewer controls in the mirador workspace.
  */
-export class WindowCanvasNavigationControls extends Component {
+export function WindowCanvasNavigationControls({
+  showZoomControls = false, size, visible = true, windowId, zoomToWorld,
+}) {
+  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
   /**
    * Determine if canvasNavControls are stacked (based on a hard-coded width)
   */
-  canvasNavControlsAreStacked() {
-    const { size } = this.props;
+  const canvasNavControlsAreStacked = (size && size.width && size.width <= 253);
 
-    return (size && size.width && size.width <= 253);
-  }
+  if (!visible) return (<Typography style={visuallyHidden} component="div"><ViewerInfo windowId={windowId} /></Typography>);
 
-  /** */
-  render() {
-    const {
-      showZoomControls, visible, windowId, zoomToWorld,
-    } = this.props;
-
-    if (!visible) return (<Typography style={visuallyHidden} component="div"><ViewerInfo windowId={windowId} /></Typography>);
-
-    return (
-      <Root
-        square
-        className={
-          classNames(
-            ns('canvas-nav'),
-            this.canvasNavControlsAreStacked() ? ns('canvas-nav-stacked') : null,
-          )
-        }
-        elevation={0}
+  return (
+    <Root
+      square
+      className={
+        classNames(
+          ns('canvas-nav'),
+          canvasNavControlsAreStacked ? ns('canvas-nav-stacked') : null,
+        )
+      }
+      elevation={0}
+    >
+      <Stack
+        direction={canvasNavControlsAreStacked ? 'column' : 'row'}
+        divider={<Divider orientation={canvasNavControlsAreStacked ? 'horizontal' : 'vertical'} variant="middle" flexItem />}
+        spacing={0}
       >
-        <Stack
-          direction={this.canvasNavControlsAreStacked() ? 'column' : 'row'}
-          divider={<Divider orientation={this.canvasNavControlsAreStacked() ? 'horizontal' : 'vertical'} variant="middle" flexItem />}
-          spacing={0}
-        >
-          { showZoomControls && <ZoomControls windowId={windowId} zoomToWorld={zoomToWorld} /> }
-          <ViewerNavigation windowId={windowId} />
-        </Stack>
-        <ViewerInfo windowId={windowId} />
+        { showZoomControls && <ZoomControls windowId={windowId} zoomToWorld={zoomToWorld} /> }
+        <ViewerNavigation windowId={windowId} />
+      </Stack>
+      <ViewerInfo windowId={windowId} />
 
-        <PluginHook {...this.props} />
-      </Root>
-    );
-  }
+      <PluginHook {...pluginProps} />
+    </Root>
+  );
 }
 
 WindowCanvasNavigationControls.propTypes = {
@@ -82,9 +73,4 @@ WindowCanvasNavigationControls.propTypes = {
   visible: PropTypes.bool,
   windowId: PropTypes.string.isRequired,
   zoomToWorld: PropTypes.func.isRequired,
-};
-
-WindowCanvasNavigationControls.defaultProps = {
-  showZoomControls: false,
-  visible: true,
 };

--- a/src/components/WindowList.js
+++ b/src/components/WindowList.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
@@ -7,63 +6,45 @@ import PropTypes from 'prop-types';
 
 /**
  */
-export class WindowList extends Component {
-  /**
-   * Get the title for a window from its manifest title
-   * @private
-   */
-  titleContent(windowId) {
-    const { titles, t } = this.props;
-
-    return titles[windowId] || t('untitled');
-  }
-
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      container, handleClose, windowIds, focusWindow, focusedWindowId, t, tReady,
-      ...menuProps
-    } = this.props;
-
-    return (
-      <Menu
-        anchorOrigin={{
-          horizontal: 'right',
-          vertical: 'top',
-        }}
-        transformOrigin={{
-          horizontal: 'left',
-          vertical: 'top',
-        }}
-        id="window-list-menu"
-        container={container?.current}
-        onClose={handleClose}
-        {...menuProps}
-      >
-        <ListSubheader role="presentation" selected={false} disabled tabIndex="-1">
-          {t('openWindows')}
-        </ListSubheader>
-        {
-          windowIds.map((windowId, i) => (
-            <MenuItem
-              key={windowId}
-              selected={windowId === focusedWindowId}
-              onClick={(e) => { focusWindow(windowId, true); handleClose(e); }}
-            >
-              <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
-                {
-                  this.titleContent(windowId)
-                }
-              </ListItemText>
-            </MenuItem>
-          ))
-        }
-      </Menu>
-    );
-  }
+export function WindowList({
+  container = null, handleClose, windowIds, focusWindow, focusedWindowId = null,
+  t = key => key, titles = {}, tReady = false, ...menuProps
+}) {
+  return (
+    <Menu
+      anchorOrigin={{
+        horizontal: 'right',
+        vertical: 'top',
+      }}
+      transformOrigin={{
+        horizontal: 'left',
+        vertical: 'top',
+      }}
+      id="window-list-menu"
+      container={container?.current}
+      onClose={handleClose}
+      {...menuProps}
+    >
+      <ListSubheader role="presentation" selected={false} disabled tabIndex="-1">
+        {t('openWindows')}
+      </ListSubheader>
+      {
+        windowIds.map((windowId, i) => (
+          <MenuItem
+            key={windowId}
+            selected={windowId === focusedWindowId}
+            onClick={(e) => { focusWindow(windowId, true); handleClose(e); }}
+          >
+            <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
+              {
+                titles[windowId] || t('untitled')
+              }
+            </ListItemText>
+          </MenuItem>
+        ))
+      }
+    </Menu>
+  );
 }
 
 WindowList.propTypes = {
@@ -75,12 +56,4 @@ WindowList.propTypes = {
   titles: PropTypes.objectOf(PropTypes.string),
   tReady: PropTypes.bool,
   windowIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-};
-
-WindowList.defaultProps = {
-  container: null,
-  focusedWindowId: null,
-  t: key => key,
-  titles: {},
-  tReady: false,
 };

--- a/src/components/WindowListButton.js
+++ b/src/components/WindowListButton.js
@@ -1,81 +1,56 @@
-import { Component } from 'react';
-import BookmarksIcon from '@mui/icons-material/BookmarksSharp';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
+import BookmarksIcon from '@mui/icons-material/BookmarksSharp';
 import WindowList from '../containers/WindowList';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 
 /**
  * WindowListButton ~
 */
-export class WindowListButton extends Component {
+export function WindowListButton({ disabled = false, t, windowCount }) {
+  const [windowListAnchor, setWindowListAnchor] = useState(null);
+
   /** */
-  constructor(props) {
-    super(props);
+  const handleClose = () => { setWindowListAnchor(null); };
+  /** */
+  const handleOpen = (event) => { setWindowListAnchor(event.currentTarget); };
 
-    this.state = { windowListAnchor: null };
-    this.handleClose = this.handleClose.bind(this);
-    this.handleOpen = this.handleOpen.bind(this);
-  }
-
-  /** Set the windowListAnchor to null on window close */
-  handleClose() {
-    this.setState({ windowListAnchor: null });
-  }
-
-  /** Set the windowListAnchor to the event's current target  */
-  handleOpen(event) {
-    this.setState({ windowListAnchor: event.currentTarget });
-  }
-
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      disabled, t, windowCount,
-    } = this.props;
-    const { windowListAnchor } = this.state;
-
-    return (
-      <>
-        <MiradorMenuButton
-          aria-haspopup="true"
-          aria-label={t('listAllOpenWindows')}
-          aria-owns={windowListAnchor ? 'window-list' : null}
-          selected={Boolean(windowListAnchor)}
-          disabled={disabled}
-          badge
-          BadgeProps={{
-            badgeContent: windowCount,
-            sx: {
-              '.MuiBadge-badge': {
-                paddingLeft: 1.5,
-              },
+  return (
+    <>
+      <MiradorMenuButton
+        aria-haspopup="true"
+        aria-label={t('listAllOpenWindows')}
+        aria-owns={windowListAnchor ? 'window-list' : null}
+        selected={Boolean(windowListAnchor)}
+        disabled={disabled}
+        badge
+        BadgeProps={{
+          badgeContent: windowCount,
+          sx: {
+            '.MuiBadge-badge': {
+              paddingLeft: 1.5,
             },
-          }}
-          onClick={(e) => this.handleOpen(e)}
-        >
-          <BookmarksIcon />
-        </MiradorMenuButton>
+          },
+        }}
+        onClick={(e) => handleOpen(e)}
+      >
+        <BookmarksIcon />
+      </MiradorMenuButton>
 
-        {Boolean(windowListAnchor) && (
-        <WindowList
-          anchorEl={windowListAnchor}
-          id="window-list"
-          open={Boolean(windowListAnchor)}
-          handleClose={this.handleClose}
-        />
-        )}
-      </>
-    );
-  }
+      {Boolean(windowListAnchor) && (
+      <WindowList
+        anchorEl={windowListAnchor}
+        id="window-list"
+        open={Boolean(windowListAnchor)}
+        handleClose={handleClose}
+      />
+      )}
+    </>
+  );
 }
 
 WindowListButton.propTypes = {
   disabled: PropTypes.bool,
   t: PropTypes.func.isRequired,
   windowCount: PropTypes.number.isRequired,
-};
-WindowListButton.defaultProps = {
-  disabled: false,
 };

--- a/src/components/WindowSideBar.js
+++ b/src/components/WindowSideBar.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Drawer from '@mui/material/Drawer';
@@ -18,33 +17,25 @@ const Nav = styled('nav', { name: 'WindowSideBar', slot: 'nav' })({
 /**
  * WindowSideBar
  */
-export class WindowSideBar extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      classes, direction, t, windowId, sideBarOpen,
-    } = this.props;
-
-    return (
-      <Root
-        variant="persistent"
-        className={classes.drawer}
-        anchor={direction === 'rtl' ? 'right' : 'left'}
-        PaperProps={{
-          'aria-label': t('sidebarPanelsNavigation'),
-          component: Nav,
-          variant: 'outlined',
-        }}
-        SlideProps={{ direction: direction === 'rtl' ? 'left' : 'right', mountOnEnter: true, unmountOnExit: true }}
-        open={sideBarOpen}
-      >
-        <WindowSideBarButtons windowId={windowId} />
-      </Root>
-    );
-  }
+export function WindowSideBar({
+  classes = {}, direction, t, windowId, sideBarOpen = false,
+}) {
+  return (
+    <Root
+      variant="persistent"
+      className={classes.drawer}
+      anchor={direction === 'rtl' ? 'right' : 'left'}
+      PaperProps={{
+        'aria-label': t('sidebarPanelsNavigation'),
+        component: Nav,
+        variant: 'outlined',
+      }}
+      SlideProps={{ direction: direction === 'rtl' ? 'left' : 'right', mountOnEnter: true, unmountOnExit: true }}
+      open={sideBarOpen}
+    >
+      <WindowSideBarButtons windowId={windowId} />
+    </Root>
+  );
 }
 
 WindowSideBar.propTypes = {
@@ -53,9 +44,4 @@ WindowSideBar.propTypes = {
   sideBarOpen: PropTypes.bool,
   t: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowSideBar.defaultProps = {
-  classes: {},
-  sideBarOpen: false,
 };

--- a/src/components/WindowSideBarAnnotationsPanel.js
+++ b/src/components/WindowSideBarAnnotationsPanel.js
@@ -1,4 +1,4 @@
-import { createRef, Component } from 'react';
+import { createRef } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import AnnotationSettings from '../containers/AnnotationSettings';
@@ -10,47 +10,35 @@ import ns from '../config/css-ns';
 /**
  * WindowSideBarAnnotationsPanel ~
 */
-export class WindowSideBarAnnotationsPanel extends Component {
-  /** */
-  constructor(props) {
-    super(props);
+export function WindowSideBarAnnotationsPanel({
+  annotationCount, canvasIds = [], t = k => k, windowId, id,
+}) {
+  const containerRef = createRef();
+  return (
+    <CompanionWindow
+      title={t('annotations')}
+      paperClassName={ns('window-sidebar-annotation-panel')}
+      windowId={windowId}
+      id={id}
+      ref={containerRef}
+      titleControls={<AnnotationSettings windowId={windowId} />}
+    >
+      <CompanionWindowSection>
+        <Typography component="p" variant="subtitle2">{t('showingNumAnnotations', { count: annotationCount, number: annotationCount })}</Typography>
+      </CompanionWindowSection>
 
-    this.containerRef = createRef();
-  }
-
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      annotationCount, canvasIds, t, windowId, id,
-    } = this.props;
-    return (
-      <CompanionWindow
-        title={t('annotations')}
-        paperClassName={ns('window-sidebar-annotation-panel')}
-        windowId={windowId}
-        id={id}
-        ref={this.containerRef}
-        titleControls={<AnnotationSettings windowId={windowId} />}
-      >
-        <CompanionWindowSection>
-          <Typography component="p" variant="subtitle2">{t('showingNumAnnotations', { count: annotationCount, number: annotationCount })}</Typography>
-        </CompanionWindowSection>
-
-        {canvasIds.map((canvasId, index) => (
-          <CanvasAnnotations
-            canvasId={canvasId}
-            containerRef={this.containerRef}
-            key={canvasId}
-            index={index}
-            totalSize={canvasIds.length}
-            windowId={windowId}
-          />
-        ))}
-      </CompanionWindow>
-    );
-  }
+      {canvasIds.map((canvasId, index) => (
+        <CanvasAnnotations
+          canvasId={canvasId}
+          containerRef={containerRef}
+          key={canvasId}
+          index={index}
+          totalSize={canvasIds.length}
+          windowId={windowId}
+        />
+      ))}
+    </CompanionWindow>
+  );
 }
 
 WindowSideBarAnnotationsPanel.propTypes = {
@@ -59,9 +47,4 @@ WindowSideBarAnnotationsPanel.propTypes = {
   id: PropTypes.string.isRequired,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowSideBarAnnotationsPanel.defaultProps = {
-  canvasIds: [],
-  t: key => key,
 };

--- a/src/components/WindowSideBarButtons.js
+++ b/src/components/WindowSideBarButtons.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Badge from '@mui/material/Badge';
@@ -76,126 +75,98 @@ TabButton.propTypes = {
 /**
  *
  */
-export class WindowSideBarButtons extends Component {
+export function WindowSideBarButtons({
+  addCompanionWindow,
+  hasAnnotations = false,
+  hasAnyAnnotations = false,
+  hasAnyLayers = false,
+  hasCurrentLayers = false,
+  hasSearchResults = false,
+  hasSearchService = false,
+  panels = [],
+  PluginComponents = null,
+  sideBarPanel = 'closed',
+  t = k => k,
+}) {
   /** */
-  constructor(props) {
-    super(props);
-    this.handleChange = this.handleChange.bind(this);
-  }
+  const handleChange = (event, value) => { addCompanionWindow(value); };
 
-  /**
-   * @param {object} event the change event
-   * @param {string} value the tab's value
-  */
-  handleChange(event, value) {
-    const { addCompanionWindow } = this.props;
-
-    addCompanionWindow(value);
-  }
-
-  /**
-   * render
-   *
-   * @return {type}  description
-   */
-  render() {
-    const {
-      hasAnnotations,
-      hasAnyAnnotations,
-      hasAnyLayers,
-      hasCurrentLayers,
-      hasSearchResults,
-      hasSearchService,
-      panels,
-      PluginComponents,
-      sideBarPanel,
-      t,
-    } = this.props;
-
-    return (
-      <Root
-        value={sideBarPanel === 'closed' ? false : sideBarPanel}
-        onChange={this.handleChange}
-        variant="fullWidth"
-        indicatorColor="primary"
-        textColor="primary"
-        orientation="vertical"
-        aria-orientation="vertical"
-        aria-label={t('sidebarPanelsNavigation')}
-      >
-        { panels.info && (
+  return (
+    <Root
+      value={sideBarPanel === 'closed' ? false : sideBarPanel}
+      onChange={handleChange}
+      variant="fullWidth"
+      indicatorColor="primary"
+      textColor="primary"
+      orientation="vertical"
+      aria-orientation="vertical"
+      aria-label={t('sidebarPanelsNavigation')}
+    >
+      { panels.info && (
+        <TabButton
+          value="info"
+          t={t}
+          icon={(<InfoIcon />)}
+        />
+      )}
+      { panels.attribution && (
+        <TabButton
+          value="attribution"
+          t={t}
+          icon={(<AttributionIcon />)}
+        />
+      )}
+      { panels.canvas && (
+        <TabButton
+          value="canvas"
+          t={t}
+          icon={(<CanvasIndexIcon />)}
+        />
+      )}
+      {panels.annotations && (hasAnnotations || hasAnyAnnotations) && (
+        <TabButton
+          value="annotations"
+          t={t}
+          icon={(
+            <Badge overlap="rectangular" color="notification" invisible={!hasAnnotations} variant="dot">
+              <AnnotationIcon />
+            </Badge>
+          )}
+        />
+      )}
+      {panels.search && hasSearchService && (
+        <TabButton
+          value="search"
+          t={t}
+          icon={(
+            <Badge overlap="rectangular" color="notification" invisible={!hasSearchResults} variant="dot">
+              <SearchIcon />
+            </Badge>
+          )}
+        />
+      )}
+      { panels.layers && hasAnyLayers && (
+        <TabButton
+          value="layers"
+          t={t}
+          icon={(
+            <Badge overlap="rectangular" color="notification" invisible={!hasCurrentLayers} variant="dot">
+              <LayersIcon />
+            </Badge>
+          )}
+        />
+      )}
+      { PluginComponents
+        && PluginComponents.map(PluginComponent => (
           <TabButton
-            value="info"
-            onKeyUp={this.handleKeyUp}
             t={t}
-            icon={(<InfoIcon />)}
+            key={PluginComponent.value}
+            value={PluginComponent.value}
+            icon={<PluginComponent />}
           />
-        )}
-        { panels.attribution && (
-          <TabButton
-            value="attribution"
-            onKeyUp={this.handleKeyUp}
-            t={t}
-            icon={(<AttributionIcon />)}
-          />
-        )}
-        { panels.canvas && (
-          <TabButton
-            value="canvas"
-            onKeyUp={this.handleKeyUp}
-            t={t}
-            icon={(<CanvasIndexIcon />)}
-          />
-        )}
-        {panels.annotations && (hasAnnotations || hasAnyAnnotations) && (
-          <TabButton
-            value="annotations"
-            onKeyUp={this.handleKeyUp}
-            t={t}
-            icon={(
-              <Badge overlap="rectangular" color="notification" invisible={!hasAnnotations} variant="dot">
-                <AnnotationIcon />
-              </Badge>
-            )}
-          />
-        )}
-        {panels.search && hasSearchService && (
-          <TabButton
-            value="search"
-            onKeyUp={this.handleKeyUp}
-            t={t}
-            icon={(
-              <Badge overlap="rectangular" color="notification" invisible={!hasSearchResults} variant="dot">
-                <SearchIcon />
-              </Badge>
-            )}
-          />
-        )}
-        { panels.layers && hasAnyLayers && (
-          <TabButton
-            value="layers"
-            onKeyUp={this.handleKeyUp}
-            t={t}
-            icon={(
-              <Badge overlap="rectangular" color="notification" invisible={!hasCurrentLayers} variant="dot">
-                <LayersIcon />
-              </Badge>
-            )}
-          />
-        )}
-        { PluginComponents
-          && PluginComponents.map(PluginComponent => (
-            <TabButton
-              onKeyUp={this.handleKeyUp}
-              t={t}
-              key={PluginComponent.value}
-              value={PluginComponent.value}
-              icon={<PluginComponent />}
-            />
-          ))}
-      </Root>
-    );
-  }
+        ))}
+    </Root>
+  );
 }
 
 WindowSideBarButtons.propTypes = {
@@ -210,17 +181,4 @@ WindowSideBarButtons.propTypes = {
   PluginComponents: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   sideBarPanel: PropTypes.string,
   t: PropTypes.func,
-};
-
-WindowSideBarButtons.defaultProps = {
-  hasAnnotations: false,
-  hasAnyAnnotations: false,
-  hasAnyLayers: false,
-  hasCurrentLayers: false,
-  hasSearchResults: false,
-  hasSearchService: false,
-  panels: [],
-  PluginComponents: null,
-  sideBarPanel: 'closed',
-  t: key => key,
 };

--- a/src/components/WindowSideBarCanvasPanel.js
+++ b/src/components/WindowSideBarCanvasPanel.js
@@ -1,4 +1,4 @@
-import { createRef, Component } from 'react';
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Tabs from '@mui/material/Tabs';
@@ -21,149 +21,134 @@ const StyledBreak = styled('div')(() => ({
   flexBasis: '100%',
   height: 0,
 }));
+
+/** */
+function getUseableLabel(resource, index) {
+  return (resource
+    && resource.getLabel
+    && resource.getLabel().length > 0)
+    ? resource.getLabel().getValue()
+    : resource.id;
+}
+
 /**
  * a panel showing the canvases for a given manifest
  */
-export class WindowSideBarCanvasPanel extends Component {
+export function WindowSideBarCanvasPanel({
+  collection = null,
+  id,
+  showMultipart,
+  sequenceId = null,
+  sequences = [],
+  t,
+  variant,
+  showToc = false,
+  updateSequence,
+  updateVariant,
+  windowId,
+}) {
+  const containerRef = useRef();
+
   /** */
-  constructor(props) {
-    super(props);
-    this.handleSequenceChange = this.handleSequenceChange.bind(this);
-    this.handleVariantChange = this.handleVariantChange.bind(this);
-
-    this.containerRef = createRef();
-  }
-
-  /** */
-  static getUseableLabel(resource, index) {
-    return (resource
-      && resource.getLabel
-      && resource.getLabel().length > 0)
-      ? resource.getLabel().getValue()
-      : resource.id;
-  }
-
-  /** @private */
-  handleSequenceChange(event) {
-    const { updateSequence } = this.props;
-
+  const handleSequenceChange = (event) => {
     updateSequence(event.target.value);
-  }
+  };
 
-  /** @private */
-  handleVariantChange(event, value) {
-    const { updateVariant } = this.props;
-
+  /** */
+  const handleVariantChange = (event, value) => {
     updateVariant(value);
-  }
+  };
 
-  /**
-   * render
-   */
-  render() {
-    const {
-      collection,
-      id,
-      showMultipart,
-      sequenceId,
-      sequences,
-      t,
-      variant,
-      showToc,
-      windowId,
-    } = this.props;
+  let listComponent;
 
-    let listComponent;
-
-    if (variant === 'tableOfContents') {
-      listComponent = (
-        <SidebarIndexTableOfContents
-          id={id}
-          containerRef={this.containerRef}
-          windowId={windowId}
-        />
-      );
-    } else {
-      listComponent = (
-        <SidebarIndexList
-          id={id}
-          containerRef={this.containerRef}
-          windowId={windowId}
-        />
-      );
-    }
-
-    return (
-      <CompanionWindow
-        title={t('canvasIndex')}
+  if (variant === 'tableOfContents') {
+    listComponent = (
+      <SidebarIndexTableOfContents
         id={id}
+        containerRef={containerRef}
         windowId={windowId}
-        ref={this.containerRef}
-        titleControls={(
-          <>
-            {
-              sequences && sequences.length > 1 && (
-                <FormControl>
-                  <Select
-                    MenuProps={{
-                      anchorOrigin: {
-                        horizontal: 'left',
-                        vertical: 'bottom',
-                      },
-                    }}
-                    displayEmpty
-                    value={sequenceId}
-                    onChange={this.handleSequenceChange}
-                    name="sequenceId"
-                    sx={{
-                      '&.MuiSelect-select': {
-                        '&:focus': {
-                          backgroundColor: 'background.paper',
-                        },
-                      },
-                      backgroundColor: 'background.paper',
-                    }}
-                    data-testid="sequence-select"
-                  >
-                    { sequences.map((s, i) => <MenuItem value={s.id} key={s.id}><Typography variant="body2">{ WindowSideBarCanvasPanel.getUseableLabel(s, i) }</Typography></MenuItem>) }
-                  </Select>
-                </FormControl>
-              )
-            }
-            <StyledBreak />
-            <Tabs
-              value={variant}
-              onChange={this.handleVariantChange}
-              variant="fullWidth"
-              indicatorColor="primary"
-              textColor="primary"
-            >
-              {showToc && (
-                <Tooltip title={t('tableOfContentsList')} value="tableOfContents"><Tab sx={{ minWidth: 'auto' }} value="tableOfContents" aria-label={t('tableOfContentsList')} aria-controls={`tab-panel-${id}`} icon={<TocIcon style={{ transform: 'scale(-1, 1)' }} />} /></Tooltip>
-              )}
-              <Tooltip title={t('itemList')} value="item"><Tab sx={{ minWidth: 'auto' }} value="item" aria-label={t('itemList')} aria-controls={`tab-panel-${id}`} icon={<ItemListIcon />} /></Tooltip>
-              <Tooltip title={t('thumbnailList')} value="thumbnail"><Tab sx={{ minWidth: 'auto' }} value="thumbnail" aria-label={t('thumbnailList')} aria-controls={`tab-panel-${id}`} icon={<ThumbnailListIcon />} /></Tooltip>
-            </Tabs>
-          </>
-        )}
-      >
-        <div id={`tab-panel-${id}`}>
-          { collection && (
-            <Button
-              fullWidth
-              onClick={showMultipart}
-              endIcon={<ArrowForwardIcon />}
-            >
-              <Typography sx={{ textTransform: 'none' }}>
-                {WindowSideBarCanvasPanel.getUseableLabel(collection)}
-              </Typography>
-            </Button>
-          )}
-          {listComponent}
-        </div>
-      </CompanionWindow>
+      />
+    );
+  } else {
+    listComponent = (
+      <SidebarIndexList
+        id={id}
+        containerRef={containerRef}
+        windowId={windowId}
+      />
     );
   }
+
+  return (
+    <CompanionWindow
+      title={t('canvasIndex')}
+      id={id}
+      windowId={windowId}
+      ref={containerRef}
+      titleControls={(
+        <>
+          {
+            sequences && sequences.length > 1 && (
+              <FormControl>
+                <Select
+                  MenuProps={{
+                    anchorOrigin: {
+                      horizontal: 'left',
+                      vertical: 'bottom',
+                    },
+                  }}
+                  displayEmpty
+                  value={sequenceId}
+                  onChange={handleSequenceChange}
+                  name="sequenceId"
+                  sx={{
+                    '&.MuiSelect-select': {
+                      '&:focus': {
+                        backgroundColor: 'background.paper',
+                      },
+                    },
+                    backgroundColor: 'background.paper',
+                  }}
+                  data-testid="sequence-select"
+                >
+                  { sequences.map((s, i) => <MenuItem value={s.id} key={s.id}><Typography variant="body2">{ getUseableLabel(s, i) }</Typography></MenuItem>) }
+                </Select>
+              </FormControl>
+            )
+          }
+          <StyledBreak />
+          <Tabs
+            value={variant}
+            onChange={handleVariantChange}
+            variant="fullWidth"
+            indicatorColor="primary"
+            textColor="primary"
+          >
+            {showToc && (
+              <Tooltip title={t('tableOfContentsList')} value="tableOfContents"><Tab sx={{ minWidth: 'auto' }} value="tableOfContents" aria-label={t('tableOfContentsList')} aria-controls={`tab-panel-${id}`} icon={<TocIcon style={{ transform: 'scale(-1, 1)' }} />} /></Tooltip>
+            )}
+            <Tooltip title={t('itemList')} value="item"><Tab sx={{ minWidth: 'auto' }} value="item" aria-label={t('itemList')} aria-controls={`tab-panel-${id}`} icon={<ItemListIcon />} /></Tooltip>
+            <Tooltip title={t('thumbnailList')} value="thumbnail"><Tab sx={{ minWidth: 'auto' }} value="thumbnail" aria-label={t('thumbnailList')} aria-controls={`tab-panel-${id}`} icon={<ThumbnailListIcon />} /></Tooltip>
+          </Tabs>
+        </>
+      )}
+    >
+      <div id={`tab-panel-${id}`}>
+        { collection && (
+          <Button
+            fullWidth
+            onClick={showMultipart}
+            endIcon={<ArrowForwardIcon />}
+          >
+            <Typography sx={{ textTransform: 'none' }}>
+              {getUseableLabel(collection)}
+            </Typography>
+          </Button>
+        )}
+        {listComponent}
+      </div>
+    </CompanionWindow>
+  );
 }
 
 WindowSideBarCanvasPanel.propTypes = {
@@ -178,11 +163,4 @@ WindowSideBarCanvasPanel.propTypes = {
   updateVariant: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(['item', 'thumbnail', 'tableOfContents']).isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowSideBarCanvasPanel.defaultProps = {
-  collection: null,
-  sequenceId: null,
-  sequences: [],
-  showToc: false,
 };

--- a/src/components/WindowSideBarCollectionPanel.js
+++ b/src/components/WindowSideBarCollectionPanel.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -11,6 +10,15 @@ import Skeleton from '@mui/material/Skeleton';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpwardSharp';
 import CompanionWindow from '../containers/CompanionWindow';
 import IIIFThumbnail from '../containers/IIIFThumbnail';
+
+/** */
+function getUseableLabel(resource, index) {
+  return (resource
+    && resource.getLabel
+    && resource.getLabel().length > 0)
+    ? resource.getLabel().getValue()
+    : resource.id;
+}
 
 /** */
 function Item({
@@ -37,7 +45,7 @@ function Item({
           />
         </ListItemIcon>
       )}
-      <ListItemText>{WindowSideBarCollectionPanel.getUseableLabel(manifest)}</ListItemText>
+      <ListItemText>{getUseableLabel(manifest)}</ListItemText>
     </MenuItem>
   );
 }
@@ -52,20 +60,22 @@ Item.propTypes = {
 };
 
 /** */
-export class WindowSideBarCollectionPanel extends Component {
+export function WindowSideBarCollectionPanel({
+  canvasNavigation,
+  collectionPath = [],
+  collection = null,
+  id,
+  isFetching = false,
+  manifestId,
+  parentCollection = null,
+  updateCompanionWindow,
+  updateWindow,
+  t = k => k,
+  variant = null,
+  windowId,
+}) {
   /** */
-  static getUseableLabel(resource, index) {
-    return (resource
-      && resource.getLabel
-      && resource.getLabel().length > 0)
-      ? resource.getLabel().getValue()
-      : resource.id;
-  }
-
-  /** */
-  isMultipart() {
-    const { collection } = this.props;
-
+  const isMultipart = (() => {
     if (!collection) return false;
 
     const behaviors = collection.getProperty('behavior');
@@ -73,112 +83,94 @@ export class WindowSideBarCollectionPanel extends Component {
     if (Array.isArray(behaviors)) return behaviors.includes('multi-part');
 
     return behaviors === 'multi-part';
-  }
+  })();
 
-  /** */
-  render() {
-    const {
-      canvasNavigation,
-      collectionPath,
-      collection,
-      id,
-      isFetching,
-      manifestId,
-      parentCollection,
-      updateCompanionWindow,
-      updateWindow,
-      t,
-      variant,
-      windowId,
-    } = this.props;
-
-    return (
-      <CompanionWindow
-        title={t(this.isMultipart() ? 'multipartCollection' : 'collection')}
-        windowId={windowId}
-        id={id}
-        titleControls={(
-          <>
-            { parentCollection && (
-              <List>
-                <ListItem
-                  button
-                  onClick={
-                    () => updateCompanionWindow({ collectionPath: collectionPath.slice(0, -1) })
-                  }
-                >
-                  <ListItemIcon>
-                    <ArrowUpwardIcon />
-                  </ListItemIcon>
-                  <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
-                    {WindowSideBarCollectionPanel.getUseableLabel(parentCollection)}
-                  </ListItemText>
-                </ListItem>
-              </List>
-            )}
-            <Typography variant="h6">
-              { collection && WindowSideBarCollectionPanel.getUseableLabel(collection)}
-              { isFetching && <Skeleton variant="text" />}
-            </Typography>
-          </>
-        )}
-      >
-        <MenuList>
-          { isFetching && (
-            <MenuItem>
-              <ListItemText>
-                <Skeleton variant="text" />
-                <Skeleton variant="text" />
-                <Skeleton variant="text" />
-              </ListItemText>
-            </MenuItem>
+  return (
+    <CompanionWindow
+      title={t(isMultipart ? 'multipartCollection' : 'collection')}
+      windowId={windowId}
+      id={id}
+      titleControls={(
+        <>
+          { parentCollection && (
+            <List>
+              <ListItem
+                button
+                onClick={
+                  () => updateCompanionWindow({ collectionPath: collectionPath.slice(0, -1) })
+                }
+              >
+                <ListItemIcon>
+                  <ArrowUpwardIcon />
+                </ListItemIcon>
+                <ListItemText primaryTypographyProps={{ variant: 'body1' }}>
+                  {getUseableLabel(parentCollection)}
+                </ListItemText>
+              </ListItem>
+            </List>
           )}
-          {
-            collection && collection.getCollections().map((manifest) => {
-              /** select the new manifest and go back to the normal index */
-              const onClick = () => {
-                // close collection
-                updateCompanionWindow({ collectionPath: [...collectionPath, manifest.id] });
-              };
+          <Typography variant="h6">
+            { collection && getUseableLabel(collection)}
+            { isFetching && <Skeleton variant="text" />}
+          </Typography>
+        </>
+      )}
+    >
+      <MenuList>
+        { isFetching && (
+          <MenuItem>
+            <ListItemText>
+              <Skeleton variant="text" />
+              <Skeleton variant="text" />
+              <Skeleton variant="text" />
+            </ListItemText>
+          </MenuItem>
+        )}
+        {
+          collection && collection.getCollections().map((manifest) => {
+            /** select the new manifest and go back to the normal index */
+            const onClick = () => {
+              // close collection
+              updateCompanionWindow({ collectionPath: [...collectionPath, manifest.id] });
+            };
 
-              return (
-                <Item
-                  key={manifest.id}
-                  onClick={onClick}
-                  canvasNavigation={canvasNavigation}
-                  manifest={manifest}
-                  variant={variant}
-                  selected={manifestId === manifest.id}
-                />
-              );
-            })
-          }
-          {
-            collection && collection.getManifests().map((manifest) => {
-              /** select the new manifest and go back to the normal index */
-              const onClick = () => {
-                // select new manifest
-                updateWindow({ canvasId: null, collectionPath, manifestId: manifest.id });
-                // close collection
-                updateCompanionWindow({ multipart: false });
-              };
+            return (
+              <Item
+                key={manifest.id}
+                onClick={onClick}
+                canvasNavigation={canvasNavigation}
+                manifest={manifest}
+                variant={variant}
+                selected={manifestId === manifest.id}
+              />
+            );
+          })
+        }
+        {
+          collection && collection.getManifests().map((manifest) => {
+            /** select the new manifest and go back to the normal index */
+            const onClick = () => {
+              // select new manifest
+              updateWindow({ canvasId: null, collectionPath, manifestId: manifest.id });
+              // close collection
+              updateCompanionWindow({ multipart: false });
+            };
 
-              return (
-                <Item
-                  key={manifest.id}
-                  onClick={onClick}
-                  canvasNavigation={canvasNavigation}
-                  manifest={manifest}
-                  variant={variant}
-                  selected={manifestId === manifest.id}
-                />
-              );
-            })
-          }
-        </MenuList>
-      </CompanionWindow>
-    );
-  }
+            return (
+              <Item
+                key={manifest.id}
+                onClick={onClick}
+                canvasNavigation={canvasNavigation}
+                manifest={manifest}
+                variant={variant}
+                selected={manifestId === manifest.id}
+              />
+            );
+          })
+        }
+      </MenuList>
+    </CompanionWindow>
+  );
 }
 
 WindowSideBarCollectionPanel.propTypes = {
@@ -197,13 +189,4 @@ WindowSideBarCollectionPanel.propTypes = {
   updateWindow: PropTypes.func.isRequired,
   variant: PropTypes.string,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowSideBarCollectionPanel.defaultProps = {
-  collection: null,
-  collectionPath: [],
-  isFetching: false,
-  parentCollection: null,
-  t: k => k,
-  variant: null,
 };

--- a/src/components/WindowSideBarInfoPanel.js
+++ b/src/components/WindowSideBarInfoPanel.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import CompanionWindow from '../containers/CompanionWindow';
 import { CompanionWindowSection } from './CompanionWindowSection';
@@ -12,72 +11,64 @@ import ns from '../config/css-ns';
 /**
  * WindowSideBarInfoPanel
  */
-export class WindowSideBarInfoPanel extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      windowId,
-      id,
-      canvasIds,
-      collectionPath,
-      t,
-      locale,
-      setLocale,
-      availableLocales,
-      showLocalePicker,
-    } = this.props;
-
-    return (
-      <CompanionWindow
-        title={t('aboutThisItem')}
-        paperClassName={ns('window-sidebar-info-panel')}
-        windowId={windowId}
-        id={id}
-        titleControls={(
-          showLocalePicker
-            && (
-            <LocalePicker
-              locale={locale}
-              setLocale={setLocale}
-              availableLocales={availableLocales}
+export function WindowSideBarInfoPanel({
+  windowId,
+  id,
+  canvasIds = [],
+  collectionPath = [],
+  t = k => k,
+  locale = '',
+  setLocale = undefined,
+  availableLocales = [],
+  showLocalePicker = false,
+}) {
+  return (
+    <CompanionWindow
+      title={t('aboutThisItem')}
+      paperClassName={ns('window-sidebar-info-panel')}
+      windowId={windowId}
+      id={id}
+      titleControls={(
+        showLocalePicker
+          && (
+          <LocalePicker
+            locale={locale}
+            setLocale={setLocale}
+            availableLocales={availableLocales}
+          />
+          )
+      )}
+    >
+      {
+        canvasIds.map((canvasId, index) => (
+          <CompanionWindowSection
+            key={canvasId}
+          >
+            <CanvasInfo
+              id={id}
+              canvasId={canvasId}
+              index={index}
+              totalSize={canvasIds.length}
+              windowId={windowId}
             />
-            )
-        )}
-      >
-        {
-          canvasIds.map((canvasId, index) => (
-            <CompanionWindowSection
-              key={canvasId}
-            >
-              <CanvasInfo
-                id={id}
-                canvasId={canvasId}
-                index={index}
-                totalSize={canvasIds.length}
-                windowId={windowId}
-              />
-            </CompanionWindowSection>
-          ))
-        }
-        { collectionPath.length > 0 && (
-          <CompanionWindowSection>
-            <CollectionInfo id={id} windowId={windowId} />
           </CompanionWindowSection>
-        )}
-
+        ))
+      }
+      { collectionPath.length > 0 && (
         <CompanionWindowSection>
-          <ManifestInfo id={id} windowId={windowId} />
+          <CollectionInfo id={id} windowId={windowId} />
         </CompanionWindowSection>
+      )}
 
-        <CompanionWindowSection>
-          <ManifestRelatedLinks id={id} windowId={windowId} />
-        </CompanionWindowSection>
-      </CompanionWindow>
-    );
-  }
+      <CompanionWindowSection>
+        <ManifestInfo id={id} windowId={windowId} />
+      </CompanionWindowSection>
+
+      <CompanionWindowSection>
+        <ManifestRelatedLinks id={id} windowId={windowId} />
+      </CompanionWindowSection>
+    </CompanionWindow>
+  );
 }
 
 WindowSideBarInfoPanel.propTypes = {
@@ -90,14 +81,4 @@ WindowSideBarInfoPanel.propTypes = {
   showLocalePicker: PropTypes.bool,
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowSideBarInfoPanel.defaultProps = {
-  availableLocales: [],
-  canvasIds: [],
-  collectionPath: [],
-  locale: '',
-  setLocale: undefined,
-  showLocalePicker: false,
-  t: key => key,
 };

--- a/src/components/WindowThumbnailSettings.js
+++ b/src/components/WindowThumbnailSettings.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import { styled } from '@mui/material/styles';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import ListSubheader from '@mui/material/ListSubheader';
@@ -31,75 +30,52 @@ const ThumbnailOption = styled(MenuItem, { name: 'WindowThumbnailSettings', slot
 /**
  *
  */
-export class WindowThumbnailSettings extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.handleChange = this.handleChange.bind(this);
-  }
+export function WindowThumbnailSettings({
+  handleClose = () => {}, t = k => k, thumbnailNavigationPosition, direction, windowId, setWindowThumbnailPosition,
+}) {
+  /** */
+  const handleChange = (value) => { setWindowThumbnailPosition(windowId, value); handleClose(); };
 
-  /**
-   * @private
-   */
-  handleChange(value) {
-    const { windowId, setWindowThumbnailPosition } = this.props;
+  return (
+    <>
+      <ListSubheader role="presentation" disableSticky tabIndex={-1}>{t('thumbnails')}</ListSubheader>
 
-    setWindowThumbnailPosition(windowId, value);
-  }
-
-  /**
-   * render
-   *
-   * @return {type}  description
-   */
-  render() {
-    const {
-      handleClose, t, thumbnailNavigationPosition, direction,
-    } = this.props;
-
-    return (
-      <>
-        <ListSubheader role="presentation" disableSticky tabIndex={-1}>{t('thumbnails')}</ListSubheader>
-
-        <ThumbnailOption selected={thumbnailNavigationPosition === 'off'} onClick={() => { this.handleChange('off'); handleClose(); }}>
-          <FormControlLabel
-            value="off"
-            control={
-              <ThumbnailsOffIcon color={thumbnailNavigationPosition === 'off' ? 'secondary' : undefined} fill="currentcolor" />
-            }
-            label={t('off')}
-            labelPlacement="bottom"
-          />
-        </ThumbnailOption>
-        <ThumbnailOption selected={thumbnailNavigationPosition === 'far-bottom'} onClick={() => { this.handleChange('far-bottom'); handleClose(); }}>
-          <FormControlLabel
-            value="far-bottom"
-            control={
-              <ThumbnailNavigationBottomIcon color={thumbnailNavigationPosition === 'far-bottom' ? 'secondary' : undefined} fill="currentcolor" />
-            }
-            label={t('bottom')}
-            labelPlacement="bottom"
-          />
-        </ThumbnailOption>
-        <ThumbnailOption selected={thumbnailNavigationPosition === 'far-right'} onClick={() => { this.handleChange('far-right'); handleClose(); }}>
-          <FormControlLabel
-            value="far-right"
-            control={(
-              <ThumbnailNavigationRightIcon
-                color={thumbnailNavigationPosition === 'far-right' ? 'secondary' : undefined}
-                fill="currentcolor"
-                style={direction === 'rtl' ? { transform: 'rotate(180deg)' } : {}}
-              />
-            )}
-            label={t('right')}
-            labelPlacement="bottom"
-          />
-        </ThumbnailOption>
-      </>
-    );
-  }
+      <ThumbnailOption selected={thumbnailNavigationPosition === 'off'} onClick={() => { handleChange('off'); }}>
+        <FormControlLabel
+          value="off"
+          control={
+            <ThumbnailsOffIcon color={thumbnailNavigationPosition === 'off' ? 'secondary' : undefined} fill="currentcolor" />
+          }
+          label={t('off')}
+          labelPlacement="bottom"
+        />
+      </ThumbnailOption>
+      <ThumbnailOption selected={thumbnailNavigationPosition === 'far-bottom'} onClick={() => { handleChange('far-bottom'); }}>
+        <FormControlLabel
+          value="far-bottom"
+          control={
+            <ThumbnailNavigationBottomIcon color={thumbnailNavigationPosition === 'far-bottom' ? 'secondary' : undefined} fill="currentcolor" />
+          }
+          label={t('bottom')}
+          labelPlacement="bottom"
+        />
+      </ThumbnailOption>
+      <ThumbnailOption selected={thumbnailNavigationPosition === 'far-right'} onClick={() => { handleChange('far-right'); }}>
+        <FormControlLabel
+          value="far-right"
+          control={(
+            <ThumbnailNavigationRightIcon
+              color={thumbnailNavigationPosition === 'far-right' ? 'secondary' : undefined}
+              fill="currentcolor"
+              style={direction === 'rtl' ? { transform: 'rotate(180deg)' } : {}}
+            />
+          )}
+          label={t('right')}
+          labelPlacement="bottom"
+        />
+      </ThumbnailOption>
+    </>
+  );
 }
 
 WindowThumbnailSettings.propTypes = {
@@ -109,8 +85,4 @@ WindowThumbnailSettings.propTypes = {
   t: PropTypes.func,
   thumbnailNavigationPosition: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
-};
-WindowThumbnailSettings.defaultProps = {
-  handleClose: () => {},
-  t: key => key,
 };

--- a/src/components/WindowTopBar.js
+++ b/src/components/WindowTopBar.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/MenuSharp';
@@ -35,70 +34,64 @@ const StyledToolbar = styled(Toolbar, { name: 'WindowTopBar', slot: 'toolbar' })
 /**
  * WindowTopBar
  */
-export class WindowTopBar extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      removeWindow, windowId, toggleWindowSideBar, t,
-      maximizeWindow, maximized, minimizeWindow, allowClose, allowMaximize,
-      focusWindow, allowFullscreen, allowTopMenuButton, allowWindowSideBar,
-      component,
-    } = this.props;
+export function WindowTopBar({
+  removeWindow, windowId, toggleWindowSideBar, t = k => k,
+  maximizeWindow = () => {}, maximized = false, minimizeWindow = () => {}, allowClose = true, allowMaximize = true,
+  focusWindow = () => {}, allowFullscreen = false, allowTopMenuButton = true, allowWindowSideBar = true,
+  component = 'nav',
+}) {
+  const ownerState = arguments[0]; // eslint-disable-line prefer-rest-params
 
-    return (
-      <Root component={component} aria-label={t('windowNavigation')} position="relative" color="default" enableColorOnDark>
-        <StyledToolbar
-          disableGutters
-          onMouseDown={focusWindow}
-          ownerState={this.props}
-          className={classNames(ns('window-top-bar'))}
-          variant="dense"
-        >
-          {allowWindowSideBar && (
-            <MiradorMenuButton
-              aria-label={t('toggleWindowSideBar')}
-              onClick={toggleWindowSideBar}
-              className={ns('window-menu-btn')}
-            >
-              <MenuIcon />
-            </MiradorMenuButton>
-          )}
-          <WindowTopBarTitle
-            windowId={windowId}
-          />
-          {allowTopMenuButton && (
-            <WindowTopMenuButton windowId={windowId} className={ns('window-menu-btn')} />
-          )}
-          <WindowTopBarPluginArea windowId={windowId} />
-          <WindowTopBarPluginMenu windowId={windowId} />
-          {allowMaximize && (
-            <MiradorMenuButton
-              aria-label={(maximized ? t('minimizeWindow') : t('maximizeWindow'))}
-              className={classNames(ns('window-maximize'), ns('window-menu-btn'))}
-              onClick={(maximized ? minimizeWindow : maximizeWindow)}
-            >
-              {(maximized ? <WindowMinIcon /> : <WindowMaxIcon />)}
-            </MiradorMenuButton>
-          )}
-          {allowFullscreen && (
-            <FullScreenButton className={ns('window-menu-btn')} />
-          )}
-          {allowClose && (
-            <MiradorMenuButton
-              aria-label={t('closeWindow')}
-              className={classNames(ns('window-close'), ns('window-menu-btn'))}
-              onClick={removeWindow}
-            >
-              <CloseIcon />
-            </MiradorMenuButton>
-          )}
-        </StyledToolbar>
-      </Root>
-    );
-  }
+  return (
+    <Root component={component} aria-label={t('windowNavigation')} position="relative" color="default" enableColorOnDark>
+      <StyledToolbar
+        disableGutters
+        onMouseDown={focusWindow}
+        ownerState={ownerState}
+        className={classNames(ns('window-top-bar'))}
+        variant="dense"
+      >
+        {allowWindowSideBar && (
+          <MiradorMenuButton
+            aria-label={t('toggleWindowSideBar')}
+            onClick={toggleWindowSideBar}
+            className={ns('window-menu-btn')}
+          >
+            <MenuIcon />
+          </MiradorMenuButton>
+        )}
+        <WindowTopBarTitle
+          windowId={windowId}
+        />
+        {allowTopMenuButton && (
+          <WindowTopMenuButton windowId={windowId} className={ns('window-menu-btn')} />
+        )}
+        <WindowTopBarPluginArea windowId={windowId} />
+        <WindowTopBarPluginMenu windowId={windowId} />
+        {allowMaximize && (
+          <MiradorMenuButton
+            aria-label={(maximized ? t('minimizeWindow') : t('maximizeWindow'))}
+            className={classNames(ns('window-maximize'), ns('window-menu-btn'))}
+            onClick={(maximized ? minimizeWindow : maximizeWindow)}
+          >
+            {(maximized ? <WindowMinIcon /> : <WindowMaxIcon />)}
+          </MiradorMenuButton>
+        )}
+        {allowFullscreen && (
+          <FullScreenButton className={ns('window-menu-btn')} />
+        )}
+        {allowClose && (
+          <MiradorMenuButton
+            aria-label={t('closeWindow')}
+            className={classNames(ns('window-close'), ns('window-menu-btn'))}
+            onClick={removeWindow}
+          >
+            <CloseIcon />
+          </MiradorMenuButton>
+        )}
+      </StyledToolbar>
+    </Root>
+  );
 }
 
 WindowTopBar.propTypes = {
@@ -118,20 +111,4 @@ WindowTopBar.propTypes = {
   toggleWindowSideBar: PropTypes.func.isRequired,
   windowDraggable: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
   windowId: PropTypes.string.isRequired,
-};
-
-WindowTopBar.defaultProps = {
-  allowClose: true,
-  allowFullscreen: false,
-  allowMaximize: true,
-  allowTopMenuButton: true,
-  allowWindowSideBar: true,
-  component: 'nav',
-  focused: false,
-  focusWindow: () => {},
-  maximized: false,
-  maximizeWindow: () => {},
-  minimizeWindow: () => {},
-  t: key => key,
-  windowDraggable: true,
 };

--- a/src/components/WindowTopBarPluginArea.js
+++ b/src/components/WindowTopBarPluginArea.js
@@ -1,14 +1,10 @@
-import { Component } from 'react';
 import { PluginHook } from './PluginHook';
 
 /**
  *
  */
-export class WindowTopBarPluginArea extends Component {
-  /** */
-  render() {
-    return (
-      <PluginHook {...this.props} />
-    );
-  }
+export function WindowTopBarPluginArea(props) {
+  return (
+    <PluginHook {...props} />
+  );
 }

--- a/src/components/WindowTopBarPluginMenu.js
+++ b/src/components/WindowTopBarPluginMenu.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import MoreVertIcon from '@mui/icons-material/MoreVertSharp';
 import Menu from '@mui/material/Menu';
@@ -8,83 +8,59 @@ import { PluginHook } from './PluginHook';
 /**
  *
  */
-export class WindowTopBarPluginMenu extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      open: false,
-    };
-    this.handleMenuClick = this.handleMenuClick.bind(this);
-    this.handleMenuClose = this.handleMenuClose.bind(this);
-  }
+export function WindowTopBarPluginMenu({
+  container = null, PluginComponents = [], t, windowId, menuIcon = <MoreVertIcon />,
+}) {
+  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [open, setOpen] = useState(false);
 
-  /**
-   * Set the anchorEl state to the click target
-   */
-  handleMenuClick(event) {
-    this.setState({
-      anchorEl: event.currentTarget,
-      open: true,
-    });
-  }
+  /** */
+  const handleMenuClick = (event) => {
+    setAnchorEl(event.currentTarget);
+    setOpen(true);
+  };
 
-  /**
-   * Set the anchorEl state to null (closing the menu)
-   */
-  handleMenuClose() {
-    this.setState({
-      anchorEl: null,
-      open: false,
-    });
-  }
+  /** */
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setOpen(false);
+  };
 
-  /**
-   * render component
-   */
-  render() {
-    const {
-      container, PluginComponents, t, windowId, menuIcon,
-    } = this.props;
-    const { anchorEl, open } = this.state;
-    const windowPluginMenuId = `window-plugin-menu_${windowId}`;
-    if (!PluginComponents || PluginComponents.length === 0) return null;
+  const windowPluginMenuId = `window-plugin-menu_${windowId}`;
+  if (!PluginComponents || PluginComponents.length === 0) return null;
 
-    return (
-      <>
-        <MiradorMenuButton
-          aria-haspopup="true"
-          aria-label={t('windowPluginMenu')}
-          aria-owns={open ? windowPluginMenuId : undefined}
-          selected={open}
-          onClick={this.handleMenuClick}
-        >
-          {menuIcon}
-        </MiradorMenuButton>
+  return (
+    <>
+      <MiradorMenuButton
+        aria-haspopup="true"
+        aria-label={t('windowPluginMenu')}
+        aria-owns={open ? windowPluginMenuId : undefined}
+        selected={open}
+        onClick={handleMenuClick}
+      >
+        {menuIcon}
+      </MiradorMenuButton>
 
-        <Menu
-          id={windowPluginMenuId}
-          container={container?.current}
-          anchorEl={anchorEl}
-          anchorOrigin={{
-            horizontal: 'right',
-            vertical: 'bottom',
-          }}
-          transformOrigin={{
-            horizontal: 'right',
-            vertical: 'top',
-          }}
-          open={open}
-          onClose={() => this.handleMenuClose()}
-        >
-          <PluginHook handleClose={() => this.handleMenuClose()} {...this.props} />
-        </Menu>
-      </>
-    );
-  }
+      <Menu
+        id={windowPluginMenuId}
+        container={container?.current}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          horizontal: 'right',
+          vertical: 'bottom',
+        }}
+        transformOrigin={{
+          horizontal: 'right',
+          vertical: 'top',
+        }}
+        open={open}
+        onClose={handleMenuClose}
+      >
+        <PluginHook handleClose={handleMenuClose} {...pluginProps} />
+      </Menu>
+    </>
+  );
 }
 
 WindowTopBarPluginMenu.propTypes = {
@@ -97,12 +73,4 @@ WindowTopBarPluginMenu.propTypes = {
   ),
   t: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowTopBarPluginMenu.defaultProps = {
-  anchorEl: null,
-  container: null,
-  menuIcon: <MoreVertIcon />,
-  open: false,
-  PluginComponents: [],
 };

--- a/src/components/WindowTopBarTitle.js
+++ b/src/components/WindowTopBarTitle.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
@@ -32,43 +31,35 @@ TitleTypography.propTypes = {
 /**
  * WindowTopBarTitle
  */
-export class WindowTopBarTitle extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      error, hideWindowTitle, isFetching, manifestTitle,
-    } = this.props;
-
-    let title = null;
-    if (isFetching) {
-      title = (
-        <StyledTitleTypography>
-          <Skeleton variant="text" />
+export function WindowTopBarTitle({
+  error = null, hideWindowTitle = false, isFetching = false, manifestTitle = '',
+}) {
+  let title = null;
+  if (isFetching) {
+    title = (
+      <StyledTitleTypography>
+        <Skeleton variant="text" />
+      </StyledTitleTypography>
+    );
+  } else if (error) {
+    title = (
+      <>
+        <ErrorIcon color="error" />
+        <StyledTitleTypography color="textSecondary">
+          {error}
         </StyledTitleTypography>
-      );
-    } else if (error) {
-      title = (
-        <>
-          <ErrorIcon color="error" />
-          <StyledTitleTypography color="textSecondary">
-            {error}
-          </StyledTitleTypography>
-        </>
-      );
-    } else if (hideWindowTitle) {
-      title = (<StyledTitle />);
-    } else {
-      title = (
-        <StyledTitleTypography>
-          {manifestTitle}
-        </StyledTitleTypography>
-      );
-    }
-    return title;
+      </>
+    );
+  } else if (hideWindowTitle) {
+    title = (<StyledTitle />);
+  } else {
+    title = (
+      <StyledTitleTypography>
+        {manifestTitle}
+      </StyledTitleTypography>
+    );
   }
+  return title;
 }
 
 WindowTopBarTitle.propTypes = {
@@ -76,11 +67,4 @@ WindowTopBarTitle.propTypes = {
   hideWindowTitle: PropTypes.bool,
   isFetching: PropTypes.bool,
   manifestTitle: PropTypes.string,
-};
-
-WindowTopBarTitle.defaultProps = {
-  error: null,
-  hideWindowTitle: false,
-  isFetching: false,
-  manifestTitle: '',
 };

--- a/src/components/WindowTopMenu.js
+++ b/src/components/WindowTopMenu.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import Menu from '@mui/material/Menu';
 import ListSubheader from '@mui/material/ListSubheader';
 import PropTypes from 'prop-types';
@@ -19,44 +18,38 @@ function PluginHookWithHeader(props) {
 
 /**
  */
-export class WindowTopMenu extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      container, handleClose, showThumbnailNavigationSettings,
-      toggleDraggingEnabled, windowId, anchorEl, open,
-    } = this.props;
+export function WindowTopMenu({
+  container = null, handleClose, showThumbnailNavigationSettings = true,
+  toggleDraggingEnabled, windowId, anchorEl = null, open = false,
+}) {
+  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
 
-    return (
-      <Menu
-        container={container?.current}
-        anchorOrigin={{
-          horizontal: 'right',
-          vertical: 'bottom',
-        }}
-        transformOrigin={{
-          horizontal: 'right',
-          vertical: 'top',
-        }}
-        onClose={handleClose}
-        TransitionProps={{
-          onEntering: toggleDraggingEnabled,
-          onExit: toggleDraggingEnabled,
-        }}
-        orientation="horizontal"
-        anchorEl={anchorEl}
-        open={open}
-      >
-        <WindowViewSettings windowId={windowId} handleClose={handleClose} />
-        {showThumbnailNavigationSettings
-          && <WindowThumbnailSettings windowId={windowId} handleClose={handleClose} />}
-        <PluginHookWithHeader {...this.props} />
-      </Menu>
-    );
-  }
+  return (
+    <Menu
+      container={container?.current}
+      anchorOrigin={{
+        horizontal: 'right',
+        vertical: 'bottom',
+      }}
+      transformOrigin={{
+        horizontal: 'right',
+        vertical: 'top',
+      }}
+      onClose={handleClose}
+      TransitionProps={{
+        onEntering: toggleDraggingEnabled,
+        onExit: toggleDraggingEnabled,
+      }}
+      orientation="horizontal"
+      anchorEl={anchorEl}
+      open={open}
+    >
+      <WindowViewSettings windowId={windowId} handleClose={handleClose} />
+      {showThumbnailNavigationSettings
+        && <WindowThumbnailSettings windowId={windowId} handleClose={handleClose} />}
+      <PluginHookWithHeader {...pluginProps} />
+    </Menu>
+  );
 }
 
 WindowTopMenu.propTypes = {
@@ -67,11 +60,4 @@ WindowTopMenu.propTypes = {
   showThumbnailNavigationSettings: PropTypes.bool,
   toggleDraggingEnabled: PropTypes.func.isRequired,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowTopMenu.defaultProps = {
-  anchorEl: null,
-  container: null,
-  open: false,
-  showThumbnailNavigationSettings: true,
 };

--- a/src/components/WindowTopMenuButton.js
+++ b/src/components/WindowTopMenuButton.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import WindowTopMenu from '../containers/WindowTopMenu';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
@@ -6,81 +6,48 @@ import WindowOptionsIcon from './icons/WindowOptionsIcon';
 
 /**
  */
-export class WindowTopMenuButton extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      open: false,
-    };
-    this.handleMenuClick = this.handleMenuClick.bind(this);
-    this.handleMenuClose = this.handleMenuClose.bind(this);
-  }
+export function WindowTopMenuButton({ classes = {}, t = k => k, windowId }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [open, setOpen] = useState(false);
 
-  /**
-   * @private
-   */
-  handleMenuClick(event) {
-    this.setState({
-      anchorEl: event.target,
-      open: true,
-    });
-  }
+  /** */
+  const handleMenuClick = (event) => {
+    setAnchorEl(event.currentTarget);
+    setOpen(true);
+  };
 
-  /**
-   * @private
-   */
-  handleMenuClose() {
-    this.setState({
-      anchorEl: null,
-      open: false,
-    });
-  }
+  /** */
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setOpen(false);
+  };
 
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      classes, t, windowId,
-    } = this.props;
-    const { open, anchorEl } = this.state;
-    const menuId = `window-menu_${windowId}`;
-    return (
-      <>
-        <MiradorMenuButton
-          aria-haspopup="true"
-          aria-label={t('windowMenu')}
-          aria-owns={open ? menuId : undefined}
-          className={open ? classes.ctrlBtnSelected : undefined}
-          selected={open}
-          onClick={this.handleMenuClick}
-        >
-          <WindowOptionsIcon />
-        </MiradorMenuButton>
-        <WindowTopMenu
-          windowId={windowId}
-          anchorEl={anchorEl}
-          handleClose={this.handleMenuClose}
-          id={menuId}
-          open={open}
-        />
-      </>
-    );
-  }
+  const menuId = `window-menu_${windowId}`;
+  return (
+    <>
+      <MiradorMenuButton
+        aria-haspopup="true"
+        aria-label={t('windowMenu')}
+        aria-owns={open ? menuId : undefined}
+        className={open ? classes.ctrlBtnSelected : undefined}
+        selected={open}
+        onClick={handleMenuClick}
+      >
+        <WindowOptionsIcon />
+      </MiradorMenuButton>
+      <WindowTopMenu
+        windowId={windowId}
+        anchorEl={anchorEl}
+        handleClose={handleMenuClose}
+        id={menuId}
+        open={open}
+      />
+    </>
+  );
 }
 
 WindowTopMenuButton.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
   t: PropTypes.func,
   windowId: PropTypes.string.isRequired,
-};
-
-WindowTopMenuButton.defaultProps = {
-  classes: {},
-  t: key => key,
 };

--- a/src/components/WindowViewSettings.js
+++ b/src/components/WindowViewSettings.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import { styled } from '@mui/material/styles';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import MenuItem from '@mui/material/MenuItem';
@@ -32,67 +31,46 @@ const ViewOption = styled(MenuItem, { name: 'WindowViewSettings', slot: 'option'
 /**
  *
  */
-export class WindowViewSettings extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  /**
-   * @private
-   */
-  handleChange(value) {
-    const { windowId, setWindowViewType } = this.props;
-
+export function WindowViewSettings({
+  handleClose = () => {}, t = k => k, windowViewType, viewTypes = [], setWindowViewType, windowId,
+}) {
+  /** */
+  const handleChange = (value) => {
     setWindowViewType(windowId, value);
-  }
+  };
 
-  /**
-   * render
-   *
-   * @return {type}  description
-   */
-  render() {
-    const {
-      handleClose, t, windowViewType, viewTypes,
-    } = this.props;
+  const iconMap = {
+    book: BookViewIcon,
+    gallery: GalleryViewIcon,
+    scroll: ScrollViewIcon,
+    single: SingleIcon,
+  };
 
-    const iconMap = {
-      book: BookViewIcon,
-      gallery: GalleryViewIcon,
-      scroll: ScrollViewIcon,
-      single: SingleIcon,
-    };
+  /** Suspiciously similar to a component, yet if it is invoked through JSX
+      none of the click handlers work? */
+  const menuItem = ({ value, Icon }) => (
+    <ViewOption
+      selected={windowViewType === value}
+      key={value}
+      autoFocus={windowViewType === value}
+      onClick={() => { handleChange(value); handleClose(); }}
+    >
+      <FormControlLabel
+        value={value}
+        control={<Icon fill="currentcolor" color={windowViewType === value ? 'secondary' : undefined} />}
+        label={t(value)}
+        labelPlacement="bottom"
+      />
+    </ViewOption>
+  );
 
-    /** Suspiciously similar to a component, yet if it is invoked through JSX
-        none of the click handlers work? */
-    const menuItem = ({ value, Icon }) => (
-      <ViewOption
-        selected={windowViewType === value}
-        key={value}
-        autoFocus={windowViewType === value}
-        onClick={() => { this.handleChange(value); handleClose(); }}
-      >
-        <FormControlLabel
-          value={value}
-          control={<Icon fill="currentcolor" color={windowViewType === value ? 'secondary' : undefined} />}
-          label={t(value)}
-          labelPlacement="bottom"
-        />
-      </ViewOption>
-    );
-
-    if (viewTypes.length === 0) return null;
-    return (
-      <>
-        <ListSubheader role="presentation" disableSticky tabIndex={-1}>{t('view')}</ListSubheader>
-        { viewTypes.map(value => menuItem({ Icon: iconMap[value], value })) }
-      </>
-    );
-  }
+  if (viewTypes.length === 0) return null;
+  return (
+    <>
+      <ListSubheader role="presentation" disableSticky tabIndex={-1}>{t('view')}</ListSubheader>
+      { viewTypes.map(value => menuItem({ Icon: iconMap[value], value })) }
+    </>
+  );
 }
 
 WindowViewSettings.propTypes = {
@@ -102,9 +80,4 @@ WindowViewSettings.propTypes = {
   viewTypes: PropTypes.arrayOf(PropTypes.string),
   windowId: PropTypes.string.isRequired,
   windowViewType: PropTypes.string.isRequired,
-};
-WindowViewSettings.defaultProps = {
-  handleClose: () => {},
-  t: key => key,
-  viewTypes: [],
 };

--- a/src/components/WindowViewer.js
+++ b/src/components/WindowViewer.js
@@ -1,4 +1,5 @@
-import { Component, lazy, Suspense } from 'react';
+import { lazy, Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import PropTypes from 'prop-types';
 import WindowCanvasNavigationControls from '../containers/WindowCanvasNavigationControls';
 
@@ -8,30 +9,9 @@ const OSDViewer = lazy(() => import('../containers/OpenSeadragonViewer'));
  * Represents a WindowViewer in the mirador workspace. Responsible for mounting
  * OSD and Navigation
  */
-export class WindowViewer extends Component {
-  /** */
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
-  /** */
-  static getDerivedStateFromError(error) {
-    // Update state so the next render will show the fallback UI.
-    return { hasError: true };
-  }
-
-  /**
-   * Renders things
-   */
-  render() {
-    const { windowId } = this.props;
-
-    const { hasError } = this.state;
-
-    if (hasError) return null;
-
-    return (
+export function WindowViewer({ windowId }) {
+  return (
+    <ErrorBoundary fallback={null}>
       <Suspense fallback={<div />}>
         <OSDViewer
           windowId={windowId}
@@ -39,8 +19,8 @@ export class WindowViewer extends Component {
           <WindowCanvasNavigationControls windowId={windowId} />
         </OSDViewer>
       </Suspense>
-    );
-  }
+    </ErrorBoundary>
+  );
 }
 
 WindowViewer.propTypes = {

--- a/src/components/WorkspaceAddButton.js
+++ b/src/components/WorkspaceAddButton.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Fab from '@mui/material/Fab';
 import Tooltip from '@mui/material/Tooltip';
@@ -12,39 +11,32 @@ const Root = styled(Fab, { name: 'WorkspaceAddButton', slot: 'root' })(({ theme 
 
 /**
  */
-export class WorkspaceAddButton extends Component {
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      t, setWorkspaceAddVisibility, isWorkspaceAddVisible, useExtendedFab,
-    } = this.props;
-    return (
-      <Tooltip title={isWorkspaceAddVisible ? t('closeAddResourceMenu') : t('addResource')}>
-        <Root
-          size="medium"
-          color="primary"
-          id="addBtn"
-          aria-label={
-            isWorkspaceAddVisible
-              ? t('closeAddResourceMenu')
-              : ((useExtendedFab && t('startHere')) || t('addResource'))
-          }
-          variant={useExtendedFab ? 'extended' : 'circular'}
-          onClick={() => { setWorkspaceAddVisibility(!isWorkspaceAddVisible); }}
-        >
-          {
-            isWorkspaceAddVisible
-              ? <CloseIcon />
-              : <AddIcon />
-          }
-          { useExtendedFab && t('startHere') }
-        </Root>
-      </Tooltip>
-    );
-  }
+export function WorkspaceAddButton({
+  t = k => k, setWorkspaceAddVisibility, isWorkspaceAddVisible = false, useExtendedFab,
+}) {
+  return (
+    <Tooltip title={isWorkspaceAddVisible ? t('closeAddResourceMenu') : t('addResource')}>
+      <Root
+        size="medium"
+        color="primary"
+        id="addBtn"
+        aria-label={
+          isWorkspaceAddVisible
+            ? t('closeAddResourceMenu')
+            : ((useExtendedFab && t('startHere')) || t('addResource'))
+        }
+        variant={useExtendedFab ? 'extended' : 'circular'}
+        onClick={() => { setWorkspaceAddVisibility(!isWorkspaceAddVisible); }}
+      >
+        {
+          isWorkspaceAddVisible
+            ? <CloseIcon />
+            : <AddIcon />
+        }
+        { useExtendedFab && t('startHere') }
+      </Root>
+    </Tooltip>
+  );
 }
 
 WorkspaceAddButton.propTypes = {
@@ -52,9 +44,4 @@ WorkspaceAddButton.propTypes = {
   setWorkspaceAddVisibility: PropTypes.func.isRequired,
   t: PropTypes.func,
   useExtendedFab: PropTypes.bool.isRequired,
-};
-
-WorkspaceAddButton.defaultProps = {
-  isWorkspaceAddVisible: false,
-  t: key => key,
 };

--- a/src/components/WorkspaceArea.js
+++ b/src/components/WorkspaceArea.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled, lighten, darken } from '@mui/material/styles';
 import ErrorDialog from '../containers/ErrorDialog';
@@ -35,44 +34,38 @@ const ViewerArea = styled('main', { name: 'WorkspaceArea', slot: 'viewer' })(() 
  * This is the top level Mirador component.
  * @prop {Object} manifests
  */
-export class WorkspaceArea extends Component {
-  /**
-   * render
-   * @return {String} - HTML markup for the component
-   */
-  render() {
-    const {
-      areaRef,
-      controlPanelVariant,
-      isWorkspaceAddVisible,
-      isWorkspaceControlPanelVisible,
-      lang,
-      t,
-    } = this.props;
+export function WorkspaceArea({
+  areaRef = null,
+  controlPanelVariant = undefined,
+  isWorkspaceAddVisible = false,
+  isWorkspaceControlPanelVisible,
+  lang = undefined,
+  t,
+}) {
+  const ownerState = arguments[0]; // eslint-disable-line prefer-rest-params
 
-    return (
-      <Root ownerState={this.props}>
+  return (
+    <Root ownerState={ownerState}>
+      {
+        isWorkspaceControlPanelVisible
+          && <WorkspaceControlPanel variant={controlPanelVariant} />
+      }
+      <ViewerArea
+        className={ns('viewer')}
+        lang={lang}
+        aria-label={t('workspace')}
+        {...(areaRef ? { ref: areaRef } : {})}
+      >
         {
-          isWorkspaceControlPanelVisible
-            && <WorkspaceControlPanel variant={controlPanelVariant} />
+          isWorkspaceAddVisible
+            ? <WorkspaceAdd />
+            : <Workspace />
         }
-        <ViewerArea
-          className={ns('viewer')}
-          lang={lang}
-          aria-label={t('workspace')}
-          {...(areaRef ? { ref: areaRef } : {})}
-        >
-          {
-            isWorkspaceAddVisible
-              ? <WorkspaceAdd />
-              : <Workspace />
-          }
-          <ErrorDialog />
-          <BackgroundPluginArea />
-        </ViewerArea>
-      </Root>
-    );
-  }
+        <ErrorDialog />
+        <BackgroundPluginArea />
+      </ViewerArea>
+    </Root>
+  );
 }
 
 WorkspaceArea.propTypes = {
@@ -82,11 +75,4 @@ WorkspaceArea.propTypes = {
   isWorkspaceControlPanelVisible: PropTypes.bool.isRequired,
   lang: PropTypes.string,
   t: PropTypes.func.isRequired,
-};
-
-WorkspaceArea.defaultProps = {
-  areaRef: null,
-  controlPanelVariant: undefined,
-  isWorkspaceAddVisible: false,
-  lang: undefined,
 };

--- a/src/components/WorkspaceControlPanel.js
+++ b/src/components/WorkspaceControlPanel.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import classNames from 'classnames';
@@ -57,42 +56,31 @@ const StyledBranding = styled(Branding, { name: 'WorkspaceControlPanel', slot: '
 /**
  * Provides the panel responsible for controlling the entire workspace
  */
-export class WorkspaceControlPanel extends Component {
-  /**
-   * render
-   * @return {String} - HTML markup for the component
-   */
-  render() {
-    const { t, variant } = this.props;
-    return (
-      <Root
-        ownerState={this.props}
-        className={classNames(ns('workspace-control-panel'))}
-        color="default"
-        enableColorOnDark
-        position="absolute"
-        component="nav"
-        aria-label={t('workspaceNavigation')}
+export function WorkspaceControlPanel({ t, variant = 'default', ...rest }) {
+  return (
+    <Root
+      ownerState={{ t, variant, ...rest }}
+      className={classNames(ns('workspace-control-panel'))}
+      color="default"
+      enableColorOnDark
+      position="absolute"
+      component="nav"
+      aria-label={t('workspaceNavigation')}
+    >
+      <StyledToolbar
+        disableGutters
       >
-        <StyledToolbar
-          disableGutters
-        >
-          <WorkspaceAddButton />
-          <StyledWorkspaceButtons>
-            <WorkspaceControlPanelButtons />
-          </StyledWorkspaceButtons>
-        </StyledToolbar>
-        <StyledBranding t={t} variant={variant} />
-      </Root>
-    );
-  }
+        <WorkspaceAddButton />
+        <StyledWorkspaceButtons>
+          <WorkspaceControlPanelButtons />
+        </StyledWorkspaceButtons>
+      </StyledToolbar>
+      <StyledBranding t={t} variant={variant} />
+    </Root>
+  );
 }
 
 WorkspaceControlPanel.propTypes = {
   t: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(['default', 'wide']),
-};
-
-WorkspaceControlPanel.defaultProps = {
-  variant: 'default',
 };

--- a/src/components/WorkspaceControlPanelButtons.js
+++ b/src/components/WorkspaceControlPanelButtons.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import FullScreenButton from '../containers/FullScreenButton';
 import WorkspaceMenuButton from '../containers/WorkspaceMenuButton';
 import WorkspaceOptionsButton from '../containers/WorkspaceOptionsButton';
@@ -8,21 +7,14 @@ import { PluginHook } from './PluginHook';
 /**
  *
  */
-export class WorkspaceControlPanelButtons extends Component {
-  /**
-   * render
-   *
-   * @return {type}  description
-   */
-  render() {
-    return (
-      <>
-        <WindowListButton />
-        <WorkspaceMenuButton />
-        <WorkspaceOptionsButton />
-        <FullScreenButton />
-        <PluginHook {...this.props} />
-      </>
-    );
-  }
+export function WorkspaceControlPanelButtons({ ...rest }) {
+  return (
+    <>
+      <WindowListButton />
+      <WorkspaceMenuButton />
+      <WorkspaceOptionsButton />
+      <FullScreenButton />
+      <PluginHook {...rest} />
+    </>
+  );
 }

--- a/src/components/WorkspaceElastic.js
+++ b/src/components/WorkspaceElastic.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { Rnd } from 'react-rnd';
@@ -29,65 +28,59 @@ const StyledRnd = styled(Rnd)({
  * @memberof Workspace
  * @private
  */
-class WorkspaceElastic extends Component {
-  /**
-   */
-  render() {
-    const {
-      workspace,
-      elasticLayout,
-      setWorkspaceViewportDimensions,
-      setWorkspaceViewportPosition,
-    } = this.props;
+function WorkspaceElastic({
+  workspace,
+  elasticLayout,
+  setWorkspaceViewportDimensions,
+  setWorkspaceViewportPosition,
+}) {
+  const { viewportPosition } = workspace;
+  const offsetX = workspace.width / 2;
+  const offsetY = workspace.height / 2;
 
-    const { viewportPosition } = workspace;
-    const offsetX = workspace.width / 2;
-    const offsetY = workspace.height / 2;
+  return (
+    <Root>
+      <ResizeObserver
+        onReflow={() => {}}
+        onResize={(rect) => { setWorkspaceViewportDimensions(rect); }}
+      />
 
-    return (
-      <Root>
-        <ResizeObserver
-          onReflow={() => {}}
-          onResize={(rect) => { setWorkspaceViewportDimensions(rect); }}
-        />
-
-        <StyledRnd
-          size={{
-            height: workspace.height,
-            width: workspace.width,
-          }}
-          position={{
-            x: -1 * viewportPosition.x - offsetX, y: -1 * viewportPosition.y - offsetY,
-          }}
-          enableResizing={{
-            bottom: false,
-            bottomLeft: false,
-            bottomRight: false,
-            left: false,
-            right: false,
-            top: false,
-            topLeft: false,
-            topRight: false,
-          }}
-          onDragStop={(e, d) => {
-            setWorkspaceViewportPosition({ x: -1 * d.x - offsetX, y: -1 * d.y - offsetY });
-          }}
-          cancel={`.${ns('window')}`}
-          className={ns('workspace')}
-          disableDragging={!workspace.draggingEnabled}
-        >
-          {
-            Object.keys(elasticLayout).map(windowId => (
-              <WorkspaceElasticWindow
-                key={windowId}
-                windowId={windowId}
-              />
-            ))
-          }
-        </StyledRnd>
-      </Root>
-    );
-  }
+      <StyledRnd
+        size={{
+          height: workspace.height,
+          width: workspace.width,
+        }}
+        position={{
+          x: -1 * viewportPosition.x - offsetX, y: -1 * viewportPosition.y - offsetY,
+        }}
+        enableResizing={{
+          bottom: false,
+          bottomLeft: false,
+          bottomRight: false,
+          left: false,
+          right: false,
+          top: false,
+          topLeft: false,
+          topRight: false,
+        }}
+        onDragStop={(e, d) => {
+          setWorkspaceViewportPosition({ x: -1 * d.x - offsetX, y: -1 * d.y - offsetY });
+        }}
+        cancel={`.${ns('window')}`}
+        className={ns('workspace')}
+        disableDragging={!workspace.draggingEnabled}
+      >
+        {
+          Object.keys(elasticLayout).map(windowId => (
+            <WorkspaceElasticWindow
+              key={windowId}
+              windowId={windowId}
+            />
+          ))
+        }
+      </StyledRnd>
+    </Root>
+  );
 }
 
 WorkspaceElastic.propTypes = {

--- a/src/components/WorkspaceElasticWindow.js
+++ b/src/components/WorkspaceElasticWindow.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { Rnd } from 'react-rnd';
@@ -14,58 +13,53 @@ const StyledRnd = styled(Rnd, { shouldForwardProp: prop => prop !== 'focused' })
  * @memberof Workspace
  * @private
  */
-class WorkspaceElasticWindow extends Component {
-  /**
-   */
-  render() {
-    const {
-      classes,
-      companionWindowDimensions,
-      focused,
-      focusWindow,
-      layout,
-      workspace,
-      updateElasticWindowLayout,
-    } = this.props;
+function WorkspaceElasticWindow({
+  classes = {},
+  companionWindowDimensions = { height: 0, width: 0 },
+  focused = false,
+  focusWindow = () => {},
+  layout,
+  workspace,
+  updateElasticWindowLayout,
 
-    const offsetX = workspace.width / 2;
-    const offsetY = workspace.height / 2;
+}) {
+  const offsetX = workspace.width / 2;
+  const offsetY = workspace.height / 2;
 
-    return (
-      <StyledRnd
-        focused={focused}
-        className={focused ? classes.focused : undefined}
-        key={`${layout.windowId}-${workspace.id}`}
-        size={{
-          height: layout.height + companionWindowDimensions.height,
-          width: layout.width + companionWindowDimensions.width,
-        }}
-        position={{ x: layout.x + offsetX, y: layout.y + offsetY }}
-        bounds="parent"
-        onDragStop={(e, d) => {
-          updateElasticWindowLayout(
-            layout.windowId,
-            { x: d.x - offsetX, y: d.y - offsetY },
-          );
-        }}
-        onDragStart={focusWindow}
-        onResize={(e, direction, ref, delta, position) => {
-          updateElasticWindowLayout(layout.windowId, {
-            height: Number.parseInt(ref.style.height, 10) - companionWindowDimensions.height,
-            width: Number.parseInt(ref.style.width, 10) - companionWindowDimensions.width,
-            x: position.x - offsetX,
-            y: position.y - offsetY,
-          });
-        }}
-        dragHandleClassName={ns('window-top-bar')}
-        cancel={`.${ns('window-menu-btn')}`}
-      >
-        <Window
-          windowId={layout.windowId}
-        />
-      </StyledRnd>
-    );
-  }
+  return (
+    <StyledRnd
+      focused={focused}
+      className={focused ? classes.focused : undefined}
+      key={`${layout.windowId}-${workspace.id}`}
+      size={{
+        height: layout.height + companionWindowDimensions.height,
+        width: layout.width + companionWindowDimensions.width,
+      }}
+      position={{ x: layout.x + offsetX, y: layout.y + offsetY }}
+      bounds="parent"
+      onDragStop={(e, d) => {
+        updateElasticWindowLayout(
+          layout.windowId,
+          { x: d.x - offsetX, y: d.y - offsetY },
+        );
+      }}
+      onDragStart={focusWindow}
+      onResize={(e, direction, ref, delta, position) => {
+        updateElasticWindowLayout(layout.windowId, {
+          height: Number.parseInt(ref.style.height, 10) - companionWindowDimensions.height,
+          width: Number.parseInt(ref.style.width, 10) - companionWindowDimensions.width,
+          x: position.x - offsetX,
+          y: position.y - offsetY,
+        });
+      }}
+      dragHandleClassName={ns('window-top-bar')}
+      cancel={`.${ns('window-menu-btn')}`}
+    >
+      <Window
+        windowId={layout.windowId}
+      />
+    </StyledRnd>
+  );
 }
 
 WorkspaceElasticWindow.propTypes = {
@@ -86,13 +80,6 @@ WorkspaceElasticWindow.propTypes = {
   }).isRequired,
   updateElasticWindowLayout: PropTypes.func.isRequired,
   workspace: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-};
-
-WorkspaceElasticWindow.defaultProps = {
-  classes: {},
-  companionWindowDimensions: { height: 0, width: 0 },
-  focused: false,
-  focusWindow: () => {},
 };
 
 export default WorkspaceElasticWindow;

--- a/src/components/WorkspaceExport.js
+++ b/src/components/WorkspaceExport.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import Button from '@mui/material/Button';
 import DialogActions from '@mui/material/DialogActions';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -17,109 +17,73 @@ import { WorkspaceDialog } from './WorkspaceDialog';
 
 /**
  */
-export class WorkspaceExport extends Component {
-  /** */
-  constructor(props) {
-    super(props);
+export function WorkspaceExport({
+  children = null, container = null, open = false, t = k => k, handleClose, exportableState,
+}) {
+  const [copied, setCopied] = useState(false);
+  const exportedState = JSON.stringify(exportableState, null, 2);
 
-    this.state = { copied: false };
-    this.onCopy = this.onCopy.bind(this);
-    this.handleClose = this.handleClose.bind(this);
-  }
-
-  /** Handle closing after the content is copied and the snackbar is done */
-  handleClose() {
-    const { handleClose } = this.props;
-
-    handleClose();
-  }
-
-  /** Show the snackbar */
-  onCopy() {
-    this.setState({ copied: true });
-  }
-
-  /**
-   * @private
-   */
-  exportedState() {
-    const { exportableState } = this.props;
-
-    return JSON.stringify(exportableState, null, 2);
-  }
-
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      children, container, open, t,
-    } = this.props;
-    const { copied } = this.state;
-
-    if (copied) {
-      return (
-        <Snackbar
-          anchorOrigin={{
-            horizontal: 'center',
-            vertical: 'top',
-          }}
-          open
-          autoHideDuration={6000}
-          onClose={this.handleClose}
-          message={t('exportCopied')}
-          action={(
-            <IconButton size="small" aria-label={t('dismiss')} color="inherit" onClick={this.handleClose}>
-              <CloseIcon fontSize="small" />
-            </IconButton>
-          )}
-        />
-      );
-    }
-
+  if (copied) {
     return (
-      <WorkspaceDialog
-        id="workspace-export"
-        container={container}
-        open={open}
-        onClose={this.handleClose}
-        scroll="paper"
-        fullWidth
-        maxWidth="sm"
-      >
-        <DialogTitle id="form-dialog-title">
-          {t('downloadExport')}
-        </DialogTitle>
-
-        <DialogContent>
-          <Accordion elevation={2}>
-            <AccordionSummary
-              expandIcon={<ExpandMoreIcon />}
-            >
-              <Typography variant="h4">{t('viewWorkspaceConfiguration')}</Typography>
-            </AccordionSummary>
-            <AccordionDetails sx={{ overflow: 'scroll' }}>
-              {children}
-              <pre>
-                {this.exportedState()}
-              </pre>
-            </AccordionDetails>
-          </Accordion>
-        </DialogContent>
-
-        <DialogActions>
-          <Button onClick={this.handleClose}>{t('cancel')}</Button>
-          <CopyToClipboard
-            onCopy={this.onCopy}
-            text={this.exportedState()}
-          >
-            <Button variant="contained" color="primary">{t('copy')}</Button>
-          </CopyToClipboard>
-        </DialogActions>
-      </WorkspaceDialog>
+      <Snackbar
+        anchorOrigin={{
+          horizontal: 'center',
+          vertical: 'top',
+        }}
+        open
+        autoHideDuration={6000}
+        onClose={handleClose}
+        message={t('exportCopied')}
+        action={(
+          <IconButton size="small" aria-label={t('dismiss')} color="inherit" onClick={handleClose}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        )}
+      />
     );
   }
+
+  return (
+    <WorkspaceDialog
+      id="workspace-export"
+      container={container}
+      open={open}
+      onClose={handleClose}
+      scroll="paper"
+      fullWidth
+      maxWidth="sm"
+    >
+      <DialogTitle id="form-dialog-title">
+        {t('downloadExport')}
+      </DialogTitle>
+
+      <DialogContent>
+        <Accordion elevation={2}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+          >
+            <Typography variant="h4">{t('viewWorkspaceConfiguration')}</Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ overflow: 'scroll' }}>
+            {children}
+            <pre>
+              {exportedState}
+            </pre>
+          </AccordionDetails>
+        </Accordion>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={handleClose}>{t('cancel')}</Button>
+        <CopyToClipboard
+          onCopy={() => setCopied(true)}
+          text={exportedState}
+        >
+          <Button variant="contained" color="primary">{t('copy')}</Button>
+        </CopyToClipboard>
+      </DialogActions>
+    </WorkspaceDialog>
+  );
 }
 
 WorkspaceExport.propTypes = {
@@ -129,11 +93,4 @@ WorkspaceExport.propTypes = {
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   t: PropTypes.func,
-};
-
-WorkspaceExport.defaultProps = {
-  children: null,
-  container: null,
-  open: false,
-  t: key => key,
 };

--- a/src/components/WorkspaceImport.js
+++ b/src/components/WorkspaceImport.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import DialogTitle from '@mui/material/DialogTitle';
 import PropTypes from 'prop-types';
 import {
@@ -11,97 +11,66 @@ import ScrollIndicatedDialogContent from '../containers/ScrollIndicatedDialogCon
 
 /**
  */
-export class WorkspaceImport extends Component {
-  /**
-   *
-   * constructor
-   */
-  constructor(props) {
-    super(props);
+export function WorkspaceImport({
+  addError, importConfig, classes = {}, handleClose, open = false, t = k => k,
+}) {
+  const [configImportValue, setConfigImportValue] = useState('');
 
-    this.state = {
-      configImportValue: '',
-    };
-
-    this.handleImportConfig = this.handleImportConfig.bind(this);
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  /**
-   * @private
-   */
-  handleChange(event) {
+  /** */
+  const handleChange = (event) => {
     event.preventDefault();
-    this.setState({
-      configImportValue: event.target.value,
-    });
-  }
+    setConfigImportValue(event.target.value);
+  };
 
-  /**
-   * @private
-   */
-  handleImportConfig(event) {
-    const { handleClose, importConfig } = this.props;
-    const { configImportValue } = this.state;
-
+  /** */
+  const handleImportConfig = (_event) => {
     try {
       const configJSON = JSON.parse(configImportValue);
       importConfig(configJSON);
       handleClose();
     } catch (ex) {
-      const { addError } = this.props;
       addError(ex.toString());
     }
-  }
+  };
 
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      classes, handleClose, open, t,
-    } = this.props;
-
-    return (
-      <WorkspaceDialog
-        aria-labelledby="workspace-import-title"
-        id="workspace-import"
-        onClose={handleClose}
-        open={open}
-        fullWidth
-        maxWidth="sm"
-      >
-        <DialogTitle id="workspace-import-title">
-          {t('importWorkspace')}
-        </DialogTitle>
-        <ScrollIndicatedDialogContent>
-          <TextField
-            className={classes.textField}
-            id="workspace-import-input"
-            multiline
-            onChange={this.handleChange}
-            minRows={15}
-            variant="filled"
-            sx={{
-              '& .MuiInputBase-input': { fontFamily: 'monospace' },
-              width: '100%',
-            }}
-            inputProps={{ autoFocus: 'autofocus' }}
-            helperText={t('importWorkspaceHint')}
-          />
-        </ScrollIndicatedDialogContent>
-        <DialogActions>
-          <Button onClick={handleClose}>
-            {t('cancel')}
-          </Button>
-          <Button color="primary" onClick={this.handleImportConfig} variant="contained">
-            {t('import')}
-          </Button>
-        </DialogActions>
-      </WorkspaceDialog>
-    );
-  }
+  return (
+    <WorkspaceDialog
+      aria-labelledby="workspace-import-title"
+      id="workspace-import"
+      onClose={handleClose}
+      open={open}
+      fullWidth
+      maxWidth="sm"
+    >
+      <DialogTitle id="workspace-import-title">
+        {t('importWorkspace')}
+      </DialogTitle>
+      <ScrollIndicatedDialogContent>
+        <TextField
+          className={classes.textField}
+          id="workspace-import-input"
+          multiline
+          onChange={handleChange}
+          minRows={15}
+          variant="filled"
+          sx={{
+            '& .MuiInputBase-input': { fontFamily: 'monospace' },
+            width: '100%',
+          }}
+          inputProps={{ autoFocus: 'autofocus' }}
+          helperText={t('importWorkspaceHint')}
+        />
+      </ScrollIndicatedDialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>
+          {t('cancel')}
+        </Button>
+        <Button color="primary" onClick={handleImportConfig} variant="contained">
+          {t('import')}
+        </Button>
+      </DialogActions>
+    </WorkspaceDialog>
+  );
 }
 
 WorkspaceImport.propTypes = {
@@ -111,10 +80,4 @@ WorkspaceImport.propTypes = {
   importConfig: PropTypes.func.isRequired,
   open: PropTypes.bool,
   t: PropTypes.func,
-};
-
-WorkspaceImport.defaultProps = {
-  classes: {},
-  open: false,
-  t: key => key,
 };

--- a/src/components/WorkspaceMenu.js
+++ b/src/components/WorkspaceMenu.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
@@ -11,140 +11,94 @@ import { PluginHook } from './PluginHook';
 
 /**
  */
-export class WorkspaceMenu extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      changeTheme: {},
-      toggleZoom: {},
-      workspaceSelection: {},
-    };
-    this.handleMenuItemClick = this.handleMenuItemClick.bind(this);
-    this.handleMenuItemClose = this.handleMenuItemClose.bind(this);
-  }
+export function WorkspaceMenu({
+  container = null, handleClose, showThemePicker = false, isWorkspaceAddVisible = false,
+  t = k => k, tReady = false, toggleZoomControls = () => {}, showZoomControls = false, ...menuProps
+}) {
+  const [selectedOption, setSelectedOption] = useState(null);
 
-  /**
-   * @private
-   */
-  handleMenuItemClick(item, event) {
-    const obj = {};
-    obj[item] = {};
-    obj[item].open = true;
-    obj[item].anchorEl = event.currentTarget;
-    this.setState(obj);
-  }
+  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
 
-  /**
-   * @private
-   */
-  handleMenuItemClose(item) {
-    return (event) => {
-      const obj = {};
-      obj[item] = {};
-      obj[item].open = false;
-      obj[item].anchorEl = null;
-      this.setState(obj);
-    };
-  }
+  /** */
+  const handleClick = (option, e) => {
+    setSelectedOption(option);
+    handleClose(e);
+  };
 
-  /**
-   * @private
-   */
-  handleZoomToggleClick() {
-    const { toggleZoomControls, showZoomControls } = this.props;
+  /** */
+  const handleDialogClose = () => {
+    setSelectedOption(null);
+  };
+
+  /** */
+  const handleZoomToggleClick = (e) => {
     toggleZoomControls(!showZoomControls);
-  }
+    handleClose(e);
+  };
 
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      container,
-      handleClose,
-      showThemePicker,
-      isWorkspaceAddVisible,
-      t,
-      tReady,
-      showZoomControls,
-      toggleZoomControls,
-      ...menuProps
-    } = this.props;
-
-    const {
-      changeTheme,
-      toggleZoom,
-      workspaceSelection,
-    } = this.state;
-
-    return (
-      <>
-        <Menu
-          container={container?.current}
-          anchorOrigin={{
-            horizontal: 'right',
-            vertical: 'top',
-          }}
-          transformOrigin={{
-            horizontal: 'left',
-            vertical: 'top',
-          }}
-          onClose={handleClose}
-          {...menuProps}
+  return (
+    <>
+      <Menu
+        container={container?.current}
+        anchorOrigin={{
+          horizontal: 'right',
+          vertical: 'top',
+        }}
+        transformOrigin={{
+          horizontal: 'left',
+          vertical: 'top',
+        }}
+        onClose={handleClose}
+        {...menuProps}
+      >
+        <MenuItem
+          aria-haspopup="true"
+          disabled={isWorkspaceAddVisible}
+          onClick={(e) => { handleZoomToggleClick(e); }}
+          aria-owns={selectedOption === 'toggleZoom' ? 'toggle-zoom-menu' : undefined}
         >
-          <MenuItem
-            aria-haspopup="true"
-            disabled={isWorkspaceAddVisible}
-            onClick={(e) => { this.handleZoomToggleClick(e); handleClose(e); }}
-            aria-owns={toggleZoom.anchorEl ? 'toggle-zoom-menu' : undefined}
-          >
-            <Typography variant="body1">
-              { showZoomControls ? t('hideZoomControls') : t('showZoomControls') }
-            </Typography>
-          </MenuItem>
-          <MenuItem
-            aria-haspopup="true"
-            onClick={(e) => { this.handleMenuItemClick('workspaceSelection', e); handleClose(e); }}
-            aria-owns={workspaceSelection.anchorEl ? 'workspace-selection' : undefined}
-          >
-            <Typography variant="body1">{t('selectWorkspaceMenu')}</Typography>
-          </MenuItem>
+          <Typography variant="body1">
+            { showZoomControls ? t('hideZoomControls') : t('showZoomControls') }
+          </Typography>
+        </MenuItem>
+        <MenuItem
+          aria-haspopup="true"
+          onClick={(e) => { handleClick('workspaceSelection', e); }}
+          aria-owns={selectedOption === 'workspaceSelection' ? 'workspace-selection' : undefined}
+        >
+          <Typography variant="body1">{t('selectWorkspaceMenu')}</Typography>
+        </MenuItem>
 
-          <NestedMenu label={t('language')}>
-            <LanguageSettings afterSelect={handleClose} />
-          </NestedMenu>
-          { showThemePicker && (
-            <MenuItem
-              aria-haspopup="true"
-              onClick={(e) => { this.handleMenuItemClick('changeTheme', e); handleClose(e); }}
-              aria-owns={changeTheme.anchorEl ? 'change-theme' : undefined}
-            >
-              <Typography variant="body1">{t('changeTheme')}</Typography>
-            </MenuItem>
-          )}
-          <PluginHook {...this.props} />
-        </Menu>
-        {Boolean(changeTheme.open) && (
-          <ChangeThemeDialog
-            container={container?.current}
-            handleClose={this.handleMenuItemClose('changeTheme')}
-            open={Boolean(changeTheme.open)}
-          />
+        <NestedMenu label={t('language')}>
+          <LanguageSettings afterSelect={handleClose} />
+        </NestedMenu>
+        { showThemePicker && (
+          <MenuItem
+            aria-haspopup="true"
+            onClick={(e) => { handleClick('changeTheme', e); }}
+            aria-owns={selectedOption === 'changeTheme' ? 'change-theme' : undefined}
+          >
+            <Typography variant="body1">{t('changeTheme')}</Typography>
+          </MenuItem>
         )}
-        {Boolean(workspaceSelection.open) && (
-          <WorkspaceSelectionDialog
-            open={Boolean(workspaceSelection.open)}
-            container={container?.current}
-            handleClose={this.handleMenuItemClose('workspaceSelection')}
-          />
-        )}
-      </>
-    );
-  }
+        <PluginHook {...pluginProps} />
+      </Menu>
+      {selectedOption === 'changeTheme' && (
+        <ChangeThemeDialog
+          container={container?.current}
+          handleClose={handleDialogClose}
+          open={selectedOption === 'changeTheme'}
+        />
+      )}
+      {selectedOption === 'workspaceSelection' && (
+        <WorkspaceSelectionDialog
+          open={selectedOption === 'workspaceSelection'}
+          container={container?.current}
+          handleClose={handleDialogClose}
+        />
+      )}
+    </>
+  );
 }
 
 WorkspaceMenu.propTypes = {
@@ -156,14 +110,4 @@ WorkspaceMenu.propTypes = {
   t: PropTypes.func,
   toggleZoomControls: PropTypes.func,
   tReady: PropTypes.bool,
-};
-
-WorkspaceMenu.defaultProps = {
-  container: null,
-  isWorkspaceAddVisible: false,
-  showThemePicker: false,
-  showZoomControls: false,
-  t: key => key,
-  toggleZoomControls: () => {},
-  tReady: false,
 };

--- a/src/components/WorkspaceMenuButton.js
+++ b/src/components/WorkspaceMenuButton.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import SettingsIcon from '@mui/icons-material/SettingsSharp';
 import PropTypes from 'prop-types';
 import WorkspaceMenu from '../containers/WorkspaceMenu';
@@ -6,75 +6,44 @@ import MiradorMenuButton from '../containers/MiradorMenuButton';
 
 /**
  */
-export class WorkspaceMenuButton extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      open: false,
-    };
-    this.handleMenuClick = this.handleMenuClick.bind(this);
-    this.handleMenuClose = this.handleMenuClose.bind(this);
-  }
+export function WorkspaceMenuButton({ t = k => k }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [open, setOpen] = useState(false);
 
-  /**
-   * @private
-   */
-  handleMenuClick(event) {
-    this.setState({
-      anchorEl: event.currentTarget,
-      open: true,
-    });
-  }
+  /**  */
+  const handleMenuClick = (event) => {
+    setAnchorEl(event.currentTarget);
+    setOpen(true);
+  };
 
-  /**
-   * @private
-   */
-  handleMenuClose() {
-    this.setState({
-      anchorEl: null,
-      open: false,
-    });
-  }
+  /**  */
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setOpen(false);
+  };
 
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const { t } = this.props;
-    const { anchorEl, open } = this.state;
-
-    return (
-      <>
-        <MiradorMenuButton
-          aria-haspopup="true"
-          aria-label={t('workspaceMenu')}
-          aria-owns={open ? 'workspace-menu' : undefined}
-          selected={open}
-          id="menuBtn"
-          onClick={this.handleMenuClick}
-        >
-          <SettingsIcon />
-        </MiradorMenuButton>
-        <WorkspaceMenu
-          anchorEl={anchorEl}
-          id="workspace-menu"
-          handleClose={this.handleMenuClose}
-          open={open}
-        />
-      </>
-    );
-  }
+  return (
+    <>
+      <MiradorMenuButton
+        aria-haspopup="true"
+        aria-label={t('workspaceMenu')}
+        aria-owns={open ? 'workspace-menu' : undefined}
+        selected={open}
+        id="menuBtn"
+        onClick={handleMenuClick}
+      >
+        <SettingsIcon />
+      </MiradorMenuButton>
+      <WorkspaceMenu
+        anchorEl={anchorEl}
+        id="workspace-menu"
+        handleClose={handleMenuClose}
+        open={open}
+      />
+    </>
+  );
 }
 
 WorkspaceMenuButton.propTypes = {
   t: PropTypes.func,
-};
-
-WorkspaceMenuButton.defaultProps = {
-  t: key => key,
 };

--- a/src/components/WorkspaceOptionsButton.js
+++ b/src/components/WorkspaceOptionsButton.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import MoreHorizontalIcon from '@mui/icons-material/MoreHorizSharp';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
@@ -7,64 +7,38 @@ import WorkspaceOptionsMenu from '../containers/WorkspaceOptionsMenu';
 /**
  * WorkspaceOptionsButton ~
 */
-export class WorkspaceOptionsButton extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      open: false,
-    };
-    this.handleMenuClick = this.handleMenuClick.bind(this);
-    this.handleMenuClose = this.handleMenuClose.bind(this);
-  }
+export function WorkspaceOptionsButton({ t }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [open, setOpen] = useState(false);
 
-  /**
-   * @private
-   */
-  handleMenuClick(event) {
-    this.setState({
-      anchorEl: event.currentTarget,
-      open: true,
-    });
-  }
+  /**  */
+  const handleMenuClick = (event) => {
+    setAnchorEl(event.currentTarget);
+    setOpen(true);
+  };
 
-  /**
-   * @private
-   */
-  handleMenuClose() {
-    this.setState({
-      anchorEl: null,
-      open: false,
-    });
-  }
+  /**  */
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setOpen(false);
+  };
 
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const { t } = this.props;
-    const { anchorEl, open } = this.state;
-
-    return (
-      <>
-        <MiradorMenuButton
-          aria-label={t('workspaceOptions')}
-          onClick={this.handleMenuClick}
-          selected={open}
-        >
-          <MoreHorizontalIcon />
-        </MiradorMenuButton>
-        <WorkspaceOptionsMenu
-          anchorEl={anchorEl}
-          handleClose={this.handleMenuClose}
-          open={open}
-        />
-      </>
-    );
-  }
+  return (
+    <>
+      <MiradorMenuButton
+        aria-label={t('workspaceOptions')}
+        onClick={handleMenuClick}
+        selected={open}
+      >
+        <MoreHorizontalIcon />
+      </MiradorMenuButton>
+      <WorkspaceOptionsMenu
+        anchorEl={anchorEl}
+        handleClose={handleMenuClose}
+        open={open}
+      />
+    </>
+  );
 }
 
 WorkspaceOptionsButton.propTypes = {

--- a/src/components/WorkspaceOptionsMenu.js
+++ b/src/components/WorkspaceOptionsMenu.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import ImportIcon from '@mui/icons-material/Input';
 import SaveAltIcon from '@mui/icons-material/SaveAltSharp';
@@ -13,108 +13,82 @@ import { PluginHook } from './PluginHook';
 /**
  * WorkspaceOptionsMenu ~ the menu for workspace options such as import/export
 */
-export class WorkspaceOptionsMenu extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-    this.state = {
-      exportWorkspace: {},
-      importWorkspace: {},
-    };
-    this.handleMenuItemClick = this.handleMenuItemClick.bind(this);
-    this.handleMenuItemClose = this.handleMenuItemClose.bind(this);
-  }
+export function WorkspaceOptionsMenu({
+  anchorEl = null, container = null, handleClose, open = false, t,
+}) {
+  const [selectedOption, setSelectedOption] = useState(null);
 
-  /**
-   * @private
-   */
-  handleMenuItemClick(item) {
-    const obj = {};
-    obj[item] = {};
-    obj[item].open = true;
-    this.setState(obj);
-  }
+  const pluginProps = {
+    anchorEl, container, handleClose, open, t,
+  };
 
-  /**
-   * @private
-   */
-  handleMenuItemClose(item) {
-    return (event) => {
-      const obj = {};
-      obj[item] = {};
-      obj[item].open = false;
-      this.setState(obj);
-    };
-  }
+  /** */
+  const handleClick = (option) => {
+    setSelectedOption(option);
+    handleClose();
+  };
 
-  /**
-   * Returns the rendered component
-  */
-  render() {
-    const {
-      anchorEl, container, handleClose, t, open,
-    } = this.props;
-    const { exportWorkspace, importWorkspace } = this.state;
+  /** */
+  const handleDialogClose = () => {
+    setSelectedOption(null);
+  };
 
-    return (
-      <>
-        <Menu
-          id="workspace-options-menu"
-          container={container?.current}
-          anchorEl={anchorEl}
-          anchorOrigin={{
-            horizontal: 'right',
-            vertical: 'top',
-          }}
-          transformOrigin={{
-            horizontal: 'left',
-            vertical: 'top',
-          }}
-          open={open}
-          onClose={handleClose}
+  return (
+    <>
+      <Menu
+        id="workspace-options-menu"
+        container={container?.current}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          horizontal: 'right',
+          vertical: 'top',
+        }}
+        transformOrigin={{
+          horizontal: 'left',
+          vertical: 'top',
+        }}
+        open={open}
+        onClose={handleClose}
+      >
+        <MenuItem
+          aria-haspopup="true"
+          onClick={() => { handleClick('exportWorkspace'); }}
+          aria-owns={selectedOption === 'exportWorkspace' ? 'workspace-export' : undefined}
         >
-          <MenuItem
-            aria-haspopup="true"
-            onClick={() => { this.handleMenuItemClick('exportWorkspace'); handleClose(); }}
-            aria-owns={exportWorkspace.open ? 'workspace-export' : undefined}
-          >
-            <ListItemIcon>
-              <SaveAltIcon />
-            </ListItemIcon>
-            <Typography variant="body1">{t('downloadExportWorkspace')}</Typography>
-          </MenuItem>
-          <MenuItem
-            aria-haspopup="true"
-            id="workspace-menu-import"
-            onClick={() => { this.handleMenuItemClick('importWorkspace'); handleClose(); }}
-            aria-owns={exportWorkspace.open ? 'workspace-import' : undefined}
-          >
-            <ListItemIcon>
-              <ImportIcon />
-            </ListItemIcon>
-            <Typography variant="body1">{t('importWorkspace')}</Typography>
-          </MenuItem>
-          <PluginHook {...this.props} />
-        </Menu>
-        {Boolean(exportWorkspace.open) && (
-          <WorkspaceExport
-            open={Boolean(exportWorkspace.open)}
-            container={container?.current}
-            handleClose={this.handleMenuItemClose('exportWorkspace')}
-          />
-        )}
-        {Boolean(importWorkspace.open) && (
-          <WorkspaceImport
-            open={Boolean(importWorkspace.open)}
-            container={container?.current}
-            handleClose={this.handleMenuItemClose('importWorkspace')}
-          />
-        )}
-      </>
-    );
-  }
+          <ListItemIcon>
+            <SaveAltIcon />
+          </ListItemIcon>
+          <Typography variant="body1">{t('downloadExportWorkspace')}</Typography>
+        </MenuItem>
+        <MenuItem
+          aria-haspopup="true"
+          id="workspace-menu-import"
+          onClick={() => { handleClick('importWorkspace'); }}
+          aria-owns={selectedOption === 'importWorkspace' ? 'workspace-import' : undefined}
+        >
+          <ListItemIcon>
+            <ImportIcon />
+          </ListItemIcon>
+          <Typography variant="body1">{t('importWorkspace')}</Typography>
+        </MenuItem>
+        <PluginHook {...pluginProps} />
+      </Menu>
+      {selectedOption === 'exportWorkspace' && (
+        <WorkspaceExport
+          open={selectedOption === 'exportWorkspace'}
+          container={container?.current}
+          handleClose={handleDialogClose}
+        />
+      )}
+      {selectedOption === 'importWorkspace' && (
+        <WorkspaceImport
+          open={selectedOption === 'importWorkspace'}
+          container={container?.current}
+          handleClose={handleDialogClose}
+        />
+      )}
+    </>
+  );
 }
 
 WorkspaceOptionsMenu.propTypes = {
@@ -123,10 +97,4 @@ WorkspaceOptionsMenu.propTypes = {
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   t: PropTypes.func.isRequired,
-};
-
-WorkspaceOptionsMenu.defaultProps = {
-  anchorEl: null,
-  container: null,
-  open: false,
 };

--- a/src/components/WorkspaceSelectionDialog.js
+++ b/src/components/WorkspaceSelectionDialog.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import DialogTitle from '@mui/material/DialogTitle';
 import {
   Card,
@@ -18,158 +17,140 @@ const StyledDetails = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
 }));
+
 /**
  */
-export class WorkspaceSelectionDialog extends Component {
-  /**
-   * constructor
-   */
-  constructor(props) {
-    super(props);
-
-    this.handleWorkspaceTypeChange = this.handleWorkspaceTypeChange.bind(this);
-  }
-
-  /**
-   * Propagate workspace type selection into the global state
-   */
-  handleWorkspaceTypeChange(workspaceType) {
-    const { handleClose, updateWorkspace } = this.props;
+export function WorkspaceSelectionDialog({
+  container = null, handleClose, open = false, children = null, t = k => k, updateWorkspace, workspaceType,
+}) {
+  /** */
+  const handleWorkspaceTypeChange = (newWorkspaceType) => {
     updateWorkspace({
-      type: workspaceType,
+      type: newWorkspaceType,
     });
     handleClose();
-  }
+  };
 
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      container, handleClose, open, children, t, workspaceType,
-    } = this.props;
-    return (
-      <WorkspaceDialog
-        aria-labelledby="workspace-selection-dialog-title"
-        container={container}
-        id="workspace-selection-dialog"
-        onClose={handleClose}
-        open={open}
-      >
-        <DialogTitle id="workspace-selection-dialog-title">
-          {t('workspaceSelectionTitle')}
-        </DialogTitle>
-        <ScrollIndicatedDialogContent>
-          {children}
-          <MenuList
-            sx={{
-              '&active': {
-                outline: 'none',
-              },
-              '&focus': {
-                outline: 'none',
-              },
+  return (
+    <WorkspaceDialog
+      aria-labelledby="workspace-selection-dialog-title"
+      container={container}
+      id="workspace-selection-dialog"
+      onClose={handleClose}
+      open={open}
+    >
+      <DialogTitle id="workspace-selection-dialog-title">
+        {t('workspaceSelectionTitle')}
+      </DialogTitle>
+      <ScrollIndicatedDialogContent>
+        {children}
+        <MenuList
+          sx={{
+            '&active': {
               outline: 'none',
+            },
+            '&focus': {
+              outline: 'none',
+            },
+            outline: 'none',
+          }}
+          selected={workspaceType}
+          autoFocusItem
+        >
+          <MenuItem
+            sx={{
+              height: 'auto',
+              overflow: 'auto',
+              whiteSpace: 'inherit',
             }}
-            selected={workspaceType}
-            autoFocusItem
+            onClick={() => handleWorkspaceTypeChange('elastic')}
+            selected={workspaceType === 'elastic'}
+            value="elastic"
           >
-            <MenuItem
-              sx={{
-                height: 'auto',
-                overflow: 'auto',
-                whiteSpace: 'inherit',
-              }}
-              onClick={() => this.handleWorkspaceTypeChange('elastic')}
-              selected={workspaceType === 'elastic'}
-              value="elastic"
+            <Card sx={{
+              backgroundColor: 'transparent',
+              borderRadius: '0',
+              boxShadow: '0 0 transparent',
+              display: 'flex',
+            }}
             >
-              <Card sx={{
-                backgroundColor: 'transparent',
-                borderRadius: '0',
-                boxShadow: '0 0 transparent',
-                display: 'flex',
-              }}
-              >
-                <WorkspaceTypeElasticIcon
+              <WorkspaceTypeElasticIcon
+                sx={{
+                  flexShrink: 0,
+                  height: '90px',
+                  width: '120px',
+                }}
+                viewBox="0 0 120 90"
+              />
+              <StyledDetails>
+                <CardContent
                   sx={{
-                    flexShrink: 0,
-                    height: '90px',
-                    width: '120px',
-                  }}
-                  viewBox="0 0 120 90"
-                />
-                <StyledDetails>
-                  <CardContent
-                    sx={{
-                      '&.MuiCardContent-root': {
-                        '&:last-child': {
-                          paddingBottom: '12px',
-                        },
-                        paddingBottom: 0,
-                        paddingTop: 0,
-                        textAlign: 'left',
+                    '&.MuiCardContent-root': {
+                      '&:last-child': {
+                        paddingBottom: '12px',
                       },
-                      flex: '1 0 auto',
-                    }}
-                  >
-                    <Typography sx={{ paddingBottom: '6px' }} component="p" variant="h3">{t('elastic')}</Typography>
-                    <Typography variant="body1">{t('elasticDescription')}</Typography>
-                  </CardContent>
-                </StyledDetails>
-              </Card>
-            </MenuItem>
-            <MenuItem
-              sx={{
-                height: 'auto',
-                overflow: 'auto',
-                whiteSpace: 'inherit',
-              }}
-              onClick={() => this.handleWorkspaceTypeChange('mosaic')}
-              selected={workspaceType === 'mosaic'}
-              value="mosaic"
+                      paddingBottom: 0,
+                      paddingTop: 0,
+                      textAlign: 'left',
+                    },
+                    flex: '1 0 auto',
+                  }}
+                >
+                  <Typography sx={{ paddingBottom: '6px' }} component="p" variant="h3">{t('elastic')}</Typography>
+                  <Typography variant="body1">{t('elasticDescription')}</Typography>
+                </CardContent>
+              </StyledDetails>
+            </Card>
+          </MenuItem>
+          <MenuItem
+            sx={{
+              height: 'auto',
+              overflow: 'auto',
+              whiteSpace: 'inherit',
+            }}
+            onClick={() => handleWorkspaceTypeChange('mosaic')}
+            selected={workspaceType === 'mosaic'}
+            value="mosaic"
+          >
+            <Card sx={{
+              backgroundColor: 'transparent',
+              borderRadius: '0',
+              boxShadow: '0 0 transparent',
+              display: 'flex',
+            }}
             >
-              <Card sx={{
-                backgroundColor: 'transparent',
-                borderRadius: '0',
-                boxShadow: '0 0 transparent',
-                display: 'flex',
-              }}
-              >
-                <WorkspaceTypeMosaicIcon
+              <WorkspaceTypeMosaicIcon
+                sx={{
+                  flexShrink: 0,
+                  height: '90px',
+                  width: '120px',
+                }}
+                viewBox="0 0 120 90"
+              />
+              <StyledDetails>
+                <CardContent
                   sx={{
-                    flexShrink: 0,
-                    height: '90px',
-                    width: '120px',
-                  }}
-                  viewBox="0 0 120 90"
-                />
-                <StyledDetails>
-                  <CardContent
-                    sx={{
-                      '&.MuiCardContent-root': {
-                        '&:last-child': {
-                          paddingBottom: '12px',
-                        },
-                        paddingBottom: 0,
-                        paddingTop: 0,
-                        textAlign: 'left',
+                    '&.MuiCardContent-root': {
+                      '&:last-child': {
+                        paddingBottom: '12px',
                       },
-                      flex: '1 0 auto',
-                    }}
-                  >
-                    <Typography sx={{ paddingBottom: '6px' }} component="p" variant="h3">{t('mosaic')}</Typography>
-                    <Typography variant="body1">{t('mosaicDescription')}</Typography>
-                  </CardContent>
-                </StyledDetails>
-              </Card>
-            </MenuItem>
-          </MenuList>
-        </ScrollIndicatedDialogContent>
-      </WorkspaceDialog>
-    );
-  }
+                      paddingBottom: 0,
+                      paddingTop: 0,
+                      textAlign: 'left',
+                    },
+                    flex: '1 0 auto',
+                  }}
+                >
+                  <Typography sx={{ paddingBottom: '6px' }} component="p" variant="h3">{t('mosaic')}</Typography>
+                  <Typography variant="body1">{t('mosaicDescription')}</Typography>
+                </CardContent>
+              </StyledDetails>
+            </Card>
+          </MenuItem>
+        </MenuList>
+      </ScrollIndicatedDialogContent>
+    </WorkspaceDialog>
+  );
 }
 
 WorkspaceSelectionDialog.propTypes = {
@@ -180,11 +161,4 @@ WorkspaceSelectionDialog.propTypes = {
   t: PropTypes.func,
   updateWorkspace: PropTypes.func.isRequired,
   workspaceType: PropTypes.string.isRequired,
-};
-
-WorkspaceSelectionDialog.defaultProps = {
-  children: null,
-  container: null,
-  open: false,
-  t: key => key,
 };

--- a/src/components/ZoomControls.js
+++ b/src/components/ZoomControls.js
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import AddCircleIcon from '@mui/icons-material/AddCircleOutlineSharp';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircleOutlineSharp';
 import { styled } from '@mui/material/styles';
@@ -14,62 +13,36 @@ const StyledZoomControlsWrapper = styled('div')({
 
 /**
  */
-export class ZoomControls extends Component {
-  /**
-   * constructor -
-   */
-  constructor(props) {
-    super(props);
-
-    this.handleZoomInClick = this.handleZoomInClick.bind(this);
-    this.handleZoomOutClick = this.handleZoomOutClick.bind(this);
-  }
-
-  /**
-   * @private
-   */
-  handleZoomInClick() {
-    const { windowId, updateViewport, viewer } = this.props;
-
+export function ZoomControls({
+  windowId = '', updateViewport = () => {}, viewer = {}, t = k => k, zoomToWorld,
+}) {
+  /** */
+  const handleZoomInClick = () => {
     updateViewport(windowId, {
       zoom: viewer.zoom * 2,
     });
-  }
+  };
 
-  /**
-   * @private
-   */
-  handleZoomOutClick() {
-    const { windowId, updateViewport, viewer } = this.props;
-
+  /** */
+  const handleZoomOutClick = () => {
     updateViewport(windowId, {
       zoom: viewer.zoom / 2,
     });
-  }
+  };
 
-  /**
-   * render
-   * @return
-   */
-  render() {
-    const {
-      t, zoomToWorld,
-    } = this.props;
-
-    return (
-      <StyledZoomControlsWrapper>
-        <MiradorMenuButton aria-label={t('zoomIn')} onClick={this.handleZoomInClick}>
-          <AddCircleIcon />
-        </MiradorMenuButton>
-        <MiradorMenuButton aria-label={t('zoomOut')} onClick={this.handleZoomOutClick}>
-          <RemoveCircleIcon />
-        </MiradorMenuButton>
-        <MiradorMenuButton aria-label={t('zoomReset')} onClick={() => zoomToWorld(false)}>
-          <RestoreZoomIcon />
-        </MiradorMenuButton>
-      </StyledZoomControlsWrapper>
-    );
-  }
+  return (
+    <StyledZoomControlsWrapper>
+      <MiradorMenuButton aria-label={t('zoomIn')} onClick={handleZoomInClick}>
+        <AddCircleIcon />
+      </MiradorMenuButton>
+      <MiradorMenuButton aria-label={t('zoomOut')} onClick={handleZoomOutClick}>
+        <RemoveCircleIcon />
+      </MiradorMenuButton>
+      <MiradorMenuButton aria-label={t('zoomReset')} onClick={() => zoomToWorld(false)}>
+        <RestoreZoomIcon />
+      </MiradorMenuButton>
+    </StyledZoomControlsWrapper>
+  );
 }
 
 ZoomControls.propTypes = {
@@ -82,11 +55,4 @@ ZoomControls.propTypes = {
   }),
   windowId: PropTypes.string,
   zoomToWorld: PropTypes.func.isRequired,
-};
-
-ZoomControls.defaultProps = {
-  t: key => key,
-  updateViewport: () => {},
-  viewer: {},
-  windowId: '',
 };


### PR DESCRIPTION
Fixes #1858 

This PR updates all but ~13 components to use functions instead of class-based components to make it easier to use react hooks, etc. The remaining components have some significant complexity and might be better to migrate separately to ease PR review.