### PR TITLE
Fix withSize regression

### DIFF
--- a/__tests__/src/extend/withSize.test.js
+++ b/__tests__/src/extend/withSize.test.js
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import PropTypes from 'prop-types';
 import { withSize } from '../../../src/extend/withSize';
@@ -25,12 +26,12 @@ class ResizeObserver {
 global.ResizeObserver = ResizeObserver;
 
 /** */
-const TestComponent = ({ size }) => (
-  <div>
+const TestComponent = forwardRef(({ size }, ref) => (
+  <div ref={ref}>
     {size.width}
     {size.height}
   </div>
-);
+));
 
 TestComponent.propTypes = {
   size: PropTypes.shape({

--- a/src/components/WindowCanvasNavigationControls.js
+++ b/src/components/WindowCanvasNavigationControls.js
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { alpha, styled } from '@mui/material/styles';
 import classNames from 'classnames';
@@ -30,10 +31,12 @@ const Root = styled(Paper, { name: 'WindowCanvasNavigationControls', slot: 'root
 /**
  * Represents the viewer controls in the mirador workspace.
  */
-export function WindowCanvasNavigationControls({
+export const WindowCanvasNavigationControls = forwardRef(({
   showZoomControls = false, size, visible = true, windowId, zoomToWorld,
-}) {
-  const pluginProps = arguments[0]; // eslint-disable-line prefer-rest-params
+}, ref) => {
+  const pluginProps = {
+    showZoomControls, size, visible, windowId,
+  };
   /**
    * Determine if canvasNavControls are stacked (based on a hard-coded width)
   */
@@ -51,6 +54,7 @@ export function WindowCanvasNavigationControls({
         )
       }
       elevation={0}
+      ref={ref}
     >
       <Stack
         direction={canvasNavControlsAreStacked ? 'column' : 'row'}
@@ -65,7 +69,7 @@ export function WindowCanvasNavigationControls({
       <PluginHook {...pluginProps} />
     </Root>
   );
-}
+});
 
 WindowCanvasNavigationControls.propTypes = {
   showZoomControls: PropTypes.bool,
@@ -73,4 +77,9 @@ WindowCanvasNavigationControls.propTypes = {
   visible: PropTypes.bool,
   windowId: PropTypes.string.isRequired,
   zoomToWorld: PropTypes.func.isRequired,
+};
+
+WindowCanvasNavigationControls.defaultProps = {
+  showZoomControls: false,
+  visible: true,
 };

--- a/src/containers/CompanionWindow.js
+++ b/src/containers/CompanionWindow.js
@@ -45,8 +45,8 @@ const mapDispatchToProps = (dispatch, { windowId, id }) => ({
 });
 
 const enhance = compose(
-  withRef(),
   withSize(),
+  withRef(),
   withTranslation(),
   connect(mapStateToProps, mapDispatchToProps),
   withPlugins('CompanionWindow'),

--- a/src/extend/withSize.js
+++ b/src/extend/withSize.js
@@ -2,16 +2,20 @@
  * when its dependencies went out of date and is very much inspired by its code.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import {
+  forwardRef, useEffect, useRef, useState,
+} from 'react';
 
 /** */
 export function withSize() {
   return function WrapComponent(WrappedComponent) {
     /** */
-    const SizeAwareComponent = (props) => {
+    const SizeAwareComponent = forwardRef((props, ref) => {
       const [size, setSize] = useState({ height: undefined, width: undefined });
-      const elementRef = useRef(null);
+      const defaultElementRef = useRef(null);
       const observerRef = useRef(null);
+
+      const elementRef = ref || defaultElementRef;
 
       useEffect(() => {
         /** */
@@ -33,14 +37,12 @@ export function withSize() {
             observerRef.current.disconnect();
           }
         };
-      }, []);
+      }, [elementRef]);
 
       return (
-        <div ref={elementRef}>
-          <WrappedComponent size={size} {...props} />
-        </div>
+        <WrappedComponent ref={elementRef} size={size} {...props} />
       );
-    };
+    });
 
     return SizeAwareComponent;
   };


### PR DESCRIPTION
With 19c2694a37fc11be971e4677b110e0294eeebf13, the added `<div>` broke the ability to scroll companionWindows because the appropriate styles weren't in the right places in the DOM. This PR removes the additional div and instead ensures the withSize'd components appropriately forward refs to the underlying DOM element.

