### PR TITLE
Guard against null required statements...

### DIFF
--- a/src/components/CollectionDialog.js
+++ b/src/components/CollectionDialog.js
@@ -129,7 +129,7 @@ export function CollectionDialog({
   const rights = manifest && (asArray(manifest.getProperty('rights') || manifest.getProperty('license')));
 
   const requiredStatement = manifest
-    && asArray(manifest.getRequiredStatement()).filter(l => l.getValue()).map(labelValuePair => ({
+    && asArray(manifest.getRequiredStatement()).filter(l => l && l.getValue()).map(labelValuePair => ({
       label: null,
       values: labelValuePair.getValues(),
     }));

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -275,7 +275,7 @@ export const getRequiredStatement = createSelector(
   [getManifestoInstance],
   manifest => manifest
     && asArray(manifest.getRequiredStatement())
-      .filter(l => l.getValues().some(v => v))
+      .filter(l => l && l.getValues().some(v => v))
       .map(labelValuePair => ({
         label: (labelValuePair.label && labelValuePair.label.getValue()) || null,
         values: labelValuePair.getValues(),


### PR DESCRIPTION
... to work around a possible regression in manifesto.js 4.2.21