### PR TITLE
allow user to pass initalViewerConfig into windows

### DIFF
--- a/__tests__/integration/mirador/viewer_config.html
+++ b/__tests__/integration/mirador/viewer_config.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+     var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       theme: {
+         transitions: window.location.port === '4488' ?  { create: () => 'none' } : {},
+       },
+       windows: [{
+         manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+         canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
+         thumbnailNavigationPosition: 'far-bottom',
+         initialViewerConfig: {
+            x: 934,
+            y: 782,
+            // you need to specify zoom for this to look good
+            zoom: 0.0007,
+         }
+       }]
+     });
+    </script>
+  </body>
+</html>

--- a/__tests__/integration/mirador/viewer_config.test.js
+++ b/__tests__/integration/mirador/viewer_config.test.js
@@ -1,0 +1,15 @@
+describe('initialViewerConfig', () => {
+  beforeAll(async () => {
+    // See this html file for where the initialViewerConfig is set
+    await page.goto('http://127.0.0.1:4488/__tests__/integration/mirador/viewer_config.html');
+    await expect(page).toMatchElement('.mirador-window');
+  });
+
+  it('allows initialViewerConfig to be passed', async () => {
+    const viewers = await page.evaluate(() => window.miradorInstance.store.getState().viewers);
+    // matches initialViewerConfig from the html file
+    expect(viewers[Object.keys(viewers)[0]].x).toBe(934);
+    expect(viewers[Object.keys(viewers)[0]].y).toBe(782);
+    expect(viewers[Object.keys(viewers)[0]].zoom).toBe(0.0007);
+  });
+});

--- a/__tests__/src/sagas/app.test.js
+++ b/__tests__/src/sagas/app.test.js
@@ -1,4 +1,4 @@
-import { call } from 'redux-saga/effects';
+import { call, put } from 'redux-saga/effects';
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 
 import { importConfig, importState } from '../../../src/state/sagas/app';
@@ -68,15 +68,13 @@ describe('app-level sagas', () => {
 
       return expectSaga(importConfig, action)
         .provide([
-          [call(addWindow, {
+          [put(addWindow({
             id: 'x', manifestId: 'a', thumbnailNavigationPosition: undefined,
-          }), { type: 'thunk1' }],
-          [call(addWindow, {
+          }))],
+          [put(addWindow({
             id: 'y', manifestId: 'b', thumbnailNavigationPosition: undefined,
-          }), { type: 'thunk2' }],
+          }))],
         ])
-        .put({ type: 'thunk1' })
-        .put({ type: 'thunk2' })
         .run();
     });
   });

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -100,6 +100,7 @@ export class OpenSeadragonViewer extends Component {
 
     if (prevState.viewer === undefined) {
       if (viewerConfig) {
+        viewerConfig.zoom = viewerConfig.zoom || viewer.viewport.imageToViewportZoom(1);
         viewer.viewport.panTo(viewerConfig, true);
         viewer.viewport.zoomTo(viewerConfig.zoom, viewerConfig, true);
         viewerConfig.degrees !== undefined && viewer.viewport.setRotation(viewerConfig.degrees);


### PR DESCRIPTION
Allows user to add 
```
initalViewerConfig: {
          flip: false,
          x: 200,
          y: 200,
          degrees: 90,
          zoom: 0.0009995577178239718
 }
 ```
to 
```
windows: [{
         manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
         canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
         thumbnailNavigationPosition: 'far-bottom',
         initalViewerConfig: {
          flip: false,
          x: 200,
          y: 200,
          degrees: 90,
          zoom: 0.0009995577178239718
        }}]
  ```
     