### PR TITLE
Extract components for handling OSD + tile sources.

### DIFF
--- a/__tests__/src/components/OpenSeadragonTileSource.test.js
+++ b/__tests__/src/components/OpenSeadragonTileSource.test.js
@@ -1,0 +1,135 @@
+import { act, render } from 'test-utils';
+import TileSource from '../../../src/components/OpenSeadragonTileSource';
+import OpenSeadragonViewerContext from '../../../src/contexts/OpenSeadragonViewerContext';
+
+describe('OpenSeadragonTileSource', () => {
+  it('calls addTiledImage with the tile source', () => {
+    const viewer = {
+      addTiledImage: jest.fn(),
+    };
+    const ref = { current: viewer };
+    const tileSource = { '@id': 'http://example.com/image/info.json' };
+
+    render(
+      <OpenSeadragonViewerContext.Provider value={ref}>
+        <TileSource tileSource={tileSource} />
+      </OpenSeadragonViewerContext.Provider>,
+    );
+
+    expect(viewer.addTiledImage).toHaveBeenCalledWith(expect.objectContaining({ tileSource }));
+  });
+
+  it('updates the opacity when the prop changes', async () => {
+    const mockOsdItem = { setOpacity: jest.fn() };
+    const viewer = {
+      addTiledImage: jest.fn().mockImplementation(({ success }) => { success({ item: mockOsdItem }); }),
+      world: {
+        removeItem: jest.fn(),
+      },
+    };
+    const ref = { current: viewer };
+    const tileSource = { '@id': 'http://example.com/image/info.json' };
+
+    const { rerender } = render(
+      <OpenSeadragonViewerContext.Provider value={ref}>
+        <TileSource tileSource={tileSource} />
+      </OpenSeadragonViewerContext.Provider>,
+    );
+    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+      rerender(
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} opacity={0.5} />
+        </OpenSeadragonViewerContext.Provider>,
+      );
+    });
+
+    expect(viewer.addTiledImage).toHaveBeenCalledTimes(1);
+    expect(mockOsdItem.setOpacity).toHaveBeenCalledWith(0.5);
+  });
+
+  it('updates the index when the prop changes', async () => {
+    const mockOsdItem = jest.fn();
+    const viewer = {
+      addTiledImage: jest.fn().mockImplementation(({ success }) => { success({ item: mockOsdItem }); }),
+      world: {
+        removeItem: jest.fn(),
+        setItemIndex: jest.fn(),
+      },
+    };
+
+    const ref = { current: viewer };
+    const tileSource = { '@id': 'http://example.com/image/info.json' };
+
+    const { rerender } = render(
+      <OpenSeadragonViewerContext.Provider value={ref}>
+        <TileSource tileSource={tileSource} />
+      </OpenSeadragonViewerContext.Provider>,
+    );
+    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+      rerender(
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} index={5} />
+        </OpenSeadragonViewerContext.Provider>,
+      );
+    });
+
+    expect(viewer.addTiledImage).toHaveBeenCalledTimes(1);
+    expect(viewer.world.setItemIndex).toHaveBeenCalledWith(mockOsdItem, 5);
+  });
+
+  it('updates the rendered bounds when the prop changes', async () => {
+    const mockOsdItem = { fitBounds: jest.fn() };
+    const viewer = {
+      addTiledImage: jest.fn().mockImplementation(({ success }) => { success({ item: mockOsdItem }); }),
+      world: {
+        removeItem: jest.fn(),
+        setItemIndex: jest.fn(),
+      },
+    };
+
+    const ref = { current: viewer };
+    const tileSource = { '@id': 'http://example.com/image/info.json' };
+
+    const { rerender } = render(
+      <OpenSeadragonViewerContext.Provider value={ref}>
+        <TileSource tileSource={tileSource} />
+      </OpenSeadragonViewerContext.Provider>,
+    );
+    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+      rerender(
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} fitBounds={[0, 0, 10, 10]} />
+        </OpenSeadragonViewerContext.Provider>,
+      );
+    });
+
+    expect(viewer.addTiledImage).toHaveBeenCalledTimes(1);
+    expect(mockOsdItem.fitBounds).toHaveBeenCalled();
+  });
+
+  it('deletes the item from the world when the item is unmounted', async () => {
+    const mockOsdItem = jest.fn();
+    const viewer = {
+      addTiledImage: ({ success }) => { success({ item: mockOsdItem }); },
+      world: {
+        removeItem: jest.fn(),
+      },
+    };
+    const ref = { current: viewer };
+    const tileSource = { '@id': 'http://example.com/image/info.json' };
+
+    const { rerender } = render(
+      <OpenSeadragonViewerContext.Provider value={ref}>
+        <TileSource tileSource={tileSource} />
+      </OpenSeadragonViewerContext.Provider>,
+    );
+
+    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+      rerender(
+        <OpenSeadragonViewerContext.Provider value={ref} />,
+      );
+    });
+
+    expect(viewer.world.removeItem).toHaveBeenCalledWith(mockOsdItem);
+  });
+});

--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -1,5 +1,4 @@
-import { cloneElement } from 'react';
-import { render, screen, waitFor } from 'test-utils';
+import { render, screen } from 'test-utils';
 import PropTypes from 'prop-types';
 import userEvent from '@testing-library/user-event';
 import { Utils } from 'manifesto.js';
@@ -24,25 +23,6 @@ function createWrapper(props) {
   const component = (
     <OpenSeadragonViewer
       classes={{}}
-      infoResponses={[{
-        id: 'a',
-        json: {
-          '@id': 'http://foo',
-          height: 200,
-          width: 100,
-        },
-      }, {
-        id: 'b',
-        json: {
-          '@id': 'http://bar',
-          height: 201,
-          width: 150,
-        },
-      }]}
-      nonTiledImages={[{
-        getProperty: () => { },
-        id: 'http://foo',
-      }]}
       windowId="base"
       config={{}}
       updateViewport={jest.fn()}
@@ -66,10 +46,12 @@ describe('OpenSeadragonViewer', () => {
   beforeEach(() => {
     user = userEvent.setup();
   });
+
   it('renders the component', () => {
     createWrapper({});
     expect(screen.getByLabelText('item')).toHaveClass('mirador-osd-container');
   });
+
   it('renders child components enhanced with additional props', async () => {
     const { viewer } = createWrapper({});
     const fitBounds = jest.fn();
@@ -77,170 +59,6 @@ describe('OpenSeadragonViewer', () => {
 
     await user.click(screen.getByTestId('foo'));
     expect(fitBounds).toHaveBeenCalled();
-  });
-
-  describe('infoResponsesMatch', () => {
-    it('when they do not match', () => {
-      const { component, rerender, viewer } = createWrapper({});
-      const mockClose = jest.spyOn(viewer, 'close');
-
-      rerender(cloneElement(component, { infoResponses: [] }));
-
-      expect(mockClose).toHaveBeenCalled();
-    });
-    it('with an empty array', () => {
-      const { component, rerender, viewer } = createWrapper({ infoResponses: [] });
-      const mockClose = jest.spyOn(viewer, 'close');
-
-      rerender(cloneElement(component, { infoResponses: [] }));
-
-      expect(mockClose).not.toHaveBeenCalled();
-    });
-    it('when the @ids do match', () => {
-      const { component, rerender, viewer } = createWrapper({});
-      const mockClose = jest.spyOn(viewer, 'close');
-
-      const newInfos = [
-        { id: 'a', json: { '@id': 'http://foo' } },
-        { id: 'b', json: { '@id': 'http://bar' } },
-      ];
-
-      rerender(cloneElement(component, { infoResponses: newInfos }));
-
-      expect(mockClose).not.toHaveBeenCalled();
-    });
-    it('when the @ids do not match', () => {
-      const { component, rerender, viewer } = createWrapper({});
-      const mockClose = jest.spyOn(viewer, 'close');
-
-      rerender(cloneElement(component, { infoResponses: [{ id: 'a', json: { '@id': 'http://foo-degraded' } }] }));
-
-      expect(mockClose).toHaveBeenCalled();
-    });
-    it('when the id props match', () => {
-      const { component, rerender, viewer } = createWrapper({
-        infoResponses: [{
-          id: 'a',
-          json: {
-            height: 200,
-            id: 'http://foo',
-            width: 100,
-          },
-        }],
-      });
-      const mockClose = jest.spyOn(viewer, 'close');
-      rerender(cloneElement(component, { infoResponses: [{ id: 'a', json: { id: 'http://foo' } }] }));
-      expect(mockClose).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('nonTiledImagedMatch', () => {
-    it('when they do not match', () => {
-      const { component, rerender, viewer } = createWrapper({});
-      const mockClose = jest.spyOn(viewer, 'close');
-
-      rerender(cloneElement(component, { nonTiledImages: [] }));
-      expect(mockClose).toHaveBeenCalled();
-    });
-    it('with an empty array', () => {
-      const { component, rerender, viewer } = createWrapper({ nonTiledImages: [] });
-      const mockClose = jest.spyOn(viewer, 'close');
-
-      rerender(cloneElement(component, { nonTiledImages: [] }));
-      expect(mockClose).not.toHaveBeenCalled();
-    });
-    it('when the ids do match', () => {
-      const { component, rerender, viewer } = createWrapper({});
-      const mockClose = jest.spyOn(viewer, 'close');
-
-      rerender(cloneElement(component, { nonTiledImages: [{ id: 'http://foo' }] }));
-      expect(mockClose).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('addAllImageSources', () => {
-    it('calls addTileSource for every tileSources and then zoomsToWorld', async () => {
-      const { component, rerender, viewer } = createWrapper({ infoResponses: [] });
-
-      const mockAddTiledImage = jest.spyOn(viewer, 'addTiledImage');
-      const mockFitBounds = jest.spyOn(viewer.viewport, 'fitBounds');
-
-      rerender(cloneElement(component, { infoResponses: [{ id: 'https://stacks.stanford.edu/image/iiif/hg676jb4964%2F0380_796-44' }, { id: 'https://stacks.stanford.edu/image/iiif/fr426cg9537%2FSC1094_s3_b14_f17_Cats_1976_0005' }] }));
-
-      expect(mockAddTiledImage).toHaveBeenCalledTimes(2);
-      await waitFor(() => expect(mockFitBounds).toHaveBeenCalled());
-    });
-
-    it('calls addNonTileSource for every nonTiledImage and then zoomsToWorld', async () => {
-      const { component, rerender, viewer } = createWrapper({ infoResponses: [], nonTiledImages: [] });
-
-      const mockAddNonTiledImage = jest.spyOn(viewer, 'addSimpleImage').mockImplementation(() => true);
-      const mockFitBounds = jest.spyOn(viewer.viewport, 'fitBounds');
-
-      rerender(cloneElement(component, {
-        nonTiledImages: [
-          { getProperty: () => 'Image' },
-          { getProperty: () => 'Image' },
-          { getProperty: () => 'Image' },
-          { getProperty: () => 'Image' },
-        ],
-      }));
-
-      expect(mockAddNonTiledImage).toHaveBeenCalledTimes(4);
-
-      await waitFor(() => expect(mockFitBounds).toHaveBeenCalled());
-    });
-  });
-
-  describe('addNonTiledImage', () => {
-    it('calls addSimpleImage asynchronously on the OSD viewer', () => {
-      const { component, rerender, viewer } = createWrapper({ nonTiledImages: [] });
-      const mockAdd = jest.spyOn(viewer, 'addSimpleImage');
-      rerender(cloneElement(component, { nonTiledImages: [{ getProperty: () => 'Image', id: 'a' }] }));
-
-      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({ url: 'a' }));
-    });
-
-    it('only calls addSimpleImage for images', () => {
-      const { component, rerender, viewer } = createWrapper({ nonTiledImages: [] });
-      const mockAdd = jest.spyOn(viewer, 'addSimpleImage');
-      rerender(cloneElement(component, { nonTiledImages: [{ getProperty: () => 'Video', id: 'a' }] }));
-
-      expect(mockAdd).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('refreshTileProperties', () => {
-    it('updates the index and opacity of the OSD tiles from the canvas world', () => {
-      const setOpacity = jest.fn();
-      const setItemIndex = jest.fn();
-      const canvasWorld = {
-        contentResource: i => i,
-        layerIndexOfImageResource: i => 1 - i,
-        layerOpacityOfImageResource: i => 0.5,
-        layers: [{ id: 'a' }, { id: 'b' }],
-        worldBounds: () => ([0, 0, 100, 100]),
-      };
-      const { component, rerender, viewer } = createWrapper({ canvasWorld });
-
-      const newCanvasWorld = {
-        ...canvasWorld,
-        layers: [{ id: 'a' }, { id: 'c' }],
-      };
-
-      jest.spyOn(viewer.world, 'getItemAt').mockImplementation(i => ({ setOpacity, source: { id: i } }));
-      jest.spyOn(viewer.world, 'setItemIndex').mockImplementation(setItemIndex);
-      jest.spyOn(viewer.world, 'getItemCount').mockImplementation(() => 2);
-
-      rerender(cloneElement(component, { canvasWorld: newCanvasWorld }));
-
-      expect(setOpacity).toHaveBeenCalledTimes(1);
-      expect(setOpacity.mock.calls[0]).toEqual([0.5]);
-
-      expect(setItemIndex).toHaveBeenCalledTimes(1);
-      expect(setItemIndex.mock.calls[0][0].source.id).toEqual(1);
-      expect(setItemIndex.mock.calls[0][1]).toEqual(0);
-    });
   });
 
   describe('zoomToWorld', () => {
@@ -256,50 +74,6 @@ describe('OpenSeadragonViewer', () => {
     });
   });
 
-  describe('componentDidMount', () => {
-    let wrapper;
-
-    beforeEach(() => {
-      wrapper = createWrapper({
-        canvasWorld: new CanvasWorld([]),
-        tileSources: [{ '@id': 'http://foo' }],
-        viewerConfig: { x: 1, y: 0, zoom: 0.5 },
-      });
-    });
-
-    it('controls the OSD viewport pan and zoom', () => {
-      expect(wrapper.viewer.viewport.getZoom()).toBe(0.5);
-      expect(wrapper.viewer.viewport.getCenter()).toEqual({ x: 1, y: 0 });
-    });
-  });
-
-  describe('componentDidUpdate', () => {
-    // Requires canvas to handle canvas-y stuff.
-    it.skip('calls the OSD viewport panTo and zoomTo with the component state and forces a redraw', () => {
-      const { component, rerender, viewer } = createWrapper({});
-
-      rerender(cloneElement(component, {
-        viewerConfig: {
-          flip: false, rotation: 90, x: 0.5, y: 0.5, zoom: 0.1,
-        },
-      }));
-      expect(viewer.viewport.getFlip()).toBe(false);
-      expect(viewer.viewport.getRotation()).toBe(90);
-      expect(viewer.viewport.getZoom()).toBe(0.1);
-      expect(viewer.viewport.getCenter()).toEqual({ x: 0.5, y: 0.5 });
-
-      rerender(cloneElement(component, {
-        viewerConfig: {
-          flip: true, rotation: 0, x: 1, y: 0, zoom: 0.5,
-        },
-      }));
-      expect(viewer.viewport.getFlip()).toBe(true);
-      expect(viewer.viewport.getRotation()).toBe(0);
-      expect(viewer.viewport.getZoom()).toBe(0.5);
-      expect(viewer.viewport.getCenter()).toEqual({ x: 1, y: 0 });
-    });
-  });
-
   describe('onViewportChange', () => {
     it('translates the OSD viewport data into an update to the component state', () => {
       const updateViewport = jest.fn();
@@ -308,6 +82,7 @@ describe('OpenSeadragonViewer', () => {
       jest.replaceProperty(viewer, 'viewport', {
         centerSpringX: { target: { value: 1 } },
         centerSpringY: { target: { value: 0 } },
+        getBounds: () => [],
         getFlip: () => false,
         getRotation: () => 90,
         zoomSpring: { target: { value: 0.5 } },

--- a/setupJest.js
+++ b/setupJest.js
@@ -43,6 +43,9 @@ jest.mock('react-i18next', () => ({
     init: jest.fn(),
     type: '3rdParty',
   },
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
   // this mock makes sure any components using the translate HoC receive the t function as a prop
   withTranslation: () => (WrappedComponent) => {
     /**

--- a/src/components/OpenSeadragonComponent.js
+++ b/src/components/OpenSeadragonComponent.js
@@ -1,0 +1,189 @@
+import Openseadragon from 'openseadragon';
+import PropTypes from 'prop-types';
+import {
+  Children, useEffect, useId, useRef, useReducer,
+  useState, useCallback, cloneElement,
+} from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+import { useTranslation } from 'react-i18next';
+import OpenSeadragonViewerContext from '../contexts/OpenSeadragonViewerContext';
+
+/** Handle setting up OSD for use in mirador + react */
+function OpenSeadragonComponent({
+  children = undefined, Container = 'div', osdConfig = {}, viewerConfig = {}, onUpdateViewport = () => {}, setViewer = () => {}, style = {}, ...passThruProps
+}) {
+  const id = useId();
+  const [grabbing, setGrabbing] = useState(false);
+  const viewerRef = useRef(undefined);
+  const [, forceUpdate] = useReducer(x => x + 1, 0);
+
+  const moveHandler = useDebouncedCallback(useCallback((event) => {
+    /** Shim to provide a mouse-move event coming from the viewer */
+    viewerRef.current?.raiseEvent('mouse-move', event);
+  }, [viewerRef]), 10);
+
+  const onViewportChange = useCallback((event) => {
+    const { viewport } = event.eventSource;
+
+    onUpdateViewport({
+      bounds: viewport.getBounds(),
+      flip: viewport.getFlip(),
+      rotation: viewport.getRotation(),
+      x: Math.round(viewport.centerSpringX.target.value),
+      y: Math.round(viewport.centerSpringY.target.value),
+      zoom: viewport.zoomSpring.target.value,
+    });
+  }, [onUpdateViewport]);
+
+  useEffect(() => {
+    const viewer = viewerRef.current;
+    if (!viewer) return;
+
+    const { viewport } = viewer;
+
+    // @ts-expect-error
+    if (viewerConfig.x && viewerConfig.y
+      && (Math.round(viewerConfig.x) !== Math.round(viewport.centerSpringX.target.value)
+      // @ts-expect-error
+      || Math.round(viewerConfig.y) !== Math.round(viewport.centerSpringY.target.value))) {
+      viewport.panTo(new Openseadragon.Point(viewerConfig.x, viewerConfig.y), false);
+    }
+
+    // @ts-expect-error
+    if (viewerConfig.zoom && viewerConfig.zoom !== viewport.zoomSpring.target.value) {
+      viewport.zoomTo(viewerConfig.zoom, new Openseadragon.Point(viewerConfig.x, viewerConfig.y), false);
+    }
+
+    if (viewerConfig.rotation && viewerConfig.rotation !== viewport.getRotation()) {
+      viewport.setRotation(viewerConfig.rotation);
+    }
+
+    if (viewerConfig.flip !== undefined && (viewerConfig.flip || false) !== viewport.getFlip()) {
+      viewport.setFlip(viewerConfig.flip);
+    }
+
+    if (viewerConfig.bounds && !viewerConfig.x && !viewerConfig.y && !viewerConfig.zoom) {
+      const rect = new Openseadragon.Rect(...viewerConfig.bounds);
+      if (rect.equals(viewport.getBounds())) {
+        viewport.fitBounds(rect, false);
+      }
+    }
+  }, [viewerConfig, viewerRef]);
+
+  // initialize OSD stuff when this component is mounted
+  useEffect(() => {
+    const viewer = Openseadragon({
+      id,
+      ...osdConfig,
+    });
+
+    viewer.addHandler('canvas-drag', () => {
+      setGrabbing(true);
+    });
+
+    viewer.addHandler('canvas-drag-end', () => {
+      setGrabbing(false);
+    });
+
+    viewer.addHandler('canvas-double-click', ({ position, shift }) => {
+      if (!osdConfig.zoomPerDoubleClick) return;
+
+      const currentZoom = viewer.viewport.getZoom();
+      const zoomRatio = (shift ? 1.0 / osdConfig.zoomPerDoubleClick : osdConfig.zoomPerDoubleClick);
+      viewer.viewport.zoomTo(currentZoom * zoomRatio, viewer.viewport.pointFromPixel(position), false);
+    });
+
+    viewer.addHandler('animation-finish', onViewportChange);
+    // @ts-expect-error
+    viewer.innerTracker.moveHandler = moveHandler;
+
+    viewerRef.current = viewer;
+    setViewer(viewer);
+    viewer.addOnceHandler('tile-loaded', () => {
+      const { viewport } = viewer;
+
+      if (viewerConfig.x !== undefined && viewerConfig.y !== undefined) {
+        viewport.panTo(new Openseadragon.Point(viewerConfig.x, viewerConfig.y), true);
+      }
+
+      if (viewerConfig.zoom !== undefined) {
+        viewport.zoomTo(viewerConfig.zoom, new Openseadragon.Point(viewerConfig.x, viewerConfig.y), true);
+      }
+
+      if (viewerConfig.rotation && viewerConfig.rotation !== viewport.getRotation()) {
+        viewport.setRotation(viewerConfig.rotation);
+      }
+
+      if (viewerConfig.flip !== undefined && (viewerConfig.flip || false) !== viewport.getFlip()) {
+        viewport.setFlip(viewerConfig.flip);
+      }
+
+      if (!viewerConfig.x && !viewerConfig.y && !viewerConfig.zoom) {
+        if (viewerConfig.bounds) {
+          viewport.fitBounds(new Openseadragon.Rect(...viewerConfig.bounds), true);
+        } else {
+          viewport.goHome();
+        }
+      }
+    });
+
+    forceUpdate();
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // cleanup OSD viewer cruft when this component is unmounted
+  useEffect(() => () => {
+    const viewer = viewerRef.current;
+
+    if (!viewer) return;
+
+    // @ts-expect-error
+    if (viewer.innerTracker?.moveHandler === moveHandler) {
+      // @ts-expect-error
+      viewer.innerTracker.moveHandler = () => {};
+    }
+    // @ts-expect-error
+    viewer.removeAllHandlers();
+
+    viewer.destroy();
+    viewerRef.current = undefined;
+    setViewer(null);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const canvas = viewerRef?.current?.canvas?.firstElementChild;
+    if (canvas) {
+      canvas.setAttribute('role', 'img');
+      canvas.setAttribute('aria-label', t('digitizedView'));
+      canvas.setAttribute('aria-describedby', id);
+    }
+  }, [viewerRef?.current?.canvas?.firstElementChild, id, t]);
+
+  return (
+    <OpenSeadragonViewerContext.Provider value={viewerRef}>
+      <Container id={id} style={{ ...style, cursor: grabbing ? 'grabbing' : 'grab' }} {...passThruProps}>
+        {Children.map(children, child => (child && cloneElement(child, { viewer: child.props.viewer || viewerRef })))}
+      </Container>
+    </OpenSeadragonViewerContext.Provider>
+  );
+}
+
+OpenSeadragonComponent.propTypes = {
+  children: PropTypes.node,
+  Container: PropTypes.elementType,
+  onUpdateViewport: PropTypes.func,
+  osdConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  setViewer: PropTypes.func,
+  style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  viewerConfig: PropTypes.shape({
+    bounds: PropTypes.arrayOf(PropTypes.number),
+    flip: PropTypes.bool,
+    rotation: PropTypes.number,
+    x: PropTypes.number,
+    y: PropTypes.number,
+    zoom: PropTypes.number,
+  }),
+};
+
+export default OpenSeadragonComponent;

--- a/src/components/OpenSeadragonTileSource.js
+++ b/src/components/OpenSeadragonTileSource.js
@@ -1,0 +1,71 @@
+import Openseadragon from 'openseadragon';
+import PropTypes from 'prop-types';
+import { useContext, useEffect, useRef } from 'react';
+import OpenSeadragonViewerContext from '../contexts/OpenSeadragonViewerContext';
+
+/** OSD tile source shim that adds + updates its tile source data */
+export default function OpenSeadragonTileSource({
+  index = undefined, opacity = undefined, fitBounds = undefined, tileSource = {}, url = undefined,
+}) {
+  const viewer = useContext(OpenSeadragonViewerContext);
+  const tiledImage = useRef(undefined);
+
+  useEffect(() => {
+    if (!opacity) return;
+
+    tiledImage.current?.setOpacity(opacity);
+  }, [opacity]);
+
+  useEffect(() => {
+    if (!fitBounds) return;
+
+    tiledImage.current?.fitBounds(new Openseadragon.Rect(...fitBounds));
+  }, [fitBounds]);
+
+  useEffect(() => {
+    if (!tiledImage.current || !viewer?.current || !index) return;
+
+    viewer.current.world.setItemIndex(tiledImage.current, index);
+  }, [index, viewer]);
+
+  useEffect(() => {
+    if (!viewer?.current) return undefined;
+
+    const promise = new Promise((resolve, reject) => {
+      const localTileSource = (url && { type: 'image', url })
+        || (((typeof tileSource === 'string' || tileSource instanceof String) && tileSource)
+        // OSD mutates this object, so we give it a shallow copy
+        || { ...tileSource });
+
+      viewer.current?.addTiledImage({
+        error: (event) => reject(event),
+        fitBounds: (fitBounds ? new Openseadragon.Rect(...fitBounds) : undefined),
+        index,
+        opacity,
+        success: (event) => resolve(event),
+        tileSource: localTileSource,
+      });
+    }).then((event) => {
+      tiledImage.current = event.item;
+    });
+
+    const osd = viewer.current;
+    return () => (
+      promise.finally(() => {
+        if (osd && tiledImage.current) {
+          osd.world.removeItem(tiledImage.current);
+        }
+      })
+    );
+  }, [viewer?.current, url]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return null;
+}
+
+OpenSeadragonTileSource.propTypes = {
+  fitBounds: PropTypes.arrayOf(PropTypes.number),
+  index: PropTypes.number,
+  opacity: PropTypes.number,
+  tileSource: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  url: PropTypes.string,
+};

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -1,10 +1,8 @@
 import {
-  createRef, Children, cloneElement, Component,
+  useRef, Children, cloneElement, useCallback, useState, useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
-import debounce from 'lodash/debounce';
-import isEqual from 'lodash/isEqual';
 import OpenSeadragon from 'openseadragon';
 import classNames from 'classnames';
 import ns from '../config/css-ns';
@@ -12,385 +10,133 @@ import AnnotationsOverlay from '../containers/AnnotationsOverlay';
 import CanvasWorld from '../lib/CanvasWorld';
 import { PluginHook } from './PluginHook';
 import { OSDReferences } from '../plugins/OSDReferences';
+import OpenSeadragonComponent from './OpenSeadragonComponent';
+import TileSource from './OpenSeadragonTileSource';
 
 const StyledSection = styled('section')({
   cursor: 'grab',
   flex: 1,
   position: 'relative',
 });
+
 /**
  * Represents a OpenSeadragonViewer in the mirador workspace. Responsible for mounting
  * and rendering OSD.
  */
-export class OpenSeadragonViewer extends Component {
-  /**
-   * @param {Object} props
-   */
-  constructor(props) {
-    super(props);
-
-    this.state = { grabbing: false, viewer: undefined };
-    this.ref = createRef();
-    this.apiRef = createRef();
-    OSDReferences.set(props.windowId, this.apiRef);
-    this.onCanvasMouseMove = debounce(this.onCanvasMouseMove.bind(this), 10);
-    this.onViewportChange = this.onViewportChange.bind(this);
-    this.zoomToWorld = this.zoomToWorld.bind(this);
-  }
-
-  /**
-   * React lifecycle event
-   */
-  componentDidMount() {
-    const { osdConfig, t, windowId } = this.props;
-    if (!this.ref.current) {
-      return;
-    }
-
-    const viewer = new OpenSeadragon({
-      id: this.ref.current.id,
-      ...osdConfig,
-    });
-
-    const canvas = viewer.canvas && viewer.canvas.firstElementChild;
-    if (canvas) {
-      canvas.setAttribute('role', 'img');
-      canvas.setAttribute('aria-label', t('digitizedView'));
-      canvas.setAttribute('aria-describedby', `${windowId}-osd`);
-    }
-
-    this.apiRef.current = viewer;
-
-    this.setState({ viewer });
-
-    viewer.addHandler('canvas-double-click', ({ position, shift }) => {
-      const currentZoom = viewer.viewport.getZoom();
-      const zoomRatio = (shift ? 1.0 / osdConfig.zoomPerDoubleClick : osdConfig.zoomPerDoubleClick);
-      viewer.viewport.zoomTo(currentZoom * zoomRatio, viewer.viewport.pointFromPixel(position), false);
-    });
-
-    viewer.addHandler('canvas-drag', () => {
-      this.setState({ grabbing: true });
-    });
-
-    viewer.addHandler('canvas-drag-end', () => {
-      this.setState({ grabbing: false });
-    });
-
-    viewer.addHandler('animation-finish', this.onViewportChange);
-
-    if (viewer.innerTracker) {
-      viewer.innerTracker.moveHandler = this.onCanvasMouseMove;
-    }
-  }
-
-  /**
-   * When the tileSources change, make sure to close the OSD viewer.
-   * When the annotations change, reset the updateCanvas method to make sure
-   * they are added.
-   * When the viewport state changes, pan or zoom the OSD viewer as appropriate
-   */
-  componentDidUpdate(prevProps, prevState) {
-    const {
-      viewerConfig,
-      canvasWorld,
-    } = this.props;
-    const { viewer } = this.state;
-    this.apiRef.current = viewer;
-
-    if (prevState.viewer === undefined) {
-      if (viewerConfig) {
-        viewer.viewport.panTo(viewerConfig, true);
-        viewer.viewport.zoomTo(viewerConfig.zoom, viewerConfig, true);
-        viewerConfig.degrees !== undefined && viewer.viewport.setRotation(viewerConfig.degrees);
-        viewerConfig.flip !== undefined && viewer.viewport.setFlip(viewerConfig.flip);
-      }
-
-      this.addAllImageSources(!(viewerConfig));
-
-      return;
-    }
-
-    if (!this.infoResponsesMatch(prevProps.infoResponses)
-      || !this.nonTiledImagedMatch(prevProps.nonTiledImages)
-    ) {
-      viewer.close();
-      const canvasesChanged = !(isEqual(canvasWorld.canvasIds, prevProps.canvasWorld.canvasIds));
-      if (canvasesChanged && viewer.preserveViewport) {
-        // Do not reset the zoom after add
-        this.addAllImageSources(false);
-      } else {
-        // Reset the zoom if the canvas has changed or if there is no viewerConfig
-        this.addAllImageSources((canvasesChanged || !viewerConfig));
-      }
-    } else if (!isEqual(canvasWorld.layers, prevProps.canvasWorld.layers)) {
-      this.refreshTileProperties();
-    } else if (viewerConfig && viewerConfig !== prevProps.viewerConfig) {
-      const { viewport } = viewer;
-
-      if (viewerConfig.x !== viewport.centerSpringX.target.value
-        || viewerConfig.y !== viewport.centerSpringY.target.value) {
-        viewport.panTo(viewerConfig, false);
-      }
-
-      if (viewerConfig.zoom !== viewport.zoomSpring.target.value) {
-        viewport.zoomTo(viewerConfig.zoom, viewerConfig, false);
-      }
-
-      if (viewerConfig.rotation !== viewport.getRotation()) {
-        viewport.setRotation(viewerConfig.rotation);
-      }
-
-      if (viewerConfig.flip !== viewport.getFlip()) {
-        viewport.setFlip(viewerConfig.flip);
-      }
-    }
-  }
-
-  /**
-   */
-  componentWillUnmount() {
-    const { viewer } = this.state;
-
-    if (viewer.innerTracker
-      && viewer.innerTracker.moveHandler === this.onCanvasMouseMove) {
-      viewer.innerTracker.moveHandler = null;
-    }
-    viewer.removeAllHandlers();
-    this.onCanvasMouseMove.cancel();
-    this.apiRef.current = undefined;
-  }
-
-  /** Shim to provide a mouse-move event coming from the viewer */
-  onCanvasMouseMove(event) {
-    const { viewer } = this.state;
-
-    viewer.raiseEvent('mouse-move', event);
-  }
-
-  /**
-   * Forward OSD state to redux
-   */
-  onViewportChange(event) {
-    const { updateViewport, windowId } = this.props;
-
-    const { viewport } = event.eventSource;
-
+export function OpenSeadragonViewer({
+  children = null, label = null, t, windowId, osdConfig = {}, viewerConfig = null,
+  drawAnnotations = false, infoResponses = [], canvasWorld, nonTiledImages = [], updateViewport,
+}) {
+  const apiRef = useRef();
+  const [viewer, setViewer] = useState(null);
+  const onViewportChange = useCallback(({
+    flip, rotation, x, y, zoom,
+  }) => {
     updateViewport(windowId, {
-      flip: viewport.getFlip(),
-      rotation: viewport.getRotation(),
-      x: Math.round(viewport.centerSpringX.target.value),
-      y: Math.round(viewport.centerSpringY.target.value),
-      zoom: viewport.zoomSpring.target.value,
+      flip,
+      rotation,
+      x,
+      y,
+      zoom,
     });
-  }
+  }, [updateViewport, windowId]);
 
-  /** */
-  addAllImageSources(zoomAfterAdd = true) {
-    const { nonTiledImages, infoResponses } = this.props;
+  const zoomToWorld = useCallback((immediately = true) => {
+    if (!apiRef.current?.viewport) return;
 
-    return Promise.allSettled([
-      ...infoResponses.map(infoResponse => this.addTileSource(infoResponse)),
-      ...nonTiledImages.map(image => this.addNonTiledImage(image)),
-    ]).then(() => {
-      if (infoResponses[0] || nonTiledImages[0]) {
-        if (zoomAfterAdd) this.zoomToWorld();
-        this.refreshTileProperties();
-      }
-    });
-  }
-
-  /** */
-  addNonTiledImage(contentResource) {
-    const { canvasWorld } = this.props;
-    const { viewer } = this.state;
-
-    const type = contentResource.getProperty('type');
-    const format = contentResource.getProperty('format') || '';
-
-    if (!(type === 'Image' || type === 'dctypes:Image' || format.startsWith('image/'))) return Promise.resolve();
-
-    return new Promise((resolve, reject) => {
-      resolve(viewer.addSimpleImage({
-        error: event => reject(event),
-        fitBounds: new OpenSeadragon.Rect(
-          ...canvasWorld.contentResourceToWorldCoordinates(contentResource),
-        ),
-        index: canvasWorld.layerIndexOfImageResource(contentResource),
-        opacity: canvasWorld.layerOpacityOfImageResource(contentResource),
-        success: event => resolve(event),
-        url: contentResource.id,
-      }));
-    });
-  }
-
-  /**
-   */
-  addTileSource(infoResponse) {
-    const { canvasWorld } = this.props;
-    const { viewer } = this.state;
-    return new Promise((resolve, reject) => {
-      // OSD mutates this object, so we give it a shallow copy
-      const tileSource = { ...infoResponse.json };
-      const contentResource = canvasWorld.contentResource(infoResponse.id);
-
-      if (!contentResource) return;
-
-      viewer.addTiledImage({
-        error: event => reject(event),
-        fitBounds: new OpenSeadragon.Rect(
-          ...canvasWorld.contentResourceToWorldCoordinates(contentResource),
-        ),
-        index: canvasWorld.layerIndexOfImageResource(contentResource),
-        opacity: canvasWorld.layerOpacityOfImageResource(contentResource),
-        success: event => resolve(event),
-        tileSource,
-      });
-    });
-  }
-
-  /** */
-  refreshTileProperties() {
-    const { canvasWorld } = this.props;
-    const { viewer } = this.state;
-    const { world } = viewer;
-
-    const items = [];
-    for (let i = 0; i < world.getItemCount(); i += 1) {
-      items.push(world.getItemAt(i));
-    }
-
-    items.forEach((item, i) => {
-      const contentResource = canvasWorld.contentResource(item.source['@id'] || item.source.id);
-      if (!contentResource) return;
-      const newIndex = canvasWorld.layerIndexOfImageResource(contentResource);
-      if (i !== newIndex) world.setItemIndex(item, newIndex);
-      item.setOpacity(canvasWorld.layerOpacityOfImageResource(contentResource));
-    });
-  }
-
-  /**
-   */
-  fitBounds(x, y, w, h, immediately = true) {
-    const { viewer } = this.state;
-
-    viewer && viewer.viewport && viewer.viewport.fitBounds(
-      new OpenSeadragon.Rect(x, y, w, h),
+    apiRef.current.viewport.fitBounds(
+      new OpenSeadragon.Rect(...canvasWorld.worldBounds()),
       immediately,
     );
-  }
+  }, [canvasWorld, apiRef]);
 
-  /**
-   * infoResponsesMatch - compares previous tileSources to current to determine
-   * whether a refresh of the OSD viewer is needed.
-   * @param  {Array} prevTileSources
-   * @return {Boolean}
-   */
-  infoResponsesMatch(prevInfoResponses) {
-    const { infoResponses } = this.props;
+  useEffect(() => {
+    OSDReferences.set(windowId, apiRef);
+  }, [apiRef, windowId]);
 
-    if (infoResponses.length === 0 && prevInfoResponses.length === 0) return true;
-    if (infoResponses.length !== prevInfoResponses.length) return false;
+  useEffect(() => {
+    apiRef.current = viewer;
+  }, [apiRef, viewer]);
 
-    return infoResponses.every((infoResponse, index) => {
-      if (!prevInfoResponses[index]) {
-        return false;
-      }
+  const enhancedChildren = Children.map(children, child => (
+    cloneElement(
+      child,
+      {
+        zoomToWorld,
+      },
+    )
+  ));
 
-      if (!infoResponse.json || !prevInfoResponses[index].json) {
-        return false;
-      }
+  const pluginProps = {
+    canvasWorld,
+    drawAnnotations,
+    infoResponses,
+    label,
+    nonTiledImages,
+    osdConfig,
+    t,
+    updateViewport,
+    viewerConfig,
+    windowId,
+  };
 
-      if (infoResponse.tokenServiceId !== prevInfoResponses[index].tokenServiceId) {
-        return false;
-      }
+  return (
+    <OpenSeadragonComponent
+      className={classNames(ns('osd-container'))}
+      Container={StyledSection}
+      osdConfig={osdConfig}
+      viewerConfig={viewerConfig || { bounds: canvasWorld.worldBounds() }}
+      onUpdateViewport={onViewportChange}
+      setViewer={setViewer}
+      aria-label={t('item', { label })}
+      aria-live="polite"
+    >
+      { infoResponses.map((infoResponse) => {
+        const contentResource = canvasWorld.contentResource(infoResponse.id);
 
-      if (infoResponse.json['@id']
-        && infoResponse.json['@id'] === prevInfoResponses[index].json['@id']) {
-        return true;
-      }
-      if (infoResponse.json.id
-        && infoResponse.json.id === prevInfoResponses[index].json.id) {
-        return true;
-      }
+        if (!contentResource) return null;
 
-      return false;
-    });
-  }
+        const fitBounds = canvasWorld.contentResourceToWorldCoordinates(contentResource);
+        const index = canvasWorld.layerIndexOfImageResource(contentResource);
+        const opacity = canvasWorld.layerOpacityOfImageResource(contentResource);
 
-  /**
-   * nonTiledImagedMatch - compares previous images to current to determin
-   * whether a refresh of the OSD viewer is needed
-   */
-  nonTiledImagedMatch(prevNonTiledImages) {
-    const { nonTiledImages } = this.props;
-    if (nonTiledImages.length === 0 && prevNonTiledImages.length === 0) return true;
+        return (
+          <TileSource
+            key={infoResponse.id}
+            tileSource={infoResponse.json}
+            fitBounds={fitBounds}
+            index={index}
+            opacity={opacity}
+          />
+        );
+      })}
+      { nonTiledImages.map((contentResource) => {
+        const type = contentResource.getProperty('type');
+        const format = contentResource.getProperty('format') || '';
 
-    return nonTiledImages.some((image, index) => {
-      if (!prevNonTiledImages[index]) {
-        return false;
-      }
-      if (image.id === prevNonTiledImages[index].id) {
-        return true;
-      }
-      return false;
-    });
-  }
+        if (!(type === 'Image' || type === 'dctypes:Image' || format.startsWith('image/'))) return null;
 
-  /**
-   * zoomToWorld - zooms the viewer to the extent of the canvas world
-   */
-  zoomToWorld(immediately = true) {
-    const { canvasWorld } = this.props;
-    this.fitBounds(...canvasWorld.worldBounds(), immediately);
-  }
+        const fitBounds = canvasWorld.contentResourceToWorldCoordinates(contentResource);
+        const index = canvasWorld.layerIndexOfImageResource(contentResource);
+        const opacity = canvasWorld.layerOpacityOfImageResource(contentResource);
 
-  /**
-   * Renders things
-   */
-  render() {
-    const {
-      children, label, t, windowId,
-      drawAnnotations,
-    } = this.props;
-    const { viewer, grabbing } = this.state;
-
-    const enhancedChildren = Children.map(children, child => (
-      cloneElement(
-        child,
-        {
-          zoomToWorld: this.zoomToWorld,
-        },
-      )
-    ));
-
-    return (
-      <StyledSection
-        className={classNames(ns('osd-container'))}
-        style={{ cursor: grabbing ? 'grabbing' : undefined }}
-        id={`${windowId}-osd`}
-        ref={this.ref}
-        aria-label={t('item', { label })}
-        aria-live="polite"
-      >
-        { drawAnnotations
-            && <AnnotationsOverlay viewer={viewer} windowId={windowId} /> }
-        { enhancedChildren }
-        <PluginHook viewer={viewer} {...{ ...this.props, children: null }} />
-      </StyledSection>
-    );
-  }
+        return (
+          <TileSource
+            key={contentResource.id}
+            url={contentResource.id}
+            fitBounds={fitBounds}
+            index={index}
+            opacity={opacity}
+          />
+        );
+      })}
+      { drawAnnotations
+          && <AnnotationsOverlay viewer={viewer} windowId={windowId} /> }
+      { enhancedChildren }
+      <PluginHook viewer={viewer} {...pluginProps} />
+    </OpenSeadragonComponent>
+  );
 }
-
-OpenSeadragonViewer.defaultProps = {
-  children: null,
-  drawAnnotations: false,
-  infoResponses: [],
-  label: null,
-  nonTiledImages: [],
-  osdConfig: {},
-  viewerConfig: null,
-};
 
 OpenSeadragonViewer.propTypes = {
   canvasWorld: PropTypes.instanceOf(CanvasWorld).isRequired,

--- a/src/contexts/OpenSeadragonViewerContext.js
+++ b/src/contexts/OpenSeadragonViewerContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const ViewerContext = createContext(undefined);
+
+export default ViewerContext;


### PR DESCRIPTION
This PR extracts components from `OpenSeadragonViewer` that manage the integration between OSD + react. By expressing the tile source as a react component, we're able to take advantage of react's internal rendering smarts instead of having to managing what may have changed.

