### PR TITLE
Extract usePlugins for additive plugins.

### DIFF
--- a/__tests__/integration/mirador/components/WrapIconComponent.jsx
+++ b/__tests__/integration/mirador/components/WrapIconComponent.jsx
@@ -14,4 +14,3 @@ const CustomIcon = () => (
   }
 
   export default WrapIconComponent;
-

--- a/__tests__/src/components/BackgroundPluginArea.test.js
+++ b/__tests__/src/components/BackgroundPluginArea.test.js
@@ -1,5 +1,8 @@
 import { render, screen } from '@tests/utils/test-utils';
 import { BackgroundPluginArea } from '../../../src/components/BackgroundPluginArea';
+import { usePlugins } from '../../../src/extend/usePlugins';
+
+vi.mock('../../../src/extend/usePlugins');
 
 /** */
 const mockComponent = () => (
@@ -8,7 +11,8 @@ const mockComponent = () => (
 
 describe('BackgroundPluginArea', () => {
   it('renders the component', () => {
-    render(<BackgroundPluginArea PluginComponents={[mockComponent]} />);
+    vi.mocked(usePlugins).mockReturnValue({ PluginComponents: [mockComponent] });
+    render(<BackgroundPluginArea />);
     expect(screen.getByTestId('test')).toBeInTheDocument();
   });
 });

--- a/__tests__/src/components/PluginHook.test.js
+++ b/__tests__/src/components/PluginHook.test.js
@@ -1,5 +1,8 @@
 import { render, screen } from '@tests/utils/test-utils';
 import { PluginHook } from '../../../src/components/PluginHook';
+import { usePlugins } from '../../../src/extend/usePlugins';
+
+vi.mock('../../../src/extend/usePlugins');
 
 /** */
 const mockComponentA = () => (
@@ -13,26 +16,24 @@ const mockComponentB = () => (
 
 describe('WindowTopBarPluginArea', () => {
   it('renders nothing when no plugins passed', () => {
+    vi.mocked(usePlugins).mockReturnValue({ PluginComponents: [] });
     render(<PluginHook />);
     expect(screen.queryByTestId('testA')).not.toBeInTheDocument();
     expect(screen.queryByTestId('testB')).not.toBeInTheDocument();
   });
 
   it('renders plugin components if some passed', () => {
-    render(
-      <PluginHook
-        PluginComponents={[mockComponentA, mockComponentB]}
-      />,
-    );
+    vi.mocked(usePlugins).mockReturnValue({ PluginComponents: [mockComponentA, mockComponentB] });
+    render(<PluginHook />);
     expect(screen.getByTestId('testA')).toBeInTheDocument();
     expect(screen.getByTestId('testB')).toBeInTheDocument();
   });
 
   it('does not pass classes to PluginComponents (which will throw warnings for styles plugins)', () => {
+    vi.mocked(usePlugins).mockReturnValue({ PluginComponents: [mockComponentA] });
     render(
       <PluginHook
         classes={{ someLocal: 'classes' }}
-        PluginComponents={[mockComponentA]}
       />,
     );
     // if called with nothing passed as args, .toHaveClass checks for existence of any classes

--- a/__tests__/src/components/WindowTopBarPluginArea.test.js
+++ b/__tests__/src/components/WindowTopBarPluginArea.test.js
@@ -1,5 +1,8 @@
 import { render, screen } from '@tests/utils/test-utils';
 import { WindowTopBarPluginArea } from '../../../src/components/WindowTopBarPluginArea';
+import { usePlugins } from '../../../src/extend/usePlugins';
+
+vi.mock('../../../src/extend/usePlugins');
 
 /** */
 const mockComponent = () => (
@@ -8,7 +11,8 @@ const mockComponent = () => (
 
 describe('WindowTopBarPluginArea', () => {
   it('renders the component', () => {
-    render(<WindowTopBarPluginArea PluginComponents={[mockComponent]} />);
+    vi.mocked(usePlugins).mockReturnValue({ PluginComponents: [mockComponent] });
+    render(<WindowTopBarPluginArea />);
     expect(screen.getByTestId('test')).toBeInTheDocument();
   });
 });

--- a/__tests__/src/components/WindowTopBarPluginMenu.test.js
+++ b/__tests__/src/components/WindowTopBarPluginMenu.test.js
@@ -3,6 +3,9 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { WindowTopBarPluginMenu } from '../../../src/components/WindowTopBarPluginMenu';
+import { usePlugins } from '../../../src/extend/usePlugins';
+
+vi.mock('../../../src/extend/usePlugins');
 
 /** create wrapper */
 function Subject({ ...props }) {
@@ -27,6 +30,7 @@ class mockComponentA extends React.Component {
 describe('WindowTopBarPluginMenu', () => {
   describe('when there are no plugins present', () => {
     it('renders nothing (and no Button/Menu/PluginHook)', () => {
+      vi.mocked(usePlugins).mockReturnValue({ PluginComponents: [] });
       render(<Subject />);
       expect(screen.queryByTestId('testA')).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Window options' })).not.toBeInTheDocument();
@@ -35,9 +39,11 @@ describe('WindowTopBarPluginMenu', () => {
 
   describe('when there are plugins present', () => {
     let user;
+
     beforeEach(() => {
       user = userEvent.setup();
-      render(<Subject PluginComponents={[mockComponentA]} />);
+      vi.mocked(usePlugins).mockReturnValue({ PluginComponents: [mockComponentA] });
+      render(<Subject />);
     });
 
     it('renders the Button', async () => {

--- a/__tests__/src/extend/withPlugins.test.js
+++ b/__tests__/src/extend/withPlugins.test.js
@@ -5,17 +5,11 @@ import { PluginHook } from '../../../src/components/PluginHook';
 import PluginContext from '../../../src/extend/PluginContext';
 
 /** Mock target component */
-const Target = ({ PluginComponents, TargetComponent, ...props }) => (
+const Target = ({ ...props }) => (
   <div data-testid="target" {...props}>
     Hello
-    <PluginHook PluginComponents={PluginComponents} {...props} />
   </div>
 );
-
-Target.propTypes = {
-  PluginComponents: PropTypes.arrayOf(PropTypes.element).isRequired,
-  TargetComponent: PropTypes.elementType.isRequired,
-};
 
 /** create wrapper  */
 function createPluginHoc(pluginMap) {
@@ -84,87 +78,5 @@ describe('PluginHoc: if wrap plugins exist for target', () => {
 
     expect(screen.getByTestId('pluginA')).toBeInTheDocument();
     expect(within(screen.getByTestId('pluginA')).getByTestId('pluginB')).toBeInTheDocument();
-  });
-});
-
-describe('PluginHoc: if add plugins exist but no wrap plugin', () => {
-  it('renders the target component and passes all add plugin components as a prop', () => {
-    /** */ const AddPluginComponentA = props => <div data-testid="a">look i am a plugin</div>;
-    /** */ const AddPluginComponentB = props => <div data-testid="b">look i am a plugin</div>;
-    const plugins = {
-      Target: {
-        add: [
-          { component: AddPluginComponentA, mode: 'add', target: 'Target' },
-          { component: AddPluginComponentB, mode: 'add', target: 'Target' },
-        ],
-      },
-    };
-
-    createPluginHoc(plugins);
-
-    expect(screen.getByTestId('target')).toBeInTheDocument();
-    expect(within(screen.getByTestId('target')).getByTestId('a')).toBeInTheDocument();
-    expect(within(screen.getByTestId('target')).getByTestId('b')).toBeInTheDocument();
-  });
-});
-
-describe('PluginHoc: if wrap plugins AND add plugins exist for target', () => {
-  it('renders the first wrap plugin, ignores add plugins if props are not passed through', () => {
-    /** */ const WrapPluginComponentA = props => <div data-testid="a">look i am a plugin</div>;
-    /** */ const WrapPluginComponentB = props => <div>look i am a plugin</div>;
-    /** */ const AddPluginComponentA = props => <div>look i am a plugin</div>;
-    /** */ const AddPluginComponentB = props => <div>look i am a plugin</div>;
-    const plugins = {
-      Target: {
-        add: [
-          { component: AddPluginComponentA, mode: 'add', target: 'Target' },
-          { component: AddPluginComponentB, mode: 'add', target: 'Target' },
-        ],
-        wrap: [
-          { component: WrapPluginComponentA, mode: 'wrap', target: 'Target' },
-          { component: WrapPluginComponentB, mode: 'wrap', target: 'Target' },
-        ],
-      },
-    };
-
-    createPluginHoc(plugins);
-
-    expect(screen.getByTestId('a')).toBeInTheDocument();
-    expect(screen.queryByTestId('target')).not.toBeInTheDocument();
-  });
-  it('renders the first wrap plugin, renders add plugins if plugin/props are passed through', () => {
-    /** */ const WrapPluginComponentA = ({ targetProps, ...plugin }) => (
-      // eslint-disable-next-line react/destructuring-assignment
-      <div data-testid="a">
-        <plugin.TargetComponent {...targetProps} {...plugin} />
-      </div>
-    );
-
-    WrapPluginComponentA.propTypes = {
-      targetProps: PropTypes.shape({}).isRequired,
-    };
-
-    /** */ const WrapPluginComponentB = props => <div>look i am a plugin</div>;
-    /** */ const AddPluginComponentC = props => <div data-testid="c">look i am a plugin</div>;
-    /** */ const AddPluginComponentD = props => <div data-testid="d">look i am a plugin</div>;
-    const plugins = {
-      Target: {
-        add: [
-          { component: AddPluginComponentC, mode: 'add', target: 'Target' },
-          { component: AddPluginComponentD, mode: 'add', target: 'Target' },
-        ],
-        wrap: [
-          { component: WrapPluginComponentA, mode: 'wrap', target: 'Target' },
-          { component: WrapPluginComponentB, mode: 'wrap', target: 'Target' },
-        ],
-      },
-    };
-
-    createPluginHoc(plugins);
-
-    expect(screen.getByTestId('a')).toBeInTheDocument();
-    expect(within(screen.getByTestId('a')).getByTestId('target')).toBeInTheDocument();
-    expect(within(screen.getByTestId('target')).getByTestId('c')).toBeInTheDocument();
-    expect(within(screen.getByTestId('target')).getByTestId('d')).toBeInTheDocument();
   });
 });

--- a/src/components/AttributionPanel.jsx
+++ b/src/components/AttributionPanel.jsx
@@ -73,7 +73,7 @@ export function AttributionPanel({
       </CompanionWindowSection>
       )}
 
-      <PluginHook {...pluginProps} />
+      <PluginHook targetName="AttributionPanel" {...pluginProps} />
     </CompanionWindow>
   );
 }

--- a/src/components/BackgroundPluginArea.jsx
+++ b/src/components/BackgroundPluginArea.jsx
@@ -5,7 +5,7 @@ import { PluginHook } from './PluginHook';
 /** invisible area where background plugins can add to */
 export const BackgroundPluginArea = ({ PluginComponents = [], ...props }) => (
   <div className={ns('background-plugin-area')} style={{ display: 'none' }}>
-    <PluginHook PluginComponents={PluginComponents} {...props} />
+    <PluginHook targetName="BackgroundPluginArea" PluginComponents={PluginComponents} {...props} />
   </div>
 );
 

--- a/src/components/BackgroundPluginArea.jsx
+++ b/src/components/BackgroundPluginArea.jsx
@@ -1,14 +1,9 @@
-import PropTypes from 'prop-types';
 import ns from '../config/css-ns';
 import { PluginHook } from './PluginHook';
 
 /** invisible area where background plugins can add to */
-export const BackgroundPluginArea = ({ PluginComponents = [], ...props }) => (
+export const BackgroundPluginArea = ({ ...props }) => (
   <div className={ns('background-plugin-area')} style={{ display: 'none' }}>
-    <PluginHook targetName="BackgroundPluginArea" PluginComponents={PluginComponents} {...props} />
+    <PluginHook targetName="BackgroundPluginArea" {...props} />
   </div>
 );
-
-BackgroundPluginArea.propTypes = {
-  PluginComponents: PropTypes.array, // eslint-disable-line react/forbid-prop-types
-};

--- a/src/components/CanvasInfo.jsx
+++ b/src/components/CanvasInfo.jsx
@@ -49,7 +49,7 @@ export function CanvasInfo({
       {canvasMetadata && canvasMetadata.length > 0 && (
         <LabelValueMetadata labelValuePairs={canvasMetadata} />
       )}
-      <PluginHook {...pluginProps} />
+      <PluginHook targetName="CanvasInfo" {...pluginProps} />
     </CollapsibleSection>
   );
 }

--- a/src/components/ErrorContent.jsx
+++ b/src/components/ErrorContent.jsx
@@ -51,7 +51,7 @@ export function ErrorContent({
           </AccordionDetails>
         </InlineAccordion>
       )}
-      <PluginHook {...pluginProps} />
+      <PluginHook targetName="ErrorContent" {...pluginProps} />
     </Alert>
   );
 }

--- a/src/components/ManifestInfo.jsx
+++ b/src/components/ManifestInfo.jsx
@@ -52,7 +52,7 @@ export function ManifestInfo({
         <LabelValueMetadata labelValuePairs={manifestMetadata} />
       )}
 
-      <PluginHook {...pluginProps} />
+      <PluginHook targetName="ManifestInfo" {...pluginProps} />
     </CollapsibleSection>
   );
 }

--- a/src/components/ManifestRelatedLinks.jsx
+++ b/src/components/ManifestRelatedLinks.jsx
@@ -123,7 +123,7 @@ export function ManifestRelatedLinks({
           </>
         )}
       </StyledDl>
-      <PluginHook {...pluginProps} />
+      <PluginHook targetName="ManifestRelatedLinks" {...pluginProps} />
     </CollapsibleSection>
   );
 }

--- a/src/components/OpenSeadragonViewer.jsx
+++ b/src/components/OpenSeadragonViewer.jsx
@@ -137,7 +137,7 @@ export function OpenSeadragonViewer({
       { drawAnnotations
           && <AnnotationsOverlay viewer={viewer} windowId={windowId} /> }
       { enhancedChildren }
-      <PluginHook viewer={viewer} {...pluginProps} />
+      <PluginHook targetName="OpenSeadragonViewer" viewer={viewer} {...pluginProps} />
     </OpenSeadragonComponent>
   );
 }

--- a/src/components/PluginHook.jsx
+++ b/src/components/PluginHook.jsx
@@ -1,9 +1,11 @@
 import { forwardRef, isValidElement, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import { usePlugins } from '../extend/usePlugins';
 
 /** Renders plugins */
-export const PluginHook = forwardRef((props, ref) => {
-  const { PluginComponents } = props; // eslint-disable-line react/prop-types
-  const { classes, ...otherProps } = props; // eslint-disable-line react/prop-types
+export const PluginHook = forwardRef(({ classes = {}, targetName, ...otherProps }, ref) => {
+  const { PluginComponents } = usePlugins(targetName);
+
   return PluginComponents ? (
     PluginComponents.map((PluginComponent, index) => ( // eslint-disable-line react/prop-types
       isValidElement(PluginComponent)
@@ -20,3 +22,8 @@ export const PluginHook = forwardRef((props, ref) => {
 });
 
 PluginHook.displayName = 'PluginHook';
+
+PluginHook.propTypes = {
+  classes: PropTypes.object, // eslint-disable-line react/forbid-prop-types, react/require-default-props
+  targetName: PropTypes.string.isRequired,
+};

--- a/src/components/Window.jsx
+++ b/src/components/Window.jsx
@@ -127,7 +127,7 @@ export function Window({
           </StyledCompanionAreaRight>
         </ContentRow>
         <CompanionArea windowId={windowId} position="far-bottom" />
-        <PluginHook {...ownerState} />
+        <PluginHook targetName="Window" {...ownerState} />
       </Root>
     </ErrorBoundary>
   );

--- a/src/components/WindowAuthenticationBar.jsx
+++ b/src/components/WindowAuthenticationBar.jsx
@@ -71,7 +71,7 @@ export function WindowAuthenticationBar({
           <Typography component="h3" variant="body1" color="inherit">
             { ruleSet ? <SanitizedHtml htmlString={label} ruleSet={ruleSet} /> : label }
           </Typography>
-          <PluginHook {...pluginProps} />
+          <PluginHook targetName="WindowAuthenticationBar" {...pluginProps} />
           { button }
         </StyledTopBar>
       </Paper>
@@ -106,7 +106,7 @@ export function WindowAuthenticationBar({
         <Typography sx={{ paddingBlockEnd: 1, paddingBlockStart: 1 }} component="h3" variant="body1" color="inherit">
           { ruleSet ? <SanitizedHtml htmlString={label} ruleSet={ruleSet} /> : label }
         </Typography>
-        <PluginHook {...pluginProps} />
+        <PluginHook targetName="WindowAuthenticationBar" {...pluginProps} />
         <StyledFauxButton>
           { !open && (
             <Typography variant="button" color="inherit">

--- a/src/components/WindowCanvasNavigationControls.jsx
+++ b/src/components/WindowCanvasNavigationControls.jsx
@@ -70,7 +70,7 @@ export const WindowCanvasNavigationControls = forwardRef(({
       </Stack>
       <ViewerInfo windowId={windowId} />
 
-      <PluginHook {...pluginProps} />
+      <PluginHook targetName="WindowCanvasNavigationControls" {...pluginProps} />
     </Root>
   );
 });

--- a/src/components/WindowSideBarButtons.jsx
+++ b/src/components/WindowSideBarButtons.jsx
@@ -11,6 +11,7 @@ import LayersIcon from '@mui/icons-material/LayersSharp';
 import SearchIcon from '@mui/icons-material/SearchSharp';
 import { useTranslation } from 'react-i18next';
 import CanvasIndexIcon from './icons/CanvasIndexIcon';
+import { usePlugins } from '../extend/usePlugins';
 
 const Root = styled(Tabs, { name: 'WindowSideBarButtons', slot: 'root' })({
   '& .MuiTabs-flexContainer': {
@@ -85,10 +86,10 @@ export function WindowSideBarButtons({
   hasSearchResults = false,
   hasSearchService = false,
   panels = [],
-  PluginComponents = null,
   sideBarPanel = 'closed',
 }) {
   const { t } = useTranslation();
+  const { PluginComponents } = usePlugins("WindowSideBarButtons");
   /** */
   const handleChange = (event, value) => { addCompanionWindow(value); };
 

--- a/src/components/WindowSideBarButtons.jsx
+++ b/src/components/WindowSideBarButtons.jsx
@@ -173,6 +173,5 @@ WindowSideBarButtons.propTypes = {
   hasSearchResults: PropTypes.bool,
   hasSearchService: PropTypes.bool,
   panels: PropTypes.objectOf(PropTypes.bool),
-  PluginComponents: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   sideBarPanel: PropTypes.string,
 };

--- a/src/components/WindowTopBarPluginArea.jsx
+++ b/src/components/WindowTopBarPluginArea.jsx
@@ -5,6 +5,6 @@ import { PluginHook } from './PluginHook';
  */
 export function WindowTopBarPluginArea(props) {
   return (
-    <PluginHook {...props} />
+    <PluginHook targetName="WindowTopBarPluginArea" {...props} />
   );
 }

--- a/src/components/WindowTopBarPluginMenu.jsx
+++ b/src/components/WindowTopBarPluginMenu.jsx
@@ -74,6 +74,5 @@ WindowTopBarPluginMenu.propTypes = {
   container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   menuIcon: PropTypes.element,
   open: PropTypes.bool,
-  PluginComponents: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   windowId: PropTypes.string.isRequired,
 };

--- a/src/components/WindowTopBarPluginMenu.jsx
+++ b/src/components/WindowTopBarPluginMenu.jsx
@@ -6,12 +6,13 @@ import { useTranslation } from 'react-i18next';
 import MiradorMenuButton from '../containers/MiradorMenuButton';
 import { PluginHook } from './PluginHook';
 import WorkspaceContext from '../contexts/WorkspaceContext';
+import { usePlugins } from '../extend/usePlugins';
 
 /**
  *
  */
 export function WindowTopBarPluginMenu({
-  PluginComponents = [], windowId, menuIcon = <MoreVertIcon />,
+  windowId, menuIcon = <MoreVertIcon />,
 }) {
   const { t } = useTranslation();
   const container = useContext(WorkspaceContext);
@@ -19,6 +20,7 @@ export function WindowTopBarPluginMenu({
   const [anchorEl, setAnchorEl] = useState(null);
   const [open, setOpen] = useState(false);
   const windowPluginMenuId = useId();
+  const { PluginComponents } = usePlugins('WindowTopBarPluginMenu');
 
   /** */
   const handleMenuClick = (event) => {
@@ -61,7 +63,7 @@ export function WindowTopBarPluginMenu({
         open={open}
         onClose={handleMenuClose}
       >
-        <PluginHook handleClose={handleMenuClose} {...pluginProps} />
+        <PluginHook targetName="WindowTopBarPluginMenu" handleClose={handleMenuClose} {...pluginProps} />
       </Menu>
     </>
   );

--- a/src/components/WindowTopMenu.jsx
+++ b/src/components/WindowTopMenu.jsx
@@ -2,21 +2,28 @@ import { useContext } from 'react';
 import ListSubheader from '@mui/material/ListSubheader';
 import Popover from '@mui/material/Popover';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import WindowThumbnailSettings from '../containers/WindowThumbnailSettings';
 import WindowViewSettings from '../containers/WindowViewSettings';
 import { PluginHook } from './PluginHook';
 import WorkspaceContext from '../contexts/WorkspaceContext';
+import { usePlugins } from '../extend/usePlugins';
 
 /** Renders plugins */
-function PluginHookWithHeader(props) {
-  const { PluginComponents, t } = props; // eslint-disable-line react/prop-types
-  return PluginComponents ? (
+function PluginHookWithHeader({ targetName, ...props }) {
+  const PluginComponents = usePlugins(targetName);
+  const { t } = useTranslation();
+  return PluginComponents?.length > 0 ? (
     <>
       <ListSubheader role="presentation" disableSticky tabIndex={-1}>{t('windowPluginButtons')}</ListSubheader>
-      <PluginHook {...props} />
+      <PluginHook targetName={targetName} {...props} />
     </>
   ) : null;
 }
+
+PluginHookWithHeader.propTypes = {
+  targetName: PropTypes.string.isRequired,
+};
 
 /**
  */
@@ -51,7 +58,7 @@ export function WindowTopMenu({
       <WindowViewSettings windowId={windowId} handleClose={handleClose} />
       {showThumbnailNavigationSettings
         && <WindowThumbnailSettings windowId={windowId} handleClose={handleClose} />}
-      <PluginHookWithHeader {...pluginProps} />
+      <PluginHookWithHeader targetName="WindowTopMenu" {...pluginProps} />
     </Popover>
   );
 }

--- a/src/components/WorkspaceAdd.jsx
+++ b/src/components/WorkspaceAdd.jsx
@@ -129,7 +129,7 @@ export function WorkspaceAdd({
         ) : (
           <Paper sx={{ margin: 2 }}>
             <Typography style={visuallyHidden} component="h1">{t('miradorResources')}</Typography>
-            <PluginHook {...pluginProps} />
+            <PluginHook targetName="WorkspaceAdd" {...pluginProps} />
             <List disablePadding>
               {manifestList}
             </List>

--- a/src/components/WorkspaceControlPanelButtons.jsx
+++ b/src/components/WorkspaceControlPanelButtons.jsx
@@ -14,7 +14,7 @@ export function WorkspaceControlPanelButtons({ ...rest }) {
       <WorkspaceMenuButton />
       <WorkspaceOptionsButton />
       <FullScreenButton />
-      <PluginHook {...rest} />
+      <PluginHook targetName="WorkspaceControlPanelButtons" {...rest} />
     </>
   );
 }

--- a/src/components/WorkspaceMenu.jsx
+++ b/src/components/WorkspaceMenu.jsx
@@ -85,7 +85,7 @@ export function WorkspaceMenu({
             <Typography variant="body1">{t('changeTheme')}</Typography>
           </MenuItem>
         )}
-        <PluginHook {...pluginProps} />
+        <PluginHook targetName="WorkspaceMenu" {...pluginProps} />
       </Menu>
       {selectedOption === 'changeTheme' && (
         <ChangeThemeDialog

--- a/src/components/WorkspaceOptionsMenu.jsx
+++ b/src/components/WorkspaceOptionsMenu.jsx
@@ -76,7 +76,7 @@ export function WorkspaceOptionsMenu({
           </ListItemIcon>
           <Typography variant="body1">{t('importWorkspace')}</Typography>
         </MenuItem>
-        <PluginHook {...pluginProps} />
+        <PluginHook targetName="WorkspaceOptionsMenu" {...pluginProps} />
       </Menu>
       {selectedOption === 'exportWorkspace' && (
         <WorkspaceExport

--- a/src/extend/usePlugins.js
+++ b/src/extend/usePlugins.js
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import PluginContext from './PluginContext';
+
+/** withPlugins should be the innermost HOC */
+export function usePlugins(targetName) {
+  const pluginMap = useContext(PluginContext);
+
+  const plugins = (pluginMap || {})[targetName];
+
+  const PluginComponents = (plugins?.add || []).map(plugin => plugin.component);
+
+  return { PluginComponents };
+}

--- a/src/extend/withPlugins.jsx
+++ b/src/extend/withPlugins.jsx
@@ -16,16 +16,9 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
 
     const plugins = (pluginMap || {})[targetName];
 
-    if (isEmpty(plugins) || (isEmpty(plugins.wrap) && isEmpty(plugins.add))) {
+    if (isEmpty(plugins) || isEmpty(plugins.wrap)) {
       return <TargetComponent {...passDownProps} />;
     }
-
-    const PluginComponents = (plugins.add || []).map(plugin => plugin.component);
-    const targetComponent = (
-      <TargetComponent {...passDownProps} PluginComponents={PluginComponents} />
-    );
-
-    if (isEmpty(plugins.wrap)) return targetComponent;
 
     /** */
     const pluginWrapper = (children, plugin) => {
@@ -35,7 +28,6 @@ function _withPlugins(targetName, TargetComponent) { // eslint-disable-line no-u
         <WrapPluginComponent
           targetProps={passDownProps}
           {...passDownProps}
-          PluginComponents={PluginComponents}
           TargetComponent={TargetComponent}
         >
           {children}


### PR DESCRIPTION
Instead of relying on the withPlugins HOC to pass in the `add` plugins, we can use the `usePlugins` hook to do this instead. This is a little more explicit and hopefully easier to understand (and perhaps allows for multiple pluggable areas for a component?)