### PR TITLE
Pass through all props to the plugins

### DIFF
--- a/src/components/ManifestInfo.js
+++ b/src/components/ManifestInfo.js
@@ -10,9 +10,10 @@ import { PluginHook } from './PluginHook';
  */
 export function ManifestInfo({
   manifestDescription = null, manifestLabel = null, manifestMetadata = [], manifestSummary = null, id, t = k => k,
+  ...rest
 }) {
   const pluginProps = {
-    id, manifestDescription, manifestLabel, manifestMetadata, manifestSummary,
+    id, manifestDescription, manifestLabel, manifestMetadata, manifestSummary, ...rest,
   };
 
   return (

--- a/src/components/ManifestRelatedLinks.js
+++ b/src/components/ManifestRelatedLinks.js
@@ -25,9 +25,10 @@ export function ManifestRelatedLinks({
   renderings = null,
   seeAlso = null,
   t = k => k,
+  ...rest
 }) {
   const pluginProps = {
-    homepage, id, manifestUrl, related, renderings, seeAlso, t,
+    homepage, id, manifestUrl, related, renderings, seeAlso, t, ...rest,
   };
 
   return (

--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -26,6 +26,7 @@ const StyledSection = styled('section')({
 export function OpenSeadragonViewer({
   children = null, label = null, t, windowId, osdConfig = {}, viewerConfig = null,
   drawAnnotations = false, infoResponses = [], canvasWorld, nonTiledImages = [], updateViewport,
+  ...rest
 }) {
   const apiRef = useRef();
   const [viewer, setViewer] = useState(null);
@@ -78,6 +79,7 @@ export function OpenSeadragonViewer({
     updateViewport,
     viewerConfig,
     windowId,
+    ...rest,
   };
 
   return (

--- a/src/components/WindowCanvasNavigationControls.js
+++ b/src/components/WindowCanvasNavigationControls.js
@@ -34,12 +34,12 @@ const Root = styled(Paper, { name: 'WindowCanvasNavigationControls', slot: 'root
  * Represents the viewer controls in the mirador workspace.
  */
 export const WindowCanvasNavigationControls = forwardRef(({
-  showZoomControls = false, visible = true, windowId, zoomToWorld,
+  showZoomControls = false, visible = true, windowId, zoomToWorld, ...rest
 }, ref) => {
   const [sizeRef, size] = useElementSize();
 
   const pluginProps = {
-    showZoomControls, size, visible, windowId,
+    showZoomControls, size, visible, windowId, ...rest,
   };
   /**
    * Determine if canvasNavControls are stacked (based on a hard-coded width)

--- a/src/components/WorkspaceAdd.js
+++ b/src/components/WorkspaceAdd.js
@@ -39,6 +39,7 @@ const StyledMiradorMenuButton = styled(MiradorMenuButton)(() => ({
  */
 export function WorkspaceAdd({
   addResource = () => {}, catalog = [], setWorkspaceAddVisibility, t = k => k,
+  ...rest
 }) {
   const [addResourcesOpen, setAddResourcesVisibility] = useState(false);
   const ref = useRef();
@@ -79,7 +80,7 @@ export function WorkspaceAdd({
   ));
 
   const pluginProps = {
-    addResource, catalog, setWorkspaceAddVisibility, t,
+    addResource, catalog, setWorkspaceAddVisibility, t, ...rest,
   };
 
   return (

--- a/src/components/WorkspaceOptionsMenu.js
+++ b/src/components/WorkspaceOptionsMenu.js
@@ -15,13 +15,13 @@ import { PluginHook } from './PluginHook';
  * WorkspaceOptionsMenu ~ the menu for workspace options such as import/export
 */
 export function WorkspaceOptionsMenu({
-  anchorEl = null, handleClose, open = false, t,
+  anchorEl = null, handleClose, open = false, t, ...rest
 }) {
   const container = useContext(WorkspaceContext);
   const [selectedOption, setSelectedOption] = useState(null);
 
   const pluginProps = {
-    anchorEl, container, handleClose, open, t,
+    anchorEl, container, handleClose, open, t, ...rest,
   };
 
   /** */


### PR DESCRIPTION
the `PluginHook` depends on props that aren't declared or used in the actual component.