### PR TITLE
Don't let manifesto mutate the manifest json.

### DIFF
--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -10,6 +10,7 @@ import { getConfig } from './config';
 /** */
 function createManifestoInstance(json, locale) {
   if (!json) return undefined;
+  // Use JSON stringify/parse to create a deep copy and prevent Manifesto from mutating the json
   const manifestoObject = Utils.parseManifest(JSON.parse(JSON.stringify(json)), locale ? { locale } : undefined);
   // Local patching of Manifesto so that when its a Collection, it behaves similarly
   if (typeof manifestoObject.getSequences != 'function') {

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -10,7 +10,7 @@ import { getConfig } from './config';
 /** */
 function createManifestoInstance(json, locale) {
   if (!json) return undefined;
-  const manifestoObject = Utils.parseManifest(json, locale ? { locale } : undefined);
+  const manifestoObject = Utils.parseManifest(JSON.parse(JSON.stringify(json)), locale ? { locale } : undefined);
   // Local patching of Manifesto so that when its a Collection, it behaves similarly
   if (typeof manifestoObject.getSequences != 'function') {
     manifestoObject.getSequences = () => [];


### PR DESCRIPTION
This is the other part of #4016. manifesto's been mutating the provided manifest to add its data structures. This isn't a big problem for normal manifests, but the collection representation has a cyclic reference.