### PR TITLE
Expect zero value for opacity and index in OpenSeadragonTileSource

### DIFF
--- a/src/components/OpenSeadragonTileSource.js
+++ b/src/components/OpenSeadragonTileSource.js
@@ -11,7 +11,7 @@ export default function OpenSeadragonTileSource({
   const tiledImage = useRef(undefined);
 
   useEffect(() => {
-    if (!opacity) return;
+    if (opacity == null) return;
 
     tiledImage.current?.setOpacity(opacity);
   }, [opacity]);
@@ -23,7 +23,7 @@ export default function OpenSeadragonTileSource({
   }, [fitBounds]);
 
   useEffect(() => {
-    if (!tiledImage.current || !viewer?.current || !index) return;
+    if (!tiledImage.current || !viewer?.current || index == null) return;
 
     viewer.current.world.setItemIndex(tiledImage.current, index);
   }, [index, viewer]);


### PR DESCRIPTION
`opacity` and `index` might be `0`, so `!opacity` and `!index` might skip necessary changes. You can see the effect if you try hiding a layer from the Layers demo:
https://deploy-preview-3991--mirador-dev.netlify.app/__tests__/integration/mirador/layers.html

(Or maybe try a more simple manifest like https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json .)