### PR TITLE
Update normalize-url package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash": "^4.17.11",
     "manifesto.js": "^4.2.0",
     "merge-refs": "^1.3.0",
-    "normalize-url": "^4.5.0",
+    "normalize-url": "^8.0.0",
     "openseadragon": "^2.4.2 || ^3.0.0 || 4.0.x || ^4.1.1 || ^5.0.0",
     "prop-types": "^15.6.2",
     "rdndmb-html5-to-touch": "^8.0.0",


### PR DESCRIPTION
Part of #3963 

I see the issue noted with dropped browser support, but that comment was from 2020 and browsers may support the syntax by now -- I tested the files where this package is used and it seemed to correctly normalize -- am I missing something?

<img width="1180" alt="Screenshot 2024-12-17 at 9 33 16 AM" src="https://github.com/user-attachments/assets/2662915e-ab6f-4c01-b366-560075dc33ce" />
