### PR TITLE
Remove duplicate background key from dialog scroll

### DIFF
--- a/src/components/ScrollIndicatedDialogContent.js
+++ b/src/components/ScrollIndicatedDialogContent.js
@@ -28,16 +28,9 @@ const Root = styled(DialogContent, { name: 'ScrollIndicatedDialogContent', slot:
     /* Shadow covers */
     background: `linear-gradient(${bgcolor} 30%, rgba(255, 255, 255, 0)), `
       + `linear-gradient(rgba(255, 255, 255, 0), ${bgcolor} 70%) 0 100%, `
-      // Shaddows
-      + 'radial-gradient(50% 0, farthest-side, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)), '
-      + 'radial-gradient(50% 100%, farthest-side, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)) 0 100%,',
-    /* Shadow covers */
-    background: `linear-gradient(${bgcolor} 30%, rgba(255, 255, 255, 0)), ` // eslint-disable-line no-dupe-keys
-      + `linear-gradient(rgba(255, 255, 255, 0), ${bgcolor} 70%) 0 100%, `
-      // Shaddows
+      // Shadows
       + 'radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)), '
       + 'radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, .2), rgba(0, 0, 0, 0)) 0 100%;',
-
     backgroundAttachment: 'local, local, scroll, scroll',
     backgroundRepeat: 'no-repeat',
     backgroundSize: '100% 40px, 100% 40px, 100% 14px, 100% 14px',


### PR DESCRIPTION
This gets rid of a warning when you start up vite.
This syntax is a little hard to parse but I tested the way it looks on Chrome, Safari, and FF after this change and didn't see any impact. The top and bottom shadow is still there.

<img width="596" alt="Screenshot 2024-12-17 at 2 41 35 PM" src="https://github.com/user-attachments/assets/d4431ffe-458e-4829-9984-ab04a55b9a72" />
<img width="471" alt="Screenshot 2024-12-17 at 2 41 40 PM" src="https://github.com/user-attachments/assets/629b777b-23b0-4395-9aa2-4cc31e7ba7a6" />
<img width="531" alt="Screenshot 2024-12-17 at 2 41 58 PM" src="https://github.com/user-attachments/assets/910401ab-065b-43d0-9354-f550ec5420d3" />
