### PR TITLE
Add companionWindowId to the CanvasLayers label selectors...

### DIFF
--- a/src/containers/CanvasLayers.js
+++ b/src/containers/CanvasLayers.js
@@ -9,10 +9,10 @@ import {
 import { CanvasLayers } from '../components/CanvasLayers';
 
 /** For connect */
-const mapStateToProps = (state, { canvasId, windowId }) => ({
-  label: getCanvasLabel(state, { canvasId, windowId }),
-  layerMetadata: getLayers(state, { canvasId, windowId }),
-  layers: getSortedLayers(state, { canvasId, windowId }),
+const mapStateToProps = (state, { canvasId, companionWindowId, windowId }) => ({
+  label: getCanvasLabel(state, { canvasId, companionWindowId, windowId }),
+  layerMetadata: getLayers(state, { canvasId, companionWindowId, windowId }),
+  layers: getSortedLayers(state, { canvasId, companionWindowId, windowId }),
 });
 
 /**


### PR DESCRIPTION
… to ensure we use the contextually relevant locale to render them.