### PR TITLE
Only render the thumbnails if there are canvas groupings in the first place

### DIFF
--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -167,6 +167,7 @@ export function ThumbnailNavigation({
       role="grid"
     >
       <div role="row" style={{ height: '100%', width: '100%' }}>
+        { canvasGroupings.length > 0 && (
         <AutoSizer
           defaultHeight={100}
           defaultWidth={400}
@@ -186,6 +187,7 @@ export function ThumbnailNavigation({
             </List>
           )}
         </AutoSizer>
+        )}
       </div>
     </Paper>
   );


### PR DESCRIPTION
This incidentally fixes a problem with the first item in the canvas navigation, which seems like it might start to render before we have dimension information and we use the default width instead of the canvas width:

Before:
![Screenshot 2024-12-18 at 10 45 37](https://github.com/user-attachments/assets/4d93c622-7bb7-48ce-92d9-64c2366b586b)

After/correct:
![Screenshot 2024-12-18 at 10 45 58](https://github.com/user-attachments/assets/577f8c92-8f2a-4ca8-9251-0c559e9b979f)


