### PR TITLE
Don't run coverage by default (slows down local development)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm test
+    - run: npm test -- --coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       env:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,10 +33,6 @@ export default defineConfig({
     },
   },
   test: {
-    coverage: {
-      all: true,
-      enabled: true,
-    },
     environment: 'happy-dom',
     exclude: ['node_modules'],
     globals: true,


### PR DESCRIPTION
Just run it in CI (or on-demand)