### PR TITLE
Backport exports to package.json

### DIFF
--- a/__tests__/src/components/Window.test.js
+++ b/__tests__/src/components/Window.test.js
@@ -1,4 +1,4 @@
-import { MosaicWindowContext } from 'react-mosaic-component/lib/contextTypes';
+import { MosaicWindowContext } from 'react-mosaic-component2';
 import { render, screen } from 'test-utils';
 
 import { Window } from '../../../src/components/Window';

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0",
     "react-image": "^4.0.1",
     "react-intersection-observer": "^9.0.0",
-    "react-mosaic-component": "^6.0.0",
+    "react-mosaic-component2": "^6.0.0",
     "react-redux": "^8.0.0 || ^9.0.0",
     "react-resize-observer": "^1.1.1",
     "react-rnd": "^10.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "An open-source, web-based 'multi-up' viewer that supports zoom-pan-rotate functionality, ability to display/compare simple images, and images with annotations.",
   "main": "dist/cjs/src/index.js",
   "module": "dist/es/src/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/es/src/index.js",
+      "require": "./dist/cjs/src/index.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -2,7 +2,7 @@ import { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Paper from '@mui/material/Paper';
-import { MosaicWindowContext } from 'react-mosaic-component/lib/contextTypes';
+import { MosaicWindowContext } from 'react-mosaic-component2';
 import { ErrorBoundary } from 'react-error-boundary';
 import ns from '../config/css-ns';
 import WindowTopBar from '../containers/WindowTopBar';

--- a/src/components/WorkspaceMosaic.js
+++ b/src/components/WorkspaceMosaic.js
@@ -5,7 +5,7 @@ import GlobalStyles from '@mui/material/GlobalStyles';
 import { DndContext } from 'react-dnd';
 import {
   Mosaic, MosaicWindow, getLeaves, createBalancedTreeFromLeaves,
-} from 'react-mosaic-component';
+} from 'react-mosaic-component2';
 import difference from 'lodash/difference';
 import isEqual from 'lodash/isEqual';
 import classNames from 'classnames';

--- a/src/lib/MosaicLayout.js
+++ b/src/lib/MosaicLayout.js
@@ -1,7 +1,7 @@
-import { createRemoveUpdate, updateTree } from 'react-mosaic-component/lib/util/mosaicUpdates';
+import { createRemoveUpdate, updateTree } from 'react-mosaic-component2';
 import {
   getNodeAtPath, getOtherDirection, getPathToCorner, Corner,
-} from 'react-mosaic-component/lib/util/mosaicUtilities';
+} from 'react-mosaic-component2';
 import dropRight from 'lodash/dropRight';
 
 /** */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,10 @@ const baseConfig = mode => ({
         },
         test: /\.(js|mjs|jsx)$/,
       },
+      {
+        test: /\.mjs$/i,
+        resolve: { byDependency: { esm: { fullySpecified: false } } }
+      },
     ],
   },
   optimization: {


### PR DESCRIPTION
Apparently `exports` is the preferred (and cross-build tool) way to express `main` and `module`. Hoping this fixes plugins using the vite build system (at least with older versions of nodejs):

> Error: require() of ES Module /home/runner/work/mirador-dl-plugin/mirador-dl-plugin/node_modules/react-dnd/dist/index.js from /home/runner/work/mirador-dl-plugin/mirador-dl-plugin/node_modules/mirador/dist/cjs/src/components/AppProviders.js not supported.

(note that it's picking up the CJS bundle instead of the ESM bundle). react-mosaic-component isn't ready for ESM either, but there's a released fork that should get us through in the meantime.