### PR TITLE
Remove unnecessary createSelector

### DIFF
--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -100,20 +100,6 @@ function getProperty(property) {
 }
 
 /**
- * Returns the manifest provider.
- * @param {object} state
- * @param {object} props
- * @param {string} props.companionWindowId
- * @returns {string}
- */
-export const getManifestProvider = createSelector(
-  [
-    getProperty('provider'),
-  ],
-  (provider) => provider,
-);
-
-/**
  * Return the IIIF v3 provider of a manifest or null.
  * @param {object} state
  * @param {object} props
@@ -138,7 +124,7 @@ export const getManifestProviderName = createSelector(
  * @returns {string|null}
  */
 export const getProviderLogo = createSelector(
-  [getManifestProvider],
+  [getProperty('provider')],
   (provider) => {
     const logo = provider && provider[0] && provider[0].logo && provider[0].logo[0];
     if (!logo) return null;


### PR DESCRIPTION
Fixes warning

> The result function returned its own inputs without modification. e.g createSelector([state => state.todos], todos => todos) This could lead to inefficient memoization and unnecessary re-renders. Ensure transformation logic is in the result function, and extraction logic is in the input selectors.

The function was just returning itself.