### PR TITLE
[3.x] Ensure viewerConfig exists in OpenSeadragonViewer condition

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -104,7 +104,7 @@ export class OpenSeadragonViewer extends Component {
       }
     } else if (!isEqual(canvasWorld.layers, prevProps.canvasWorld.layers)) {
       this.refreshTileProperties();
-    } else if (viewerConfig !== prevProps.viewerConfig) {
+    } else if (viewerConfig && viewerConfig !== prevProps.viewerConfig) {
       const { viewport } = viewer;
 
       if (viewerConfig.x !== viewport.centerSpringX.target.value


### PR DESCRIPTION
Fixes #4079

I was not able to reproduce this bug in the 4.x alpha branch.