### PR TITLE
Externalize i18next in Vite's rollupOptions

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -43,6 +43,8 @@ export default defineConfig({
           external: [
             ...Object.keys(packageJson.peerDependencies),
             'react/jsx-runtime',
+            'react-i18next',
+            'i18next',
             '__tests__/*',
             '__mocks__/*',
           ],


### PR DESCRIPTION
Fixes an issue with integrating plugins that also have translations.