### PR TITLE
Loosen PluginComponents PropType requirement for WindowTopBarPluginMenu

### DIFF
--- a/src/components/WindowTopBarPluginMenu.js
+++ b/src/components/WindowTopBarPluginMenu.js
@@ -72,8 +72,6 @@ WindowTopBarPluginMenu.propTypes = {
   container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   menuIcon: PropTypes.element,
   open: PropTypes.bool,
-  PluginComponents: PropTypes.arrayOf(
-    PropTypes.node,
-  ),
+  PluginComponents: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   windowId: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
This removes an ~~error~~ scary warning found in testing plugin integration in M4 (specifically as part of https://github.com/sul-dlss/sul-embed/pull/2333)

<img width="1321" alt="Screenshot 2025-02-06 at 12 27 02 PM" src="https://github.com/user-attachments/assets/166b7a17-9eb6-4eec-a842-0996452963d7" />


This aligns this PropType with other components: for example see https://github.com/ProjectMirador/mirador/blob/6e15d9f3a1ff45a718025394ddede31062fcebf3/src/components/BackgroundPluginArea.js#L13 