### PR TITLE
add translate hook to plugins

### DIFF
--- a/src/components/PluginHook.js
+++ b/src/components/PluginHook.js
@@ -1,16 +1,19 @@
 import { forwardRef, isValidElement, cloneElement } from 'react';
+import { useTranslation } from 'react-i18next';
 
 /** Renders plugins */
 export const PluginHook = forwardRef((props, ref) => {
   const { PluginComponents } = props; // eslint-disable-line react/prop-types
   const { classes, ...otherProps } = props; // eslint-disable-line react/prop-types
+  const {t} = useTranslation()
   return PluginComponents ? (
     PluginComponents.map((PluginComponent, index) => ( // eslint-disable-line react/prop-types
       isValidElement(PluginComponent)
-        ? cloneElement(PluginComponent, { ...otherProps, ref })
+        ? cloneElement(PluginComponent, {t,  ...otherProps, ref })
         : (
           <PluginComponent
             ref={ref}
+            t={t}
             {...otherProps}
             key={index} // eslint-disable-line react/no-array-index-key
           />


### PR DESCRIPTION
Updating my mirador setup to the recent 4.0 alpha I ran into problems using the mirador-image-plugin, because it didn't get the translation function it expected as a prop `t`. This commit solved it for me locally.

Feel free to use this.

Best