### PR TITLE
Move ThumbnailFactory and manifesto.js wrappers into selectors and hooks

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.js
+++ b/__tests__/src/components/AnnotationsOverlay.test.js
@@ -2,10 +2,10 @@ import { cloneElement } from 'react';
 import { render, screen } from '@tests/utils/test-utils';
 import OpenSeadragon from 'openseadragon';
 import { Utils } from 'manifesto.js';
+import { getCanvasWorld } from '../../utils/mirador-wrappers';
 import { AnnotationsOverlay } from '../../../src/components/AnnotationsOverlay';
 import OpenSeadragonCanvasOverlay from '../../../src/lib/OpenSeadragonCanvasOverlay';
 import AnnotationList from '../../../src/lib/AnnotationList';
-import CanvasWorld from '../../../src/lib/CanvasWorld';
 import fixture from '../../fixtures/version-2/019.json';
 
 const canvases = Utils.parseManifest(fixture).getSequences()[0].getCanvases();
@@ -25,7 +25,7 @@ const createWrapper = (props) => {
       windowId="base"
       config={{}}
       updateViewport={vi.fn()}
-      canvasWorld={new CanvasWorld(canvases)}
+      canvasWorld={getCanvasWorld(canvases)}
       {...props}
     />
   );

--- a/__tests__/src/components/IIIFThumbnail.test.js
+++ b/__tests__/src/components/IIIFThumbnail.test.js
@@ -8,6 +8,7 @@ import { IIIFThumbnail } from '../../../src/components/IIIFThumbnail';
 function createWrapper(props) {
   return render(
     <IIIFThumbnail
+      resource={{}}
       {...props}
     />,
   );

--- a/__tests__/src/components/OpenSeadragonViewer.test.js
+++ b/__tests__/src/components/OpenSeadragonViewer.test.js
@@ -2,8 +2,8 @@ import { render, screen } from '@tests/utils/test-utils';
 import PropTypes from 'prop-types';
 import userEvent from '@testing-library/user-event';
 import { Utils } from 'manifesto.js';
+import { getCanvasWorld } from '../../utils/mirador-wrappers';
 import { OpenSeadragonViewer } from '../../../src/components/OpenSeadragonViewer';
-import CanvasWorld from '../../../src/lib/CanvasWorld';
 import fixture from '../../fixtures/version-2/019.json';
 import { OSDReferences } from '../../../src/plugins/OSDReferences';
 
@@ -26,7 +26,7 @@ function createWrapper(props) {
       windowId="base"
       config={{}}
       updateViewport={vi.fn()}
-      canvasWorld={new CanvasWorld(canvases)}
+      canvasWorld={getCanvasWorld(canvases)}
       {...props}
     >
       <Child testId="foo" />

--- a/__tests__/src/lib/CanvasWorld.test.js
+++ b/__tests__/src/lib/CanvasWorld.test.js
@@ -1,15 +1,16 @@
 import { Utils } from 'manifesto.js';
+import { wrapCanvas } from '../../utils/mirador-wrappers';
 import fixture from '../../fixtures/version-2/019.json';
 import fragmentFixture from '../../fixtures/version-2/hamilton.json';
 import CanvasWorld from '../../../src/lib/CanvasWorld';
 
-const canvases = Utils.parseManifest(fixture).getSequences()[0].getCanvases();
+const canvases = Utils.parseManifest(fixture).getSequences()[0].getCanvases().map(wrapCanvas);
 const canvasSubset = [canvases[1], canvases[2]];
 
 describe('CanvasWorld', () => {
   describe('constructor', () => {
     it('sets canvases', () => {
-      expect(new CanvasWorld([1]).canvases.map(c => c.canvas)).toEqual([1]);
+      expect(new CanvasWorld([wrapCanvas(1)]).canvases.map(c => c.canvas)).toEqual([1]);
     });
   });
   describe('hasDimensions', () => {
@@ -45,7 +46,7 @@ describe('CanvasWorld', () => {
     });
     it('when placed by a fragment contains the offset', () => {
       const subject = new CanvasWorld(
-        [Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0]],
+        [Utils.parseManifest(fragmentFixture).getSequences()[0].getCanvases()[0]].map(wrapCanvas),
       );
       expect(subject.contentResourceToWorldCoordinates({ id: 'https://prtd.app/image/iiif/2/hamilton%2fHL_524_1r_00_PC17/full/739,521/0/default.jpg' }))
         .toEqual([552, 1584, 3360, 2368]);

--- a/__tests__/src/selectors/thumbnails.test.js
+++ b/__tests__/src/selectors/thumbnails.test.js
@@ -1,0 +1,18 @@
+import { Utils } from 'manifesto.js';
+import settings from '../../../src/config/settings';
+import { ThumbnailFactory } from '../../../src/lib/ThumbnailFactory';
+import {
+  getThumbnailFactory,
+} from '../../../src/state/selectors/thumbnails';
+
+/** return the slice of config relevant to MiradorCanvas */
+const miradorConfigSlice = () => ({ auth: settings.auth, canvas: settings.canvas, image: settings.image });
+
+describe('getThumbnailFactory', () => {
+  const state = { config: miradorConfigSlice() };
+  const iiifOpts = {};
+  it('returns the manifest of a certain id', () => {
+    const received = getThumbnailFactory(state, iiifOpts);
+    expect(received).toBeInstanceOf(ThumbnailFactory);
+  });
+});

--- a/__tests__/src/selectors/thumbnails.test.js
+++ b/__tests__/src/selectors/thumbnails.test.js
@@ -11,7 +11,7 @@ const miradorConfigSlice = () => ({ auth: settings.auth, canvas: settings.canvas
 describe('getThumbnailFactory', () => {
   const state = { config: miradorConfigSlice() };
   const iiifOpts = {};
-  it('returns the manifest of a certain id', () => {
+  it('returns a ThumbnailFactory', () => {
     const received = getThumbnailFactory(state, iiifOpts);
     expect(received).toBeInstanceOf(ThumbnailFactory);
   });

--- a/__tests__/utils/mirador-wrappers.js
+++ b/__tests__/utils/mirador-wrappers.js
@@ -1,0 +1,8 @@
+import CanvasWorld from '../../src/lib/CanvasWorld';
+import MiradorCanvas from '../../src/lib/MiradorCanvas';
+
+/** wrap a manifesto canvas as mirador canvas  */
+export const wrapCanvas = (c) => new MiradorCanvas(c);
+
+/** CanvasWorld factory function provided by container */
+export const getCanvasWorld = (canvases) => new CanvasWorld(canvases.map(wrapCanvas));

--- a/src/components/IIIFThumbnail.js
+++ b/src/components/IIIFThumbnail.js
@@ -4,8 +4,8 @@ import {
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { useInView } from 'react-intersection-observer';
-import getThumbnail from '../lib/ThumbnailFactory';
 import { IIIFResourceLabel } from './IIIFResourceLabel';
+import { useThumbnailService } from '../hooks';
 
 const Root = styled('div', { name: 'IIIFThumbnail', slot: 'root' })({});
 
@@ -24,11 +24,11 @@ const Image = styled('img', { name: 'IIIFThumbnail', slot: 'image' })(() => ({
  */
 const LazyLoadedImage = ({
   border = false, placeholder, style = {}, thumbnail = null,
-  resource, maxHeight = null, maxWidth = null, thumbnailsConfig = {}, ...props
+  resource, maxHeight = null, maxWidth = null, ...props
 }) => {
   const { ref, inView } = useInView();
   const [loaded, setLoaded] = useState(false);
-
+  const thumbnailService = useThumbnailService(maxHeight, maxWidth);
   /**
    * Handles the intersection (visibility) of a given thumbnail, by requesting
    * the image and then updating the state.
@@ -42,12 +42,12 @@ const LazyLoadedImage = ({
   const image = useMemo(() => {
     if (thumbnail) return thumbnail;
 
-    const i = getThumbnail(resource, { ...thumbnailsConfig, maxHeight, maxWidth });
+    const i = thumbnailService.get(resource);
 
     if (i && i.url) return i;
 
     return undefined;
-  }, [resource, thumbnail, maxWidth, maxHeight, thumbnailsConfig]);
+  }, [resource, thumbnail, thumbnailService]);
 
   const imageStyles = useMemo(() => {
     const styleProps = {
@@ -128,7 +128,6 @@ LazyLoadedImage.propTypes = {
     url: PropTypes.string.isRequired,
     width: PropTypes.number,
   }),
-  thumbnailsConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 const defaultPlaceholder = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mMMDQmtBwADgwF/Op8FmAAAAABJRU5ErkJggg==';
@@ -147,7 +146,6 @@ export function IIIFThumbnail({
   resource,
   style = {},
   thumbnail = null,
-  thumbnailsConfig = {},
 }) {
   const ownerState = arguments[0]; // eslint-disable-line prefer-rest-params
 
@@ -159,7 +157,6 @@ export function IIIFThumbnail({
         resource={resource}
         maxHeight={maxHeight}
         maxWidth={maxWidth}
-        thumbnailsConfig={thumbnailsConfig}
         style={style}
         border={border}
       />
@@ -189,6 +186,5 @@ IIIFThumbnail.propTypes = {
     url: PropTypes.string.isRequired,
     width: PropTypes.number,
   }),
-  thumbnailsConfig: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   variant: PropTypes.oneOf(['inside', 'outside']), // eslint-disable-line react/no-unused-prop-types
 };

--- a/src/components/ThumbnailNavigation.js
+++ b/src/components/ThumbnailNavigation.js
@@ -5,7 +5,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { VariableSizeList as List } from 'react-window';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import CanvasWorld from '../lib/CanvasWorld';
+import { useCanvasWorldService } from '../hooks';
 import ThumbnailCanvasGrouping from '../containers/ThumbnailCanvasGrouping';
 import ns from '../config/css-ns';
 /**
@@ -19,6 +19,7 @@ export function ThumbnailNavigation({
   const spacing = 8; // 2 * (2px margin + 2px border + 2px padding + 2px padding)
   const gridRef = useRef();
   const previousView = useRef(view);
+  const canvasWorlds = useCanvasWorldService();
 
   useEffect(() => {
     if (previousView.current !== view && position !== 'off') {
@@ -61,7 +62,7 @@ export function ThumbnailNavigation({
     const canvases = canvasGroupings[index];
     if (!canvases) return thumbnailNavigation.width + spacing;
 
-    const world = new CanvasWorld(canvases);
+    const world = canvasWorlds.get(canvases);
     const bounds = world.worldBounds();
     switch (position) {
       case 'far-right': {

--- a/src/containers/WindowSideBarButtons.js
+++ b/src/containers/WindowSideBarButtons.js
@@ -9,6 +9,7 @@ import {
   getCompanionWindowsForPosition,
   getAnnotationResourcesByMotivation,
   getManifestSearchService,
+  getMiradorCanvasWrapper,
   getSearchQuery,
   getWindow,
   getWindowConfig,
@@ -27,14 +28,14 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
 });
 
 /** */
-function hasLayers(canvases) {
-  return canvases && canvases.some(c => new MiradorCanvas(c).imageResources.length > 1);
+function hasLayers(canvases, getMiradorCanvas) {
+  return canvases && canvases.some(c => getMiradorCanvas(c).imageResources.length > 1);
 }
 
 /** */
-function hasAnnotations(canvases) {
+function hasAnnotations(canvases, getMiradorCanvas) {
   return canvases && canvases.some(c => {
-    const canvas = new MiradorCanvas(c);
+    const canvas = getMiradorCanvas(c);
 
     return canvas.annotationListUris.length > 0
       || canvas.canvasAnnotationPages.length > 0;
@@ -60,9 +61,9 @@ const mapStateToProps = (state, { windowId }) => ({
     state,
     { windowId },
   ).length > 0,
-  hasAnyAnnotations: hasAnnotations(getCanvases(state, { windowId })),
-  hasAnyLayers: hasLayers(getCanvases(state, { windowId })),
-  hasCurrentLayers: hasLayers(getVisibleCanvases(state, { windowId })),
+  hasAnyAnnotations: hasAnnotations(getCanvases(state, { windowId }), getMiradorCanvasWrapper(state)),
+  hasAnyLayers: hasLayers(getCanvases(state, { windowId }), getMiradorCanvasWrapper(state)),
+  hasCurrentLayers: hasLayers(getVisibleCanvases(state, { windowId }), getMiradorCanvasWrapper(state)),
   hasSearchResults: hasSearchResults(state, { windowId }),
   hasSearchService: getManifestSearchService(state, { windowId }) !== null,
   panels: getWindowConfig(state, { windowId }).panels,

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,6 @@
+import useCanvasWorldService from './useCanvasWorldService';
+import useThumbnailService from './useThumbnailService';
+
+export {
+  useCanvasWorldService, useThumbnailService,
+};

--- a/src/hooks/useCanvasWorldService.js
+++ b/src/hooks/useCanvasWorldService.js
@@ -1,0 +1,10 @@
+import { useSelector } from 'react-redux';
+
+import CanvasWorld from '../lib/CanvasWorld';
+import { getMiradorCanvasWrapper } from '../state/selectors/wrappers';
+
+/** */
+export default function useCanvasWorldService() {
+  const getMiradorCanvas = useSelector(getMiradorCanvasWrapper);
+  return { get: (canvases) => canvases && new CanvasWorld(canvases.map(getMiradorCanvas)) };
+}

--- a/src/hooks/useThumbnailService.js
+++ b/src/hooks/useThumbnailService.js
@@ -1,0 +1,8 @@
+import { useSelector } from 'react-redux';
+
+import { getThumbnailFactory } from '../state/selectors/thumbnails';
+
+/** */
+export default function useThumbnailService(maxHeight, maxWidth) {
+  return useSelector((state) => getThumbnailFactory(state, maxHeight, maxWidth), [maxHeight, maxWidth]);
+}

--- a/src/lib/CanvasWorld.js
+++ b/src/lib/CanvasWorld.js
@@ -9,8 +9,8 @@ export default class CanvasWorld {
    * @param {Array} canvases - Array of Manifesto:Canvas objects to create a
    * world from.
    */
-  constructor(canvases, layers, viewingDirection = 'left-to-right') {
-    this.canvases = canvases.map(c => new MiradorCanvas(c));
+  constructor(miradorCanvases, layers, viewingDirection = 'left-to-right') {
+    this.canvases = miradorCanvases;
     this.layers = layers;
     this.viewingDirection = viewingDirection;
     this._canvasDimensions = null; // eslint-disable-line no-underscore-dangle

--- a/src/state/sagas/annotations.js
+++ b/src/state/sagas/annotations.js
@@ -2,7 +2,9 @@ import {
   all, put, select, takeEvery,
 } from 'redux-saga/effects';
 import { requestCanvasAnnotations, receiveAnnotation, requestAnnotation } from '../actions';
-import { getAnnotations, getCanvas } from '../selectors';
+import {
+  getAnnotations, getCanvas, getMiradorCanvasWrapper,
+} from '../selectors';
 import ActionTypes from '../actions/action-types';
 import MiradorCanvas from '../../lib/MiradorCanvas';
 
@@ -10,7 +12,8 @@ import MiradorCanvas from '../../lib/MiradorCanvas';
 export function* fetchCanvasAnnotations({ canvasId, windowId }) {
   const canvas = yield select(getCanvas, { canvasId, windowId });
   const annotations = yield select(getAnnotations);
-  const miradorCanvas = new MiradorCanvas(canvas);
+  const getMiradorCanvas = yield select(getMiradorCanvasWrapper);
+  const miradorCanvas = getMiradorCanvas(canvas);
 
   return yield all([
     // IIIF v2

--- a/src/state/sagas/auth.js
+++ b/src/state/sagas/auth.js
@@ -4,7 +4,6 @@ import {
 import { Utils } from 'manifesto.js';
 import flatten from 'lodash/flatten';
 import ActionTypes from '../actions/action-types';
-import MiradorCanvas from '../../lib/MiradorCanvas';
 import {
   addAuthenticationRequest,
   resolveAuthenticationRequest,
@@ -18,6 +17,7 @@ import {
   getConfig,
   getAuth,
   getAccessTokens,
+  getMiradorCanvasWrapper,
 } from '../selectors';
 import { fetchInfoResponse } from './iiif';
 
@@ -42,10 +42,9 @@ export function* refetchInfoResponses({ serviceId }) {
     Object.keys(windows).map(windowId => select(getVisibleCanvases, { windowId })),
   );
 
-  const visibleImageApiIds = flatten(flatten(canvases).map((canvas) => {
-    const miradorCanvas = new MiradorCanvas(canvas);
-    return miradorCanvas.imageServiceIds;
-  }));
+  const getMiradorCanvas = yield select(getMiradorCanvasWrapper);
+
+  const visibleImageApiIds = flatten(flatten(canvases).map((canvas) => getMiradorCanvas(canvas).imageServiceIds));
 
   const infoResponses = yield select(selectInfoResponses);
   /** */

--- a/src/state/selectors/auth.js
+++ b/src/state/selectors/auth.js
@@ -1,10 +1,10 @@
 import { createSelector } from 'reselect';
 import { Utils } from 'manifesto.js';
 import flatten from 'lodash/flatten';
-import MiradorCanvas from '../../lib/MiradorCanvas';
-import { miradorSlice } from './utils';
+import { miradorSlice, EMPTY_ARRAY, EMPTY_OBJECT } from './utils';
 import { getConfig } from './config';
 import { getVisibleCanvases, selectInfoResponses } from './canvases';
+import { getMiradorCanvasWrapper } from './wrappers';
 
 /**
  * Returns the authentification profile from the configuration
@@ -23,14 +23,14 @@ export const getAuthProfiles = createSelector(
  * @param {object} state
  * @returns {object}
  */
-export const getAccessTokens = state => miradorSlice(state).accessTokens || {};
+export const getAccessTokens = state => miradorSlice(state).accessTokens || EMPTY_OBJECT;
 
 /**
  * Return the authentification data from the state
  * @param {object} state
  * @returns {object}
  */
-export const getAuth = state => miradorSlice(state).auth || {};
+export const getAuth = state => miradorSlice(state).auth || EMPTY_OBJECT;
 
 /**
  * Returns current authentification services based on state and windowId
@@ -44,14 +44,15 @@ export const selectCurrentAuthServices = createSelector(
     selectInfoResponses,
     getAuthProfiles,
     getAuth,
+    getMiradorCanvasWrapper,
     (state, { iiifResources }) => iiifResources,
   ],
-  (canvases, infoResponses = {}, serviceProfiles, auth, iiifResources) => {
+  (canvases, infoResponses = {}, serviceProfiles, auth, getMiradorCanvas, iiifResources) => {
     let currentAuthResources = iiifResources;
 
     if (!currentAuthResources && canvases) {
       currentAuthResources = flatten(canvases.map(c => {
-        const miradorCanvas = new MiradorCanvas(c);
+        const miradorCanvas = getMiradorCanvas(c);
         const images = miradorCanvas.iiifImageResources;
 
         return images.map(i => {
@@ -67,8 +68,8 @@ export const selectCurrentAuthServices = createSelector(
       }));
     }
 
-    if (!currentAuthResources) return [];
-    if (currentAuthResources.length === 0) return [];
+    if (!currentAuthResources) return EMPTY_ARRAY;
+    if (currentAuthResources.length === 0) return EMPTY_ARRAY;
 
     const currentAuthServices = currentAuthResources.map(resource => {
       let lastAttemptedService;

--- a/src/state/selectors/companionWindows.js
+++ b/src/state/selectors/companionWindows.js
@@ -1,9 +1,7 @@
 import { createSelector } from 'reselect';
 import groupBy from 'lodash/groupBy';
-import { miradorSlice } from './utils';
+import { miradorSlice, EMPTY_ARRAY, EMPTY_OBJECT } from './utils';
 import { getWindow, getWindows } from './getters';
-
-const defaultConfig = Object.freeze({});
 
 /**
  * Returns companion windows.
@@ -11,7 +9,7 @@ const defaultConfig = Object.freeze({});
  * @returns {object}
  */
 export function getCompanionWindows(state) {
-  return miradorSlice(state).companionWindows || defaultConfig;
+  return miradorSlice(state).companionWindows || EMPTY_OBJECT;
 }
 
 /**
@@ -103,7 +101,7 @@ const getCompanionWindowsByWindowAndPosition = createSelector(
  */
 const getCompanionWindowsOfWindow = createSelector(
   [(state, { windowId }) => windowId, getCompanionWindowsByWindowAndPosition],
-  (windowId, companionWindows) => companionWindows[windowId] || {},
+  (windowId, companionWindows) => companionWindows[windowId] || EMPTY_OBJECT,
 );
 
 /**
@@ -114,7 +112,7 @@ const getCompanionWindowsOfWindow = createSelector(
  */
 const getCompanionWindowIdsOfWindow = createSelector(
   [(state, { windowId }) => windowId, getCompanionWindowIndexByWindowAndPosition],
-  (windowId, companionWindowIds) => companionWindowIds[windowId] || {},
+  (windowId, companionWindowIds) => companionWindowIds[windowId] || EMPTY_OBJECT,
 );
 
 /**
@@ -148,8 +146,6 @@ export const getCompanionWindowsForContent = createSelector(
     [].concat(...Object.values(companionWindows)).filter(w => w.content === content)
   ),
 );
-
-const EMPTY_ARRAY = [];
 
 /**
  * Returns companion window ids for position.

--- a/src/state/selectors/config.js
+++ b/src/state/selectors/config.js
@@ -1,9 +1,7 @@
 import { createSelector } from 'reselect';
 import deepmerge from 'deepmerge';
-import { miradorSlice } from './utils';
+import { miradorSlice, EMPTY_ARRAY, EMPTY_OBJECT } from './utils';
 import { getWorkspace } from './getters';
-
-const defaultConfig = Object.freeze({});
 
 /**
  * Returns the config from the redux state.
@@ -12,7 +10,7 @@ const defaultConfig = Object.freeze({});
  */
 export function getConfig(state) {
   const slice = miradorSlice(state || {});
-  return slice.config || defaultConfig;
+  return slice.config || EMPTY_OBJECT;
 }
 
 /**
@@ -111,11 +109,20 @@ export const getThemeDirection = createSelector(
   ({ theme }) => theme.direction || 'ltr',
 );
 /**
- * Returns the theme direction from the config.
+ * Returns the requests configurations from the config.
  * @param {object} state
  * @returns {object} {preprocessor: [...], postprocessor: [...]}
  */
 export const getRequestsConfig = createSelector(
   [getConfig],
-  ({ requests }) => requests || {},
+  ({ requests }) => requests || EMPTY_OBJECT,
+);
+/**
+ * Returns the thumbnails configurations from the config.
+ * @param {object} state
+ * @returns {object} {preprocessor: [...], postprocessor: [...]}
+ */
+export const getThumbnailsConfig = createSelector(
+  [getConfig],
+  ({ thumbnails }) => thumbnails || EMPTY_OBJECT,
 );

--- a/src/state/selectors/getters.js
+++ b/src/state/selectors/getters.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { miradorSlice } from './utils';
+import { miradorSlice, EMPTY_ARRAY, EMPTY_OBJECT } from './utils';
 
 /**
  * Returns the manifest titles for all open windows.
@@ -16,7 +16,7 @@ export function getWindowManifests(state) {
  * @returns {object} {id: {canvasId: {...}, ...}, ...}
  */
 export function getWindows(state) {
-  return miradorSlice(state).windows || {};
+  return miradorSlice(state).windows || EMPTY_OBJECT;
 }
 
 /**
@@ -61,7 +61,7 @@ export function getWorkspace(state) {
  */
 export const getWindowIds = createSelector(
   [getWorkspace],
-  ({ windowIds }) => windowIds || [],
+  ({ windowIds }) => windowIds || EMPTY_ARRAY,
 );
 
 /**
@@ -70,7 +70,7 @@ export const getWindowIds = createSelector(
  * @returns {object}
  */
 export function getManifests(state) {
-  return miradorSlice(state).manifests || {};
+  return miradorSlice(state).manifests || EMPTY_OBJECT;
 }
 
 /**
@@ -85,7 +85,7 @@ export function getManifest(state, { manifestId, windowId }) {
   const manifests = getManifests(state);
   return manifests && manifests[
     manifestId
-    || (windowId && (getWindow(state, { windowId }) || {}).manifestId)
+    || (windowId && (getWindow(state, { windowId }) || EMPTY_OBJECT).manifestId)
   ];
 }
 
@@ -95,5 +95,5 @@ export function getManifest(state, { manifestId, windowId }) {
  * @returns {object} containing manifestIds for the manifests in the catalog
  */
 export function getCatalog(state) {
-  return miradorSlice(state).catalog || {};
+  return miradorSlice(state).catalog || EMPTY_OBJECT;
 }

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -13,3 +13,5 @@ export * from './sequences';
 export * from './auth';
 export * from './utils';
 export * from './viewer';
+export * from './thumbnails';
+export * from './wrappers';

--- a/src/state/selectors/layers.js
+++ b/src/state/selectors/layers.js
@@ -2,7 +2,6 @@ import { createSelector } from 'reselect';
 import { getMiradorCanvasWrapper } from './wrappers';
 import { getCanvas, getVisibleCanvasIds } from './canvases';
 import { miradorSlice, EMPTY_ARRAY } from './utils';
-import { getConfig } from './config';
 
 /**
  * Get the image layers from a canvas.

--- a/src/state/selectors/layers.js
+++ b/src/state/selectors/layers.js
@@ -1,7 +1,8 @@
 import { createSelector } from 'reselect';
-import MiradorCanvas from '../../lib/MiradorCanvas';
+import { getMiradorCanvasWrapper } from './wrappers';
 import { getCanvas, getVisibleCanvasIds } from './canvases';
-import { miradorSlice } from './utils';
+import { miradorSlice, EMPTY_ARRAY } from './utils';
+import { getConfig } from './config';
 
 /**
  * Get the image layers from a canvas.
@@ -15,15 +16,13 @@ import { miradorSlice } from './utils';
 export const getCanvasLayers = createSelector(
   [
     getCanvas,
+    getMiradorCanvasWrapper,
   ],
-  (canvas) => {
+  (canvas, getMiradorCanvas) => {
     if (!canvas) return [];
-    const miradorCanvas = new MiradorCanvas(canvas);
-    return miradorCanvas.imageResources;
+    return getMiradorCanvas(canvas).imageResources;
   },
 );
-
-const EMPTY_ARRAY = Object.freeze([]);
 
 export const getLayersForWindow = createSelector(
   [

--- a/src/state/selectors/searches.js
+++ b/src/state/selectors/searches.js
@@ -5,7 +5,7 @@ import AnnotationList from '../../lib/AnnotationList';
 import { getCanvas, getCanvases } from './canvases';
 import { getWindow } from './getters';
 import { getManifestLocale } from './manifests';
-import { miradorSlice } from './utils';
+import { miradorSlice, EMPTY_ARRAY, EMPTY_OBJECT } from './utils';
 
 /**
  *  Get searches from state.
@@ -24,7 +24,7 @@ export const getSearchForWindow = createSelector(
     getSearches,
   ],
   (windowId, searches) => {
-    if (!windowId || !searches) return {};
+    if (!windowId || !searches) return EMPTY_OBJECT;
 
     return searches[windowId];
   },
@@ -57,7 +57,7 @@ const getSearchResponsesForCompanionWindow = createSelector(
     getSearchForCompanionWindow,
   ],
   (results) => {
-    if (!results) return [];
+    if (!results) return EMPTY_ARRAY;
     return Object.values(results.data);
   },
 );
@@ -140,7 +140,7 @@ const getSearchHitsForCompanionWindow = createSelector(
     getSearchResponsesForCompanionWindow,
   ],
   results => flatten(results.map((result) => {
-    if (!result || !result.json || result.isFetching || !result.json.hits) return [];
+    if (!result || !result.json || result.isFetching || !result.json.hits) return EMPTY_ARRAY;
 
     return result.json.hits;
   })),
@@ -166,8 +166,8 @@ export const getSortedSearchHitsForCompanionWindow = createSelector(
     getSearchAnnotationsForCompanionWindow,
   ],
   (searchHits, canvases, annotation) => {
-    if (!canvases || canvases.length === 0) return [];
-    if (!searchHits || searchHits.length === 0) return [];
+    if (!canvases || canvases.length === 0) return EMPTY_ARRAY;
+    if (!searchHits || searchHits.length === 0) return EMPTY_ARRAY;
     const canvasIds = canvases.map(canvas => canvas.id);
 
     return [].concat(searchHits).sort((a, b) => {
@@ -206,8 +206,8 @@ const searchResultsToAnnotation = (results) => {
 export function sortSearchAnnotationsByCanvasOrder(searchAnnotations, canvases) {
   if (!searchAnnotations
       || !searchAnnotations.resources
-      || searchAnnotations.length === 0) return [];
-  if (!canvases || canvases.length === 0) return [];
+      || searchAnnotations.length === 0) return EMPTY_ARRAY;
+  if (!canvases || canvases.length === 0) return EMPTY_ARRAY;
   const canvasIds = canvases.map(canvas => canvas.id);
 
   return [].concat(searchAnnotations.resources).sort(
@@ -240,7 +240,7 @@ export const getSearchAnnotationsForWindow = createSelector(
     getSearchForWindow,
   ],
   (results) => {
-    if (!results) return [];
+    if (!results) return EMPTY_ARRAY;
     const data = Object.values(results).map(r => Object.values(r.data));
 
     return data.map(d => searchResultsToAnnotation(d)).filter(a => a.resources.length > 0);
@@ -292,7 +292,7 @@ export const getResourceAnnotationLabel = createSelector(
   (resourceAnnotation, locale) => {
     if (
       !(resourceAnnotation && resourceAnnotation.resource && resourceAnnotation.resource.label)
-    ) return [];
+    ) return EMPTY_ARRAY;
 
     return PropertyValue.parse(resourceAnnotation.resource.label).getValues(locale);
   },

--- a/src/state/selectors/thumbnails.js
+++ b/src/state/selectors/thumbnails.js
@@ -1,0 +1,27 @@
+import { createSelector } from 'reselect';
+
+import { getThumbnailsConfig } from './config';
+import { getMiradorCanvasWrapper, getMiradorManifestWrapper } from './wrappers';
+
+import { ThumbnailFactory } from '../../lib/ThumbnailFactory';
+
+/** memoize thumbnail opts for selector */
+export const getIiifThumbnailOpts = createSelector(
+  [getThumbnailsConfig, (state, maxHeight, maxWidth) => maxHeight, (state, maxHeight, maxWidth) => maxWidth],
+  (thumbnails, maxHeight, maxWidth) => ({ maxHeight, maxWidth, preferredFormats: thumbnails.preferredFormats }),
+);
+
+/**
+ *  Instantiate a thumbnail factory.
+ * @param {object} state
+ * @param {integer} maxHeight
+ * @param {integer} maxWidth
+ * @return {object}
+ */
+export const getThumbnailFactory = createSelector(
+  [getIiifThumbnailOpts, getMiradorCanvasWrapper, getMiradorManifestWrapper],
+  (iiifOpts, getMiradorCanvas, getMiradorManifest) => new ThumbnailFactory(
+    iiifOpts,
+    { getMiradorCanvas, getMiradorManifest },
+  ),
+);

--- a/src/state/selectors/utils.js
+++ b/src/state/selectors/utils.js
@@ -11,3 +11,6 @@ export function miradorSlice(state) {
 
   return state;
 }
+
+export const EMPTY_ARRAY = Object.freeze([]);
+export const EMPTY_OBJECT = Object.freeze({});

--- a/src/state/selectors/viewer.js
+++ b/src/state/selectors/viewer.js
@@ -4,6 +4,7 @@ import CanvasWorld from '../../lib/CanvasWorld';
 import { getVisibleCanvases } from './canvases';
 import { getLayersForVisibleCanvases } from './layers';
 import { getSequenceViewingDirection } from './sequences';
+import { getMiradorCanvasWrapper } from './wrappers';
 
 /**
  *  Instantiate a manifesto instance.
@@ -12,6 +13,13 @@ import { getSequenceViewingDirection } from './sequences';
  * @return {object}
  */
 export const getCurrentCanvasWorld = createSelector(
-  [getVisibleCanvases, getLayersForVisibleCanvases, getSequenceViewingDirection],
-  (canvases, layers, viewingDirection) => new CanvasWorld(canvases, layers, viewingDirection),
+  [
+    getVisibleCanvases, getLayersForVisibleCanvases, getSequenceViewingDirection,
+    getMiradorCanvasWrapper,
+  ],
+  (canvases, layers, viewingDirection, getMiradorCanvas) => new CanvasWorld(
+    canvases.map(getMiradorCanvas),
+    layers,
+    viewingDirection,
+  ),
 );

--- a/src/state/selectors/wrappers.js
+++ b/src/state/selectors/wrappers.js
@@ -1,0 +1,15 @@
+import { createSelector } from 'reselect';
+import MiradorCanvas from '../../lib/MiradorCanvas';
+import MiradorManifest from '../../lib/MiradorManifest';
+
+/** */
+export const getMiradorCanvasWrapper = createSelector(
+  [],
+  (canvasTypes, imageProfiles) => ((canvas) => canvas && new MiradorCanvas(canvas)),
+);
+
+/** */
+export const getMiradorManifestWrapper = createSelector(
+  [],
+  (resourceTypes) => ((manifest) => manifest && new MiradorManifest(manifest)),
+);


### PR DESCRIPTION
- prepare for auth2 service parsing changes
- prevent exposing wrapper constructor changes to wrappers to broad swathes of app
- stabilize empty object/array references for input selectors
- fixes #4100