### PR TITLE
Re-export the viewer function as a named export.

### DIFF
--- a/__tests__/utils/test-utils.js
+++ b/__tests__/utils/test-utils.js
@@ -10,7 +10,7 @@ import settings from '../../src/config/settings';
 import createI18nInstance from '../../src/i18n';
 
 /** Mirador viewer setup for Integration tests */
-import Mirador from '../../src/index';
+import { viewer as miradorViewer } from '../../src/index';
 
 export * from '@testing-library/react';
 export { renderWithProviders as render };
@@ -61,7 +61,7 @@ function renderWithProviders(
 
 /** adds a mirador viewer to the DOM */
 const setupMiradorViewer = async (config, plugins) => {
-  const viewer = Mirador.viewer({ ...config, id: undefined }, plugins);
+  const viewer = miradorViewer({ ...config, id: undefined }, plugins);
 
   render(
     <div

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export * from './lib';
 export * from './plugins';
 export { default as settings } from './config/settings';
 export { useTranslation, withTranslation } from 'react-i18next';
+export { viewer } from './init';
 
 export default {
   ...init,

--- a/src/init.js
+++ b/src/init.js
@@ -3,7 +3,7 @@ import MiradorViewer from './lib/MiradorViewer';
 /**
  * Default Mirador instantiation
  */
-function viewer(config, pluginsOrStruct) {
+export function viewer(config, pluginsOrStruct) {
   let struct;
 
   if (Array.isArray(pluginsOrStruct)) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,7 +42,6 @@ export default defineConfig({
         rollupOptions: {
           external: [
             ...Object.keys(packageJson.peerDependencies),
-            'react/jsx-runtime',
             '__tests__/*',
             '__mocks__/*',
           ],
@@ -52,7 +51,6 @@ export default defineConfig({
             globals: {
               react: 'React',
               'react-dom': 'ReactDOM',
-              'react/jsx-runtime': 'react/jsx-runtime',
             },
           },
         },
@@ -60,6 +58,9 @@ export default defineConfig({
       },
     }
   ),
+  define: {
+    'process.env': {},
+  },
   esbuild: {
     exclude: [],
     // Matches .js and .jsx in __tests__ and .jsx in src

--- a/vite.config.js
+++ b/vite.config.js
@@ -48,6 +48,7 @@ export default defineConfig({
           ],
           output: {
             assetFileNames: 'mirador.[ext]',
+            exports: 'named',
             globals: {
               react: 'React',
               'react-dom': 'ReactDOM',


### PR DESCRIPTION
Silences the build warning:
> Entry module "src/index.js" is using named and default exports together. 