### PR TITLE
Make MUI + react-i18next peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,10 @@
     "vitest-fetch-mock": "^0.4.2"
   },
   "peerDependencies": {
-    "@mui/material": "^5.13.5",
+    "@mui/material": "^5.x",
+    "@mui/system": "^5.x",
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "vite build --config vite.config.js",
+    "build": "vite build --config vite.config.js && vite build --config vite-umd.config.js",
     "clean": "rm -rf ./dist",
     "lint": "node_modules/.bin/eslint ./ && npm run lint:translations && npm run lint:containers",
     "lint:containers": "node ./scripts/container-lint.js",
@@ -40,7 +40,6 @@
     "@emotion/styled": "^11.10.6",
     "@hello-pangea/dnd": "^16.0.1 || ^17.0.0",
     "@mui/icons-material": "^5.11.16",
-    "@mui/material": "^5.13.5",
     "@mui/utils": "^5.13.1",
     "@mui/x-tree-view": "^6.17.0",
     "@react-aria/live-announcer": "^3.1.2",
@@ -64,7 +63,6 @@
     "react-dnd-touch-backend": "^16.0.0",
     "react-error-boundary": "^4.1.2",
     "react-full-screen": "^1.1.1",
-    "react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0",
     "react-image": "^4.0.1",
     "react-intersection-observer": "^9.0.0",
     "react-mosaic-component2": "^6.0.0",
@@ -85,6 +83,7 @@
     "uuid": "^8.1.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "devDependencies": {
+    "@mui/material": "^5.13.5",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^16.0.1",
@@ -108,6 +107,7 @@
     "react": "^18.0.0",
     "react-dnd-test-backend": "^16.0.1",
     "react-dom": "^18.0.0",
+    "react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0",
     "redux-mock-store": "^1.5.1",
     "redux-saga-test-plan": "^4.0.0-rc.3",
     "vite": "^6.0.0",
@@ -115,7 +115,9 @@
     "vitest-fetch-mock": "^0.4.2"
   },
   "peerDependencies": {
+    "@mui/material": "^5.13.5",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0"
   }
 }

--- a/vite-umd.config.js
+++ b/vite-umd.config.js
@@ -1,0 +1,56 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import fs from 'fs/promises';
+
+/**
+* Vite configuration
+*/
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: './src/index.js',
+      fileName: (format) => (format === 'umd' ? 'mirador.min.js' : undefined),
+      formats: ['umd'],
+      name: 'Mirador',
+    },
+    rollupOptions: {
+      external: [
+        '__tests__/*',
+        '__mocks__/*',
+      ],
+      output: {
+        assetFileNames: 'mirador.[ext]',
+        exports: 'named',
+      },
+    },
+    sourcemap: true,
+  },
+  define: {
+    'process.env': {},
+  },
+  esbuild: {
+    exclude: [],
+    // Matches .js and .jsx in __tests__ and .jsx in src
+    include: [/__tests__\/.*\.(js|jsx)$/, /src\/.*\.jsx?$/],
+    loader: 'jsx',
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      plugins: [
+        {
+          name: 'load-js-files-as-jsx',
+          // TODO: rename all our files to .jsx ...
+          /** */
+          setup(build) {
+            build.onLoad({ filter: /(src|__tests__)\/.*\.js$/ }, async (args) => ({
+              contents: await fs.readFile(args.path, 'utf8'),
+              loader: 'jsx',
+            }));
+          },
+        },
+      ],
+    },
+  },
+  plugins: [react()],
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,8 +35,8 @@ export default defineConfig({
       build: {
         lib: {
           entry: './src/index.js',
-          fileName: (format) => (format === 'umd' ? 'mirador.min.js' : 'mirador.es.js'),
-          formats: ['es', 'umd'],
+          fileName: (format) => (format === 'es' ? 'mirador.es.js' : undefined),
+          formats: ['es'],
           name: 'Mirador',
         },
         rollupOptions: {


### PR DESCRIPTION
React isn't sharing contexts across plugins + apps the way it used to (because webpack did something special? React 18 changed something?). In order to get shared contexts, Mirador (we believe) has to treat those as peer dependencies and require the installing app to provide them (like we're already doing for React etc).

... but that's slightly annoying for people who use the UMD build ("just render me a mirador"), so this PR also adds a separate Vite configuration that (should?) include all the peer dependencies so it can be used directly 🤷‍♂️ .

