### PR TITLE
Improve annotation selection usability, dont color annotation on focus

### DIFF
--- a/src/components/CanvasAnnotations.jsx
+++ b/src/components/CanvasAnnotations.jsx
@@ -55,7 +55,7 @@ export function CanvasAnnotations({
               variant="multiline"
               divider
               sx={{
-                '&:hover,&:focus': {
+                '&:hover': {
                   backgroundColor: 'action.hover',
                 },
                 backgroundColor: hoveredAnnotationIds.includes(annotation.id) ? 'action.hover' : '',


### PR DESCRIPTION
Change background color of an annotation with focus is strange. For example after deselecting annotation (the annotation keep focus)

To recap :
- SelectedAnnotation : color from MenuItem component when selected
- hover : "action.hover" color 

Nothing more is needed 
