### PR TITLE
feat: add lang to LanguageSettings

### DIFF
--- a/src/components/LanguageSettings.jsx
+++ b/src/components/LanguageSettings.jsx
@@ -15,6 +15,7 @@ export function LanguageSettings({ handleClick, languages }) {
         languages.map(language => (
           <MenuItem
             key={language.locale}
+            lang={language.locale}
             onClick={() => { handleClick(language.locale); }}
           >
             <ListItemIcon>


### PR DESCRIPTION
I added the html language identifier to the LanguageSettings MenuItem to adress [issue 3919](https://github.com/ProjectMirador/mirador/issues/3919) 