### PR TITLE
Update to MUI 7

### DIFF
--- a/__tests__/src/actions/companionWindow.test.js
+++ b/__tests__/src/actions/companionWindow.test.js
@@ -2,7 +2,7 @@ import * as actions from '../../../src/state/actions';
 import ActionTypes from '../../../src/state/actions/action-types';
 
 vi.mock('../../../src/state/selectors', async (importOriginal) => ({
-  ...await importOriginal(),
+  ...(await importOriginal()),
   getVisibleNodeIds: (state, args) => ['openVisible', 'closedVisible', 'visible'],
 }));
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "@custom-react-hooks/use-element-size": "^1.5.1",
     "@emotion/cache": "^11.11.0",
     "@hello-pangea/dnd": "^16.0.1 || ^17.0.0 || ^18.0.0",
-    "@mui/icons-material": "^6.0.0",
-    "@mui/utils": "^6.0.0",
+    "@mui/icons-material": "^7.0.0",
+    "@mui/utils": "^7.0.0",
     "@mui/x-tree-view": "^7.25.0",
     "@react-aria/live-announcer": "^3.1.2",
     "@redux-devtools/extension": "^3.3.0",
@@ -83,8 +83,8 @@
   "devDependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@mui/material": "^6.x",
-    "@mui/system": "^6.x",
+    "@mui/material": "^7.x",
+    "@mui/system": "^7.x",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^16.0.1",
@@ -116,8 +116,8 @@
     "vitest-fetch-mock": "^0.4.2"
   },
   "peerDependencies": {
-    "@mui/material": "^6.x",
-    "@mui/system": "^6.x",
+    "@mui/material": "^7.x",
+    "@mui/system": "^7.x",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "react": "^18.0.0 || ^19.0.0",

--- a/src/components/IIIFIFrameCommunication.jsx
+++ b/src/components/IIIFIFrameCommunication.jsx
@@ -28,10 +28,10 @@ export function IIIFIFrameCommunication({ handleReceiveMessage = undefined, ...p
   return (
     // iframe "title" attribute is passed in via props for accessibility
     // eslint-disable-next-line jsx-a11y/iframe-has-title
-    <iframe
+    (<iframe
       {...IIIFIFrameCommunicationDefaultProps}
       {...props}
-    />
+    />)
   );
 }
 

--- a/src/components/ManifestForm.jsx
+++ b/src/components/ManifestForm.jsx
@@ -38,14 +38,15 @@ export function ManifestForm({
   if (!addResourcesOpen) return null;
 
   return (
-    <form onSubmit={formSubmit}>
-      <Grid container spacing={2}>
-        <Grid
-          size={{
-            xs: 12,
-            sm: 8,
-            md: 9
-          }}>
+<form onSubmit={formSubmit}>
+      <Grid
+        container
+        spacing={2}
+        columns={12}
+        wrap="nowrap"
+        sx={{ mt: 0.5 }}
+      >
+        <Grid size={9} sx={{ flexGrow: 1}}>
           <TextField
             autoFocus
             fullWidth
@@ -62,21 +63,20 @@ export function ManifestForm({
             }}
           />
         </Grid>
-        <Grid
-          sx={{
-            textAlign: { sm: 'inherit', xs: 'right' },
-          }}
-          size={{
-            xs: 12,
-            sm: 4,
-            md: 3
-          }}>
-          { onCancel && (
+        {onCancel && (
+          <Grid size="auto">
             <Button onClick={handleCancel}>
               {t('cancel')}
             </Button>
-          )}
-          <Button id="fetchBtn" type="submit" variant="contained" color="primary">
+          </Grid>
+        )}
+        <Grid size="auto">
+          <Button 
+            id="fetchBtn"
+            type="submit"
+            variant="contained"
+            color="primary"
+          >
             {t('fetchManifest')}
           </Button>
         </Grid>

--- a/src/components/ManifestForm.jsx
+++ b/src/components/ManifestForm.jsx
@@ -40,7 +40,12 @@ export function ManifestForm({
   return (
     <form onSubmit={formSubmit}>
       <Grid container spacing={2}>
-        <Grid item xs={12} sm={8} md={9}>
+        <Grid
+          size={{
+            xs: 12,
+            sm: 8,
+            md: 9
+          }}>
           <TextField
             autoFocus
             fullWidth
@@ -51,23 +56,21 @@ export function ManifestForm({
             variant="filled"
             label={t('addManifestUrl')}
             helperText={t('addManifestUrlHelp')}
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              style: { typography: 'body1' },
+            slotProps={{
+              inputLabel: { shrink: true },
+              inputProps: { style: { typography: 'body1' } },
             }}
           />
         </Grid>
         <Grid
-          item
-          xs={12}
-          sm={4}
-          md={3}
           sx={{
             textAlign: { sm: 'inherit', xs: 'right' },
           }}
-        >
+          size={{
+            xs: 12,
+            sm: 4,
+            md: 3
+          }}>
           { onCancel && (
             <Button onClick={handleCancel}>
               {t('cancel')}

--- a/src/components/ManifestForm.jsx
+++ b/src/components/ManifestForm.jsx
@@ -38,15 +38,14 @@ export function ManifestForm({
   if (!addResourcesOpen) return null;
 
   return (
-<form onSubmit={formSubmit}>
+    <form onSubmit={formSubmit}>
       <Grid
         container
         spacing={2}
         columns={12}
-        wrap="nowrap"
         sx={{ mt: 0.5 }}
       >
-        <Grid size={9} sx={{ flexGrow: 1}}>
+        <Grid size={{ sm: 'grow', xs: 12 }}>
           <TextField
             autoFocus
             fullWidth

--- a/src/components/ManifestListItem.jsx
+++ b/src/components/ManifestListItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import ListItem from '@mui/material/ListItem';
 import ButtonBase from '@mui/material/ButtonBase';
-import Grid2 from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 import { useTranslation } from 'react-i18next';
@@ -40,21 +40,21 @@ const StyledLogo = styled(Img, { name: 'ManifestListItem', slot: 'logo' })(({ th
 
 /** */
 const Placeholder = () => (
-  <Grid2 container className={ns('manifest-list-item')} spacing={2}>
-    <Grid2 xs={3} sm={2}>
+  <Grid container className={ns('manifest-list-item')} spacing={2}>
+    <Grid size={{ sm: 2, xs: 3 }}>
       <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />
-    </Grid2>
-    <Grid2 xs={9} sm={6}>
+    </Grid>
+    <Grid size={{ sm: 6, xs: 9 }}>
       <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
-    </Grid2>
-    <Grid2 xs={8} sm={2}>
+    </Grid>
+    <Grid size={{ sm: 2, xs: 8 }}>
       <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
       <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="text" />
-    </Grid2>
-    <Grid2 xs={4} sm={2}>
+    </Grid>
+    <Grid size={{ sm: 2, xs: 4 }}>
       <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={60} width={60} />
-    </Grid2>
-  </Grid2>
+    </Grid>
+  </Grid>
 );
 
 /**
@@ -116,15 +116,14 @@ export function ManifestListItem({
       data-active={active}
     >
       {ready ? (
-        <Grid2 container className={ns('manifest-list-item')} spacing={2}>
-          <Grid2 xs={12} sm={6}>
+        <Grid container className={ns('manifest-list-item')} spacing={2} size="grow">
+          <Grid size={{ sm: 6, xs: 12 }}>
             <ButtonBase
               ref={buttonRef}
               className={ns('manifest-list-item-title')}
-              style={{ width: '100%' }}
               onClick={handleOpenButtonClick}
             >
-              <Grid2
+              <Grid
                 container
                 spacing={2}
                 sx={{
@@ -133,7 +132,7 @@ export function ManifestListItem({
                 }}
                 component="span"
               >
-                <Grid2 xs={4} sm={3} component="span">
+                <Grid size={{ sm: 3, xs: 4 }} component="span">
                   { thumbnail
                     ? (
                       <StyledThumbnail
@@ -153,8 +152,8 @@ export function ManifestListItem({
                       />
                     )
                     : <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />}
-                </Grid2>
-                <Grid2 xs={8} sm={9} component="span">
+                </Grid>
+                <Grid xs={8} sm={9} component="span">
                   { isCollection && (
                     <Typography component="div" variant="overline">
                       { t(isMultipart ? 'multipartCollection' : 'collection') }
@@ -163,16 +162,16 @@ export function ManifestListItem({
                   <Typography component="span" variant="h6">
                     {title || manifestId}
                   </Typography>
-                </Grid2>
-              </Grid2>
+                </Grid>
+              </Grid>
             </ButtonBase>
-          </Grid2>
-          <Grid2 xs={8} sm={4}>
+          </Grid>
+          <Grid size={{ sm: 4, xs: 8 }}>
             <Typography className={ns('manifest-list-item-provider')}>{provider}</Typography>
             <Typography>{t('numItems', { count: size, number: size })}</Typography>
-          </Grid2>
+          </Grid>
 
-          <Grid2 xs={4} sm={2}>
+          <Grid size={{ sm: 2, xs: 4 }}>
             { manifestLogo
               && (
               <StyledLogo
@@ -190,8 +189,8 @@ export function ManifestListItem({
                 )}
               />
               )}
-          </Grid2>
-        </Grid2>
+          </Grid>
+        </Grid>
       ) : (
         <Placeholder />
       )}

--- a/src/components/ManifestListItem.jsx
+++ b/src/components/ManifestListItem.jsx
@@ -152,7 +152,7 @@ export function ManifestListItem({
                     )
                     : <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />}
                 </Grid>
-                <Grid xs={8} sm={9} component="div" paddingLeft={2}>
+                <Grid size={{ sm: 9, xs: 8 }} component="div" paddingLeft={2}>
                   {isCollection && (
                     <Typography component="div" variant="overline">
                       {t(isMultipart ? 'multipartCollection' : 'collection')}

--- a/src/components/ManifestListItem.jsx
+++ b/src/components/ManifestListItem.jsx
@@ -114,51 +114,56 @@ export function ManifestListItem({
       className={active ? 'active' : ''}
       data-manifestid={manifestId}
       data-active={active}
+      sx={{ width: '100%' }}
     >
       {ready ? (
-        <Grid container className={ns('manifest-list-item')}>
-          <Grid size={{ sm: 6, xs: 12 }} sx={{ flex: '0 0 50%' }}>
+        <Grid
+          container
+          className={ns('manifest-list-item')}
+          sx={{ width: '100%', alignItems: 'center', flexWrap: 'nowrap' }}
+        >
+          <Grid size={{ sm: 5, xs: 12 }}>
             <ButtonBase
               ref={buttonRef}
               className={ns('manifest-list-item-title')}
               onClick={handleOpenButtonClick}
+              sx={{ justifyContent: 'flex-start', alignItems: 'center', width: '100%' }}
             >
-              <Grid
-                container
-                sx={{
-                  textAlign: 'left',
-                  textTransform: 'initial',
-                }}
-                component="div"
-              >
-                <Grid size={{ sm: 3, xs: 4 }} component="div">
-                  {thumbnail
-                    ? (
-                      <StyledThumbnail
-                        className={[ns('manifest-list-item-thumb')]}
-                        src={[thumbnail]}
-                        alt=""
-                        height="80"
-                        unloader={(
-                          <Skeleton
-                            variant="rectangular"
-                            animation={false}
-                            sx={{ bgcolor: 'grey[300]' }}
-                            height={80}
-                            width={120}
-                          />
-                        )}
-                      />
-                    )
-                    : <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />}
+              <Grid container component="div" sx={{ width: '100%' }}>
+                {/* <Grid size={3} sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', width: 120, flexShrink: 0, }} > */}
+                <Grid size={3} sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }} >
+                  {thumbnail ? (
+                    <StyledThumbnail
+                      className={[ns('manifest-list-item-thumb')]}
+                      src={[thumbnail]}
+                      alt=""
+                      height="80"
+                      unloader={(
+                        <Skeleton
+                          variant="rectangular"
+                          animation={false}
+                          sx={{ bgcolor: 'grey[300]' }}
+                          height={80}
+                          width={120}
+                        />
+                      )}
+                    />
+                  ) : (
+                    <Skeleton
+                      sx={{ bgcolor: 'grey[300]' }}
+                      variant="rectangular"
+                      height={80}
+                      width={120}
+                    />
+                  )}
                 </Grid>
-                <Grid size={{ sm: 9, xs: 8 }} component="div" paddingLeft={2}>
+                <Grid size={9} sx={{ paddingLeft: 2, alignContent: 'center' }}>
                   {isCollection && (
-                    <Typography component="div" variant="overline">
+                    <Typography component="div" variant="overline" sx={{ textAlign: 'left' }}>
                       {t(isMultipart ? 'multipartCollection' : 'collection')}
                     </Typography>
                   )}
-                  <Typography component="div" variant="h6">
+                  <Typography component="div" variant="h6" sx={{ textAlign: 'left' }}>
                     {title || manifestId}
                   </Typography>
                 </Grid>
@@ -166,29 +171,32 @@ export function ManifestListItem({
             </ButtonBase>
           </Grid>
 
-          <Grid size={{ sm: 4, xs: 8 }} sx={{ flex: 1 }}>
-            <Typography className={ns('manifest-list-item-provider')}>{provider}</Typography>
-            <Typography>{t('numItems', { count: size, number: size })}</Typography>
+          <Grid size={{ sm: 4, xs: 8 }} >
+            <Typography className={ns('manifest-list-item-provider')}>
+              {provider}
+            </Typography>
+            <Typography>
+              {t('numItems', { count: size, number: size })}
+            </Typography>
           </Grid>
 
-          <Grid size={{ sm: 2, xs: 4 }} sx={{ flex: 1 }}>
-            {manifestLogo
-              && (
-                <StyledLogo
-                  src={[manifestLogo]}
-                  alt=""
-                  role="presentation"
-                  unloader={(
-                    <Skeleton
-                      variant="rectangular"
-                      animation={false}
-                      sx={{ bgcolor: 'grey[300]' }}
-                      height={60}
-                      width={60}
-                    />
-                  )}
-                />
-              )}
+          <Grid size={{ sm: 3, xs: 4 }}>
+            {manifestLogo && (
+              <StyledLogo
+                src={[manifestLogo]}
+                alt=""
+                role="presentation"
+                unloader={(
+                  <Skeleton
+                    variant="rectangular"
+                    animation={false}
+                    sx={{ bgcolor: 'grey[300]' }}
+                    height={60}
+                    width={60}
+                  />
+                )}
+              />
+            )}
           </Grid>
         </Grid>
       ) : (

--- a/src/components/ManifestListItem.jsx
+++ b/src/components/ManifestListItem.jsx
@@ -120,7 +120,7 @@ export function ManifestListItem({
         <Grid
           container
           className={ns('manifest-list-item')}
-          sx={{ width: '100%', alignItems: 'center', flexWrap: 'nowrap' }}
+          sx={{ width: '100%', alignItems: 'center' }}
         >
           <Grid size={{ sm: 5, xs: 12 }}>
             <ButtonBase
@@ -130,7 +130,6 @@ export function ManifestListItem({
               sx={{ justifyContent: 'flex-start', alignItems: 'center', width: '100%' }}
             >
               <Grid container component="div" sx={{ width: '100%' }}>
-                {/* <Grid size={3} sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', width: 120, flexShrink: 0, }} > */}
                 <Grid size={3} sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }} >
                   {thumbnail ? (
                     <StyledThumbnail

--- a/src/components/ManifestListItem.jsx
+++ b/src/components/ManifestListItem.jsx
@@ -40,7 +40,7 @@ const StyledLogo = styled(Img, { name: 'ManifestListItem', slot: 'logo' })(({ th
 
 /** */
 const Placeholder = () => (
-  <Grid container className={ns('manifest-list-item')} spacing={2}>
+  <Grid container className={ns('manifest-list-item')}>
     <Grid size={{ sm: 2, xs: 3 }}>
       <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />
     </Grid>
@@ -116,8 +116,8 @@ export function ManifestListItem({
       data-active={active}
     >
       {ready ? (
-        <Grid container className={ns('manifest-list-item')} spacing={2} size="grow">
-          <Grid size={{ sm: 6, xs: 12 }}>
+        <Grid container className={ns('manifest-list-item')}>
+          <Grid size={{ sm: 6, xs: 12 }} sx={{ flex: '0 0 50%' }}>
             <ButtonBase
               ref={buttonRef}
               className={ns('manifest-list-item-title')}
@@ -125,15 +125,14 @@ export function ManifestListItem({
             >
               <Grid
                 container
-                spacing={2}
                 sx={{
                   textAlign: 'left',
                   textTransform: 'initial',
                 }}
-                component="span"
+                component="div"
               >
-                <Grid size={{ sm: 3, xs: 4 }} component="span">
-                  { thumbnail
+                <Grid size={{ sm: 3, xs: 4 }} component="div">
+                  {thumbnail
                     ? (
                       <StyledThumbnail
                         className={[ns('manifest-list-item-thumb')]}
@@ -153,41 +152,42 @@ export function ManifestListItem({
                     )
                     : <Skeleton sx={{ bgcolor: 'grey[300]' }} variant="rectangular" height={80} width={120} />}
                 </Grid>
-                <Grid xs={8} sm={9} component="span">
-                  { isCollection && (
+                <Grid xs={8} sm={9} component="div" paddingLeft={2}>
+                  {isCollection && (
                     <Typography component="div" variant="overline">
-                      { t(isMultipart ? 'multipartCollection' : 'collection') }
+                      {t(isMultipart ? 'multipartCollection' : 'collection')}
                     </Typography>
                   )}
-                  <Typography component="span" variant="h6">
+                  <Typography component="div" variant="h6">
                     {title || manifestId}
                   </Typography>
                 </Grid>
               </Grid>
             </ButtonBase>
           </Grid>
-          <Grid size={{ sm: 4, xs: 8 }}>
+
+          <Grid size={{ sm: 4, xs: 8 }} sx={{ flex: 1 }}>
             <Typography className={ns('manifest-list-item-provider')}>{provider}</Typography>
             <Typography>{t('numItems', { count: size, number: size })}</Typography>
           </Grid>
 
-          <Grid size={{ sm: 2, xs: 4 }}>
-            { manifestLogo
+          <Grid size={{ sm: 2, xs: 4 }} sx={{ flex: 1 }}>
+            {manifestLogo
               && (
-              <StyledLogo
-                src={[manifestLogo]}
-                alt=""
-                role="presentation"
-                unloader={(
-                  <Skeleton
-                    variant="rectangular"
-                    animation={false}
-                    sx={{ bgcolor: 'grey[300]' }}
-                    height={60}
-                    width={60}
-                  />
-                )}
-              />
+                <StyledLogo
+                  src={[manifestLogo]}
+                  alt=""
+                  role="presentation"
+                  unloader={(
+                    <Skeleton
+                      variant="rectangular"
+                      animation={false}
+                      sx={{ bgcolor: 'grey[300]' }}
+                      height={60}
+                      width={60}
+                    />
+                  )}
+                />
               )}
           </Grid>
         </Grid>

--- a/src/components/ManifestListItemError.jsx
+++ b/src/components/ManifestListItemError.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import ErrorIcon from '@mui/icons-material/ErrorOutlineSharp';
-import Grid2 from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 
@@ -14,39 +14,39 @@ export function ManifestListItemError({
 }) {
   const { t } = useTranslation();
   return (
-    <Grid2 container>
-      <Grid2 container>
-        <Grid2 container xs={12} sm={6}>
-          <Grid2 xs={4} sm={3}>
-            <Grid2 container justifyContent="center">
+    <Grid container>
+      <Grid container>
+        <Grid container size={{ sm: 6, xs: 12 }}>
+          <Grid size={{ sm: 3, xs: 4 }}>
+            <Grid container justifyContent="center">
               <ErrorIcon sx={{
                 color: 'error.main',
                 height: '2rem',
                 width: '2rem',
               }}
               />
-            </Grid2>
-          </Grid2>
-          <Grid2 xs={8} sm={9}>
+            </Grid>
+          </Grid>
+          <Grid size={{ sm: 9, xs: 8 }}>
             <Typography>{t('manifestError')}</Typography>
             <Typography sx={{ wordBreak: 'break-all' }}>{manifestId}</Typography>
-          </Grid2>
-        </Grid2>
-      </Grid2>
+          </Grid>
+        </Grid>
+      </Grid>
 
-      <Grid2 container>
-        <Grid2 container xs={12} sm={6} justifyContent="flex-end">
-          <Grid2>
+      <Grid container>
+        <Grid container justifyContent="flex-end" size={{ sm: 6, xs: 12 }}>
+          <Grid>
             <Button onClick={() => { onDismissClick(manifestId); }}>
               {t('dismiss')}
             </Button>
             <Button onClick={() => { onTryAgainClick(manifestId); }}>
               {t('tryAgain')}
             </Button>
-          </Grid2>
-        </Grid2>
-      </Grid2>
-    </Grid2>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
   );
 }
 

--- a/src/components/ManifestListItemError.jsx
+++ b/src/components/ManifestListItemError.jsx
@@ -14,37 +14,26 @@ export function ManifestListItemError({
 }) {
   const { t } = useTranslation();
   return (
-    <Grid container>
-      <Grid container>
-        <Grid container size={{ sm: 6, xs: 12 }}>
-          <Grid size={{ sm: 3, xs: 4 }}>
-            <Grid container justifyContent="center">
-              <ErrorIcon sx={{
-                color: 'error.main',
-                height: '2rem',
-                width: '2rem',
-              }}
-              />
-            </Grid>
-          </Grid>
-          <Grid size={{ sm: 9, xs: 8 }}>
-            <Typography>{t('manifestError')}</Typography>
-            <Typography sx={{ wordBreak: 'break-all' }}>{manifestId}</Typography>
-          </Grid>
-        </Grid>
+    <Grid container sx={{ width: '100%', alignItems: 'center', flexWrap: 'nowrap' }}>
+      <Grid container size={{ sm: 5, xs: 6 }} sx={{alignItems: 'center'}}>
+        <ErrorIcon sx={{
+          color: 'error.main',
+          height: '2rem',
+          width: '2rem',
+          marginRight: '0.5rem',
+        }}
+        />
+          <Typography>{t('manifestError')}</Typography>
+          <Typography sx={{ wordBreak: 'break-all' }}>{manifestId}</Typography>
       </Grid>
 
-      <Grid container>
-        <Grid container size={{ sm: 6, xs: 12 }}>
-          <Grid>
-            <Button onClick={() => { onDismissClick(manifestId); }}>
-              {t('dismiss')}
-            </Button>
-            <Button onClick={() => { onTryAgainClick(manifestId); }}>
-              {t('tryAgain')}
-            </Button>
-          </Grid>
-        </Grid>
+      <Grid container size={{ sm: 7, xs: 6 }}>
+        <Button onClick={() => { onDismissClick(manifestId); }}>
+          {t('dismiss')}
+        </Button>
+        <Button onClick={() => { onTryAgainClick(manifestId); }}>
+          {t('tryAgain')}
+        </Button>
       </Grid>
     </Grid>
   );

--- a/src/components/ManifestListItemError.jsx
+++ b/src/components/ManifestListItemError.jsx
@@ -14,8 +14,8 @@ export function ManifestListItemError({
 }) {
   const { t } = useTranslation();
   return (
-    <Grid container sx={{ width: '100%', alignItems: 'center', flexWrap: 'nowrap' }}>
-      <Grid container size={{ sm: 5, xs: 6 }} sx={{alignItems: 'center'}}>
+    <Grid container sx={{ width: '100%', alignItems: 'center' }}>
+      <Grid container size={{ sm: 5, xs: 12 }} sx={{alignItems: 'center'}}>
         <ErrorIcon sx={{
           color: 'error.main',
           height: '2rem',
@@ -27,7 +27,7 @@ export function ManifestListItemError({
           <Typography sx={{ wordBreak: 'break-all' }}>{manifestId}</Typography>
       </Grid>
 
-      <Grid container size={{ sm: 7, xs: 6 }}>
+      <Grid container size={{ sm: 7, xs: 12 }}>
         <Button onClick={() => { onDismissClick(manifestId); }}>
           {t('dismiss')}
         </Button>

--- a/src/components/ManifestListItemError.jsx
+++ b/src/components/ManifestListItemError.jsx
@@ -35,7 +35,7 @@ export function ManifestListItemError({
       </Grid>
 
       <Grid container>
-        <Grid container justifyContent="flex-end" size={{ sm: 6, xs: 12 }}>
+        <Grid container size={{ sm: 6, xs: 12 }}>
           <Grid>
             <Button onClick={() => { onDismissClick(manifestId); }}>
               {t('dismiss')}

--- a/src/components/PluginHook.jsx
+++ b/src/components/PluginHook.jsx
@@ -8,15 +8,11 @@ export const PluginHook = forwardRef(({ classes = {}, targetName, ...otherProps 
 
   return PluginComponents ? (
     PluginComponents.map((PluginComponent, index) => ( // eslint-disable-line react/prop-types
-      isValidElement(PluginComponent)
-        ? cloneElement(PluginComponent, { ...otherProps, ref })
-        : (
-          <PluginComponent
-            ref={ref}
-            {...otherProps}
-            key={index} // eslint-disable-line react/no-array-index-key
-          />
-        )
+      (isValidElement(PluginComponent) ? cloneElement(PluginComponent, { ...otherProps, ref }) : (<PluginComponent
+        ref={ref}
+        {...otherProps}
+        key={index} // eslint-disable-line react/no-array-index-key
+      />))
     ))
   ) : null;
 });

--- a/src/components/SelectCollection.jsx
+++ b/src/components/SelectCollection.jsx
@@ -20,7 +20,7 @@ export function SelectCollection({
   return (
     <Grid container justifyContent="center" alignItems="center">
       <Grid container direction="column" alignItems="center">
-        <Typography variant="h4" paragraph>
+        <Typography variant="h4" component="p">
           <em>
             {t('noItemSelected')}
           </em>

--- a/src/components/SelectCollection.jsx
+++ b/src/components/SelectCollection.jsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import ListSharpIcon from '@mui/icons-material/ListSharp';
 import { useTranslation } from 'react-i18next';
@@ -18,9 +19,9 @@ export function SelectCollection({
   }, [collectionPath, manifestId, showCollectionDialog, windowId]);
 
   return (
-    <Grid container justifyContent="center" alignItems="center">
-      <Grid container direction="column" alignItems="center">
-        <Typography variant="h4" component="p">
+    <Grid container sx={{ width: '100%', alignContent: 'center', justifyContent: 'center' }}>
+      <Stack>
+        <Typography variant="h4" component="p" sx={{ textAlign: 'center', mb: 2 }}>
           <em>
             {t('noItemSelected')}
           </em>
@@ -34,7 +35,7 @@ export function SelectCollection({
         >
           {t('showCollection')}
         </Button>
-      </Grid>
+      </Stack>
     </Grid>
   );
 }

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -28,6 +28,7 @@ const ZeroWindows = () => {
         container
         style={{
           height: '100%',
+          justifyContent: 'center',
         }}
       >
         <Grid size={12}>

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -30,10 +30,7 @@ const ZeroWindows = () => {
           height: '100%',
         }}
       >
-        <Grid
-          xs={12}
-          item
-        >
+        <Grid size={12}>
           <Typography
             variant="h1"
             component="div"

--- a/src/components/WorkspaceAdd.jsx
+++ b/src/components/WorkspaceAdd.jsx
@@ -113,10 +113,7 @@ export function WorkspaceAdd({
               height: '100%',
             }}
           >
-            <Grid
-              xs={12}
-              item
-            >
+            <Grid size={12}>
               <Typography
                 variant="h1"
                 component="div"

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,11 +40,13 @@ export default defineConfig({
           name: 'Mirador',
         },
         rollupOptions: {
-          external: [
-            ...Object.keys(packageJson.peerDependencies),
-            '__tests__/*',
-            '__mocks__/*',
-          ],
+          external: (id, parentId) => {
+            const peers = Object.keys(packageJson.peerDependencies);
+            return peers.indexOf(id) > -1
+              || peers.find((peer) => id.startsWith(`${peer}/`))
+              || id.startsWith('__tests__/')
+              || id.startsWith('__mocks__/');
+          },
           output: {
             assetFileNames: 'mirador.[ext]',
             exports: 'named',


### PR DESCRIPTION
This was mostly created using MUI's codemods.
The `Grid2` component has moved back into the `Grid` namespace. That is the biggest change.
(for testing purposes, also included is @lutzhelm's syntax for externalizing peer dependencies but I can slice this out into another PR.)

Visually, the changes seem to have no impact, but of course more eyes are better!

I am interested in this upgrade because of the solution for better ESM support: https://github.com/mui/material-ui/issues/45495. This will fix some issues reported during plugin integration such as #4136 

If this is approved and merged and we cut a new alpha release, I have PRs drafted locally for several plugins to support this change. And some like `image-tools` seem to require zero changes to support 7.