### PR TITLE
Fix ChangeThemeDialog and WorkspaceImport fullscreen behaviour

### DIFF
--- a/src/components/ChangeThemeDialog.jsx
+++ b/src/components/ChangeThemeDialog.jsx
@@ -21,7 +21,7 @@ const ThemeIcon = styled(PaletteIcon, { name: 'ThemeIcon', slot: 'icon' })(({ th
  * a simple dialog providing the possibility to switch the theme
  */
 export function ChangeThemeDialog({
-  handleClose, open = false, selectedTheme, setSelectedTheme, themeIds = [],
+  container = null, handleClose, open = false, selectedTheme, setSelectedTheme, themeIds = [],
 }) {
   const { t } = useTranslation();
   const handleThemeChange = useCallback((theme) => {
@@ -30,7 +30,7 @@ export function ChangeThemeDialog({
   }, [handleClose, setSelectedTheme]);
 
   return (
-    <WorkspaceDialog onClose={handleClose} open={open} variant="menu">
+    <WorkspaceDialog container={container} onClose={handleClose} open={open} variant="menu">
       <DialogTitle>
         {t('changeTheme')}
       </DialogTitle>
@@ -57,6 +57,7 @@ export function ChangeThemeDialog({
 }
 
 ChangeThemeDialog.propTypes = {
+  container: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   handleClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   selectedTheme: PropTypes.string.isRequired,

--- a/src/components/WorkspaceImport.jsx
+++ b/src/components/WorkspaceImport.jsx
@@ -13,7 +13,7 @@ import ScrollIndicatedDialogContent from '../containers/ScrollIndicatedDialogCon
 /**
  */
 export function WorkspaceImport({
-  addError, id = undefined, importConfig, classes = {}, handleClose, open = false,
+  addError, container = null, id = undefined, importConfig, classes = {}, handleClose, open = false,
 }) {
   const { t } = useTranslation();
   const [configImportValue, setConfigImportValue] = useState('');
@@ -39,6 +39,7 @@ export function WorkspaceImport({
   return (
     <WorkspaceDialog
       aria-labelledby={titleId}
+      container={container}
       id={id}
       onClose={handleClose}
       open={open}
@@ -79,6 +80,7 @@ export function WorkspaceImport({
 WorkspaceImport.propTypes = {
   addError: PropTypes.func.isRequired,
   classes: PropTypes.objectOf(PropTypes.string),
+  container: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   handleClose: PropTypes.func.isRequired,
   id: PropTypes.string,
   importConfig: PropTypes.func.isRequired,


### PR DESCRIPTION
Random find; `ChangeThemeDialog` and `WorkspaceImport` did not pass the `container` ref prop to the `WorkspaceDialog` and thus were not visible in fullscreen mode.