### PR TITLE
Fix annotation test, account for changes in manifest used as test fixture

### DIFF
--- a/__tests__/integration/mirador/tests/annotations.test.js
+++ b/__tests__/integration/mirador/tests/annotations.test.js
@@ -42,12 +42,12 @@ describe('Annotations in Mirador', () => {
 
     expect(await screen.findByRole('heading', { name: 'Annotations' })).toBeInTheDocument();
 
-    expect(await screen.findByText('Showing 5 annotations')).toBeInTheDocument();
+    expect(await screen.findByText('Showing 6 annotations')).toBeInTheDocument();
 
     const annotationPanel = await screen.findByRole('complementary', { name: /annotations/i });
     expect(annotationPanel).toBeInTheDocument();
 
     const listItems = await within(annotationPanel).findAllByRole('menuitem');
-    expect(listItems).toHaveLength(5);
+    expect(listItems).toHaveLength(6);
   });
 });


### PR DESCRIPTION
AnnotationList https://iiif.harvardartmuseums.org/manifests/object/299843/list/47174892 for Canvas https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892 in Manifest https://iiif.harvardartmuseums.org/manifests/object/299843 now contains 6 instead of 5 annotations, previously breaking the tests.