### PR TITLE
Fix #4152, use separate state for collection info panel and collection selection dialog

### DIFF
--- a/__tests__/fixtures/version-2/parentCollection.json
+++ b/__tests__/fixtures/version-2/parentCollection.json
@@ -1,0 +1,13 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "http://iiif.io/api/presentation/2.1/example/fixtures/parentCollection.json",
+  "@type": "sc:Collection",
+  "label": "Parent Collection of Collection",
+  "collections": [
+    {
+      "@id": "http://iiif.io/api/presentation/2.1/example/fixtures/collection.json",
+      "@type": "sc:Collection",
+      "label": "Collection of Test Cases - label for parent"
+    }
+  ]
+}

--- a/__tests__/src/components/CollectionDialog.test.js
+++ b/__tests__/src/components/CollectionDialog.test.js
@@ -4,21 +4,27 @@ import { Utils } from 'manifesto.js';
 
 import { CollectionDialog } from '../../../src/components/CollectionDialog';
 import collection from '../../fixtures/version-2/collection.json';
+import parentCollection from '../../fixtures/version-2/parentCollection.json';
 
 /** */
 function createWrapper(props) {
-  const manifest = Utils.parseManifest(props.manifest ? props.manifest : collection);
+  const { collection: propsCollection, manifest, ...otherProps } = props;
+  const manifestId = (manifest && manifest['@id']) || collection['@id'];
+  const manifestObject = Utils.parseManifest(manifest || collection);
+  const collectionObject = propsCollection && Utils.parseManifest(propsCollection);
 
   render(<div id="window" />);
 
   return render(
     <CollectionDialog
       addWindow={() => {}}
+      collection={collectionObject}
       classes={{}}
       ready
-      manifest={manifest}
+      manifestId={manifestId}
+      manifest={manifestObject}
       windowId="window"
-      {...props}
+      {...otherProps}
     />,
     { preloadedState: { windows: { window: { id: 'window' } } } },
   );
@@ -32,6 +38,7 @@ describe('CollectionDialog', () => {
     expect(screen.getAllByRole('menuitem')).toHaveLength(55);
     expect(screen.getByRole('menuitem', { name: 'Test 1 Manifest: Minimum Required Fields' })).toBeInTheDocument();
   });
+
   it('when not ready returns placeholder skeleton', () => {
     createWrapper({ ready: false });
 
@@ -39,6 +46,7 @@ describe('CollectionDialog', () => {
 
     expect(screen.getByRole('dialog').querySelectorAll('.MuiSkeleton-root')).toHaveLength(3); // eslint-disable-line testing-library/no-node-access
   });
+
   it('clicking the hide button fires hideCollectionDialog', async () => {
     const user = userEvent.setup();
     const hideCollectionDialog = vi.fn();
@@ -46,5 +54,63 @@ describe('CollectionDialog', () => {
 
     await user.click(screen.getByRole('button', { name: 'Close' }));
     expect(hideCollectionDialog).toHaveBeenCalled();
+  });
+
+  it('fires correct showCollectionDialog when a child collection is selected', async () => {
+    const user = userEvent.setup();
+    const showCollectionDialog = vi.fn();
+
+    createWrapper({ manifest: parentCollection, showCollectionDialog });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getAllByRole('menuitem')).toHaveLength(1);
+    expect(screen.getByRole('menuitem', { name: 'Collection of Test Cases - label for parent' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('menuitem', { name: 'Collection of Test Cases - label for parent' }));
+    expect(showCollectionDialog).toHaveBeenCalledWith(collection['@id'], [parentCollection['@id']], 'window');
+  });
+
+  it('fires correct showCollectionDialog when the parent collection is clicked', async () => {
+    const user = userEvent.setup();
+    const showCollectionDialog = vi.fn();
+
+    createWrapper({
+      collection: parentCollection,
+      dialogCollectionPath: [parentCollection['@id']],
+      manifest: collection,
+      showCollectionDialog,
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Parent Collection of Collection' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Parent Collection of Collection' }));
+    expect(showCollectionDialog).toHaveBeenCalledWith(parentCollection['@id'], [], 'window');
+  });
+
+  it('fires hideCollectionDialog, setWorkspaceAddVisibility, updateWindow when a manifest is selected', async () => {
+    const user = userEvent.setup();
+    const hideCollectionDialog = vi.fn();
+    const setWorkspaceAddVisibility = vi.fn();
+    const updateWindow = vi.fn();
+    const manifestId = 'http://iiif.io/api/presentation/2.1/example/fixtures/1/manifest.json';
+
+    createWrapper({
+      collection: parentCollection,
+      dialogCollectionPath: [parentCollection['@id']],
+      hideCollectionDialog,
+      manifest: collection,
+      setWorkspaceAddVisibility,
+      updateWindow,
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('menuitem', { name: 'Test 1 Manifest: Minimum Required Fields' }));
+    expect(hideCollectionDialog).toHaveBeenCalledWith('window');
+    expect(setWorkspaceAddVisibility).toHaveBeenCalledWith(false);
+    expect(updateWindow).toHaveBeenCalledWith('window', {
+      canvasId: null, collectionPath: [parentCollection['@id'], collection['@id']], manifestId,
+    });
   });
 });

--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -386,10 +386,10 @@ describe('windows reducer', () => {
     it('handles SHOW_COLLECTION_DIALOG by toggling the given window\'s collection dialog', () => {
       const beforeState = { abc123: { collectionDialogOn: false } };
       const action = {
-        collectionPath: [], manifestId: 'def456', type: ActionTypes.SHOW_COLLECTION_DIALOG, windowId: 'abc123',
+        dialogCollectionPath: [], manifestId: 'def456', type: ActionTypes.SHOW_COLLECTION_DIALOG, windowId: 'abc123',
       };
       const expectedState = {
-        abc123: { collectionDialogOn: true, collectionManifestId: 'def456', collectionPath: [] },
+        abc123: { collectionDialogOn: true, collectionManifestId: 'def456', dialogCollectionPath: [] },
       };
 
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);
@@ -400,17 +400,18 @@ describe('windows reducer', () => {
     it('handles HIDE_COLLECTION_DIALOG by toggling the given window\'s collection dialog', () => {
       const beforeState = {
         abc123: {
-          collectionDialogOn: true, collectionManifestId: 'def456', collectionPath: [],
+          collectionDialogOn: true, collectionManifestId: 'def456', collectionPath: [], dialogCollectionPath: ['x'],
         },
       };
       const action = {
-        collectionPath: [],
         type: ActionTypes.HIDE_COLLECTION_DIALOG,
         windowId: 'abc123',
       };
 
       const expectedState = {
-        abc123: { collectionDialogOn: false, collectionManifestId: 'def456', collectionPath: [] },
+        abc123: {
+          collectionDialogOn: false, collectionManifestId: 'def456', collectionPath: [], dialogCollectionPath: ['x'],
+        },
       };
 
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);

--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -404,6 +404,7 @@ describe('windows reducer', () => {
         },
       };
       const action = {
+        collectionPath: [],
         type: ActionTypes.HIDE_COLLECTION_DIALOG,
         windowId: 'abc123',
       };

--- a/__tests__/src/sagas/app.test.js
+++ b/__tests__/src/sagas/app.test.js
@@ -1,7 +1,7 @@
 import { call } from 'redux-saga/effects';
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 
-import { importConfig, importState } from '../../../src/state/sagas/app';
+import { fetchCollectionManifests, importConfig, importState } from '../../../src/state/sagas/app';
 import { fetchManifests } from '../../../src/state/sagas/iiif';
 import { fetchWindowManifest } from '../../../src/state/sagas/windows';
 import { addWindow } from '../../../src/state/actions';
@@ -78,6 +78,17 @@ describe('app-level sagas', () => {
         .put({ type: 'thunk1' })
         .put({ type: 'thunk2' })
         .run();
+    });
+  });
+
+  describe('fetchCollectionManifests', () => {
+    it('fetches ressources for manifestId and all collection path ids', () => {
+      const action = {
+        dialogCollectionPath: ['a', 'b'],
+        manifestId: 'c',
+        windowId: 'w',
+      };
+      testSaga(fetchCollectionManifests, action).next().call(fetchManifests, 'c', 'a', 'b');
     });
   });
 });

--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -507,7 +507,7 @@ describe('window-level sagas', () => {
         ])
         .put.like({
           action: {
-            collectionPath: [],
+            dialogCollectionPath: [],
             manifestId: 'manifest.json',
             type: 'mirador/SHOW_COLLECTION_DIALOG',
             windowId: 'x',
@@ -525,7 +525,7 @@ describe('window-level sagas', () => {
         ])
         .not.put.like({
           action: {
-            collectionPath: [],
+            dialogCollectionPath: [],
             manifestId: 'manifest.json',
             type: 'mirador/SHOW_COLLECTION_DIALOG',
             windowId: 'x',

--- a/src/components/CollectionDialog.jsx
+++ b/src/components/CollectionDialog.jsx
@@ -76,7 +76,7 @@ export function CollectionDialog({
 
   /** */
   const hideDialog = () => {
-    hideCollectionDialog(windowId);
+    hideCollectionDialog([...collectionPath, manifestId], windowId);
   };
 
   /** */

--- a/src/components/CollectionDialog.jsx
+++ b/src/components/CollectionDialog.jsx
@@ -66,7 +66,7 @@ Placeholder.propTypes = {
  * a dialog providing the possibility to select the collection
  */
 export function CollectionDialog({
-  addWindow, collection = null, collectionPath = [], error = null, hideCollectionDialog,
+  addWindow, collection = null, dialogCollectionPath = [], error = null, hideCollectionDialog,
   isMultipart = false, manifest, manifestId, ready = false,
   setWorkspaceAddVisibility, showCollectionDialog, updateWindow, windowId = null,
 }) {
@@ -76,19 +76,19 @@ export function CollectionDialog({
 
   /** */
   const hideDialog = () => {
-    hideCollectionDialog([...collectionPath, manifestId], windowId);
+    hideCollectionDialog(windowId);
   };
 
   /** */
   const selectCollection = (c) => {
-    showCollectionDialog(c.id, [...collectionPath, manifestId], windowId);
+    showCollectionDialog(c.id, [...dialogCollectionPath, manifestId], windowId);
   };
 
   /** */
   const goToPreviousCollection = () => {
     showCollectionDialog(
-      collectionPath[collectionPath.length - 1],
-      collectionPath.slice(0, -1),
+      dialogCollectionPath[dialogCollectionPath.length - 1],
+      dialogCollectionPath.slice(0, -1),
       windowId,
     );
   };
@@ -97,10 +97,10 @@ export function CollectionDialog({
   const selectManifest = (m) => {
     if (windowId) {
       updateWindow(windowId, {
-        canvasId: null, collectionPath: [...collectionPath, manifestId], manifestId: m.id,
+        canvasId: null, collectionPath: [...dialogCollectionPath, manifestId], manifestId: m.id,
       });
     } else {
-      addWindow({ collectionPath: [...collectionPath, manifestId], manifestId: m.id });
+      addWindow({ collectionPath: [...dialogCollectionPath, manifestId], manifestId: m.id });
     }
 
     hideDialog();
@@ -230,7 +230,7 @@ export function CollectionDialog({
 CollectionDialog.propTypes = {
   addWindow: PropTypes.func.isRequired,
   collection: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  collectionPath: PropTypes.arrayOf(PropTypes.string),
+  dialogCollectionPath: PropTypes.arrayOf(PropTypes.string),
   error: PropTypes.string,
   hideCollectionDialog: PropTypes.func.isRequired,
   isMultipart: PropTypes.bool,

--- a/src/containers/CollectionDialog.js
+++ b/src/containers/CollectionDialog.js
@@ -26,15 +26,15 @@ const mapDispatchToProps = {
  * @private
  */
 const mapStateToProps = (state, { windowId }) => {
-  const { collectionPath, collectionManifestId: manifestId } = getWindow(state, { windowId });
+  const { collectionManifestId: manifestId, dialogCollectionPath } = getWindow(state, { windowId });
   const manifest = getManifest(state, { manifestId });
 
-  const collectionId = collectionPath && collectionPath[collectionPath.length - 1];
+  const collectionId = dialogCollectionPath && dialogCollectionPath[dialogCollectionPath.length - 1];
   const collection = collectionId && getManifest(state, { manifestId: collectionId });
 
   return {
     collection: collection && getManifestoInstance(state, { manifestId: collection.id }),
-    collectionPath,
+    dialogCollectionPath,
     error: manifest && manifest.error,
     isMultipart: getSequenceBehaviors(state, { manifestId }).includes('multi-part'),
     manifest: manifest && getManifestoInstance(state, { manifestId }),

--- a/src/containers/CollectionInfo.js
+++ b/src/containers/CollectionInfo.js
@@ -13,7 +13,7 @@ import { CollectionInfo } from '../components/CollectionInfo';
  * @memberof WindowSideBarInfoPanel
  * @private
  */
-const mapStateToProps = (state, { companionWindowId, windowId }) => {
+const mapStateToProps = (state, { windowId }) => {
   const { collectionPath } = (getWindow(state, { windowId }) || {});
   const manifestId = collectionPath[collectionPath.length - 1];
 

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -203,8 +203,9 @@ export function showCollectionDialog(manifestId, collectionPath = [], windowId) 
 }
 
 /** */
-export function hideCollectionDialog(windowId) {
+export function hideCollectionDialog(collectionPath = [], windowId) {
   return {
+    collectionPath,
     type: ActionTypes.HIDE_COLLECTION_DIALOG,
     windowId,
   };

--- a/src/state/actions/window.js
+++ b/src/state/actions/window.js
@@ -193,9 +193,9 @@ export function setWindowViewType(windowId, viewType) {
 }
 
 /** */
-export function showCollectionDialog(manifestId, collectionPath = [], windowId) {
+export function showCollectionDialog(manifestId, dialogCollectionPath = [], windowId) {
   return {
-    collectionPath,
+    dialogCollectionPath,
     manifestId,
     type: ActionTypes.SHOW_COLLECTION_DIALOG,
     windowId,
@@ -203,9 +203,8 @@ export function showCollectionDialog(manifestId, collectionPath = [], windowId) 
 }
 
 /** */
-export function hideCollectionDialog(collectionPath = [], windowId) {
+export function hideCollectionDialog(windowId) {
   return {
-    collectionPath,
     type: ActionTypes.HIDE_COLLECTION_DIALOG,
     windowId,
   };

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -166,6 +166,7 @@ export const windowsReducer = (state = {}, action) => {
         [action.windowId]: {
           ...state[action.windowId],
           collectionDialogOn: false,
+          collectionPath: action.collectionPath
         },
       };
     default:

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -166,7 +166,7 @@ export const windowsReducer = (state = {}, action) => {
         [action.windowId]: {
           ...state[action.windowId],
           collectionDialogOn: false,
-          collectionPath: action.collectionPath
+          collectionPath: action.collectionPath,
         },
       };
     default:

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -157,7 +157,7 @@ export const windowsReducer = (state = {}, action) => {
           ...state[action.windowId],
           collectionDialogOn: true,
           collectionManifestId: action.manifestId,
-          collectionPath: action.collectionPath,
+          dialogCollectionPath: action.dialogCollectionPath,
         },
       };
     case ActionTypes.HIDE_COLLECTION_DIALOG:
@@ -166,7 +166,6 @@ export const windowsReducer = (state = {}, action) => {
         [action.windowId]: {
           ...state[action.windowId],
           collectionDialogOn: false,
-          collectionPath: action.collectionPath,
         },
       };
     default:

--- a/src/state/sagas/app.js
+++ b/src/state/sagas/app.js
@@ -43,8 +43,8 @@ export function* importConfig({ config: { thumbnailNavigation, windows } }) {
 
 /** */
 export function* fetchCollectionManifests(action) {
-  const { collectionPath, manifestId } = action;
-  yield call(fetchManifests, manifestId, ...collectionPath);
+  const { dialogCollectionPath, manifestId } = action;
+  yield call(fetchManifests, manifestId, ...dialogCollectionPath);
 }
 
 /** */

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -82,10 +82,14 @@ export function* setCollectionPath({ manifestId, windowId }) {
 
 /** */
 export function* fetchCollectionManifests(action) {
-  const { collectionPath } = action.payload;
-  if (!collectionPath) return;
+  const { collectionPath, dialogCollectionPath } = action.payload;
 
-  yield call(fetchManifests, ...collectionPath);
+  if (collectionPath) {
+    yield call(fetchManifests, ...collectionPath);
+  }
+  if (dialogCollectionPath) {
+    yield call(fetchManifests, ...dialogCollectionPath);
+  }
 }
 
 /** @private */

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -267,6 +267,7 @@ export default function* windowsSaga() {
     takeEvery(ActionTypes.ADD_WINDOW, fetchWindowManifest),
     takeEvery(ActionTypes.UPDATE_WINDOW, fetchWindowManifest),
     takeEvery(ActionTypes.UPDATE_WINDOW, setCanvasOnNewSequence),
+    takeEvery(ActionTypes.UPDATE_WINDOW, fetchCollectionManifests),
     takeEvery(ActionTypes.SET_CANVAS, setCurrentAnnotationsOnCurrentCanvas),
     takeEvery(ActionTypes.SET_CANVAS, fetchInfoResponses),
     takeEvery(ActionTypes.UPDATE_COMPANION_WINDOW, fetchCollectionManifests),

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -82,14 +82,10 @@ export function* setCollectionPath({ manifestId, windowId }) {
 
 /** */
 export function* fetchCollectionManifests(action) {
-  const { collectionPath, dialogCollectionPath } = action.payload;
+  const { collectionPath } = action.payload;
+  if (!collectionPath) return;
 
-  if (collectionPath) {
-    yield call(fetchManifests, ...collectionPath);
-  }
-  if (dialogCollectionPath) {
-    yield call(fetchManifests, ...dialogCollectionPath);
-  }
+  yield call(fetchManifests, ...collectionPath);
 }
 
 /** @private */


### PR DESCRIPTION
Replacement for PR #4154; addresses problems mentioned in [this comment](https://github.com/ProjectMirador/mirador/pull/4154#issuecomment-2949717883).