### PR TITLE
Fix annotations integration test by updating the number of annotations (again)

### DIFF
--- a/__tests__/integration/mirador/tests/annotations.test.js
+++ b/__tests__/integration/mirador/tests/annotations.test.js
@@ -42,12 +42,12 @@ describe('Annotations in Mirador', () => {
 
     expect(await screen.findByRole('heading', { name: 'Annotations' })).toBeInTheDocument();
 
-    expect(await screen.findByText('Showing 6 annotations')).toBeInTheDocument();
+    expect(await screen.findByText('Showing 12 annotations')).toBeInTheDocument();
 
     const annotationPanel = await screen.findByRole('complementary', { name: /annotations/i });
     expect(annotationPanel).toBeInTheDocument();
 
     const listItems = await within(annotationPanel).findAllByRole('menuitem');
-    expect(listItems).toHaveLength(6);
+    expect(listItems).toHaveLength(12);
   });
 });


### PR DESCRIPTION
The annotations of the tested canvas of the used Harvard manifest have changed once again, it has now 12 annotations, resulting in a failing test.

As this is not the first time (see #4148), we should maybe think about using something different as test fixture.