### PR TITLE
Drop v18, add v24 to GitHub Node.JS CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
v18 dropped out of support two months ago; v24 as  upcoming LTS is out since May 6th.