### PR TITLE
Serve demo pages from cleaner URLs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,4 +2,5 @@ codecov:
   coverage:
     precision: 1
     round: up
-    
+  ignore:
+    - vite.config.js

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,10 @@
 
 [[redirects]]
   from = "/"
-  to = "/__tests__/integration/mirador/"
+  to = "/__tests__/integration/mirador/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/:page"
+  to = "/__tests__/integration/mirador/:page"
+  status = 200

--- a/vite.config.js
+++ b/vite.config.js
@@ -63,14 +63,65 @@ export default defineConfig({
   define: {
     'process.env': {},
   },
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      /**
+        * Middleware to rewrite HTML URLs to point to the deep path
+       */
+      configureServer(server) {
+        server.middlewares.use(async (req, res, next) => {
+          // Strip query parameters
+          const originalUrl = req.url.split('?')[0];
+
+          // Handle root URL directly
+          if (originalUrl === '/') {
+            req.url = '/__tests__/integration/mirador/index.html';
+            console.log(`[rewrite] / → ${req.url}`);
+            return next();
+          }
+
+          // Skip if path already rewritten or includes file extensions other than .html
+          if (originalUrl.startsWith('/__tests__/integration/mirador/')) return next();
+          if (path.extname(originalUrl) && path.extname(originalUrl) !== '.html') return next();
+
+          // Add .html extension if needed
+          const pathWithExtension = path.extname(originalUrl)
+            ? originalUrl
+            : `${originalUrl}.html`;
+
+          const deepPath = path.join(
+            '__tests__/integration/mirador',
+            decodeURIComponent(pathWithExtension),
+          );
+
+          try {
+            // Check if this is a file we own (not HMR-related vite files, for example)
+            await fs.access(deepPath);
+            req.url = `/__tests__/integration/mirador${pathWithExtension}`;
+            console.log(`[rewrite] ${originalUrl} → ${req.url}`);
+          } catch {
+            // Not ours / does not exist — skip rewrite
+          }
+
+          return next();
+        });
+      },
+      name: 'html-url-rewrite',
+    },
+  ],
   resolve: {
     alias: {
       '@tests/': fileURLToPath(new URL('./__tests__', import.meta.url)),
     },
   },
   server: {
-    open: '/__tests__/integration/mirador/index.html',
+    fs: {
+      allow: [path.resolve(__dirname, 'src'),
+        path.resolve(__dirname, '__tests__/integration/mirador')], // allow serving from here
+    },
+    middlewareMode: false,
+    open: '/index.html',
     port: '4444',
   },
 });


### PR DESCRIPTION
Please check out the deploy preview and use this branch locally to confirm.

`localhost:4444/__tests__/integration/mirador/index.html` now becomes `localhost:4444/index.html`
And on Netlify, we are now operating from the root.

I am curious about the history of this ticket: https://github.com/ProjectMirador/mirador/issues/3911
It doesn't seem to have completed this portion of the work.