### PR TITLE
Allow pluginTarget to be passed as a prop to WindowTopBarPluginMenu

### DIFF
--- a/__tests__/src/components/WindowTopBarPluginMenu.test.js
+++ b/__tests__/src/components/WindowTopBarPluginMenu.test.js
@@ -62,4 +62,24 @@ describe('WindowTopBarPluginMenu', () => {
       expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
   });
+
+  describe('pluginTarget prop', () => {
+    it('passes the pluginTarget to usePlugins', () => {
+      const spy = vi.mocked(usePlugins);
+      spy.mockReturnValue({ PluginComponents: [mockComponentA] });
+
+      render(<Subject pluginTarget="CustomPluginTarget" />);
+
+      expect(spy).toHaveBeenCalledWith('CustomPluginTarget');
+    });
+
+    it('defaults pluginTarget to WindowTopBarPluginMenu if not provided', () => {
+      const spy = vi.mocked(usePlugins);
+      spy.mockReturnValue({ PluginComponents: [mockComponentA] });
+
+      render(<Subject />);
+
+      expect(spy).toHaveBeenCalledWith('WindowTopBarPluginMenu');
+    });
+  });
 });

--- a/src/components/WindowTopBarPluginMenu.jsx
+++ b/src/components/WindowTopBarPluginMenu.jsx
@@ -7,12 +7,11 @@ import MiradorMenuButton from '../containers/MiradorMenuButton';
 import { PluginHook } from './PluginHook';
 import WorkspaceContext from '../contexts/WorkspaceContext';
 import { usePlugins } from '../extend/usePlugins';
-
 /**
  *
  */
 export function WindowTopBarPluginMenu({
-  windowId, menuIcon = <MoreVertIcon />,
+  windowId, menuIcon = <MoreVertIcon />, pluginTarget = 'WindowTopBarPluginMenu', 
 }) {
   const { t } = useTranslation();
   const container = useContext(WorkspaceContext);
@@ -20,7 +19,7 @@ export function WindowTopBarPluginMenu({
   const [anchorEl, setAnchorEl] = useState(null);
   const [open, setOpen] = useState(false);
   const windowPluginMenuId = useId();
-  const { PluginComponents } = usePlugins('WindowTopBarPluginMenu');
+  const { PluginComponents } = usePlugins(pluginTarget);
 
   /** */
   const handleMenuClick = (event) => {
@@ -63,7 +62,7 @@ export function WindowTopBarPluginMenu({
         open={open}
         onClose={handleMenuClose}
       >
-        <PluginHook targetName="WindowTopBarPluginMenu" handleClose={handleMenuClose} {...pluginProps} />
+        <PluginHook targetName={pluginTarget} handleClose={handleMenuClose} {...pluginProps} />
       </Menu>
     </>
   );
@@ -74,5 +73,6 @@ WindowTopBarPluginMenu.propTypes = {
   container: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   menuIcon: PropTypes.element,
   open: PropTypes.bool,
+  pluginTarget: PropTypes.string,
   windowId: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
It seems that after [this work ](https://github.com/ProjectMirador/mirador/commit/5b099fd99f3afc60dc3a53815aba188062b016e6#diff-1ca0daa66fd0765ca0ba5989323787b65e28ef5caf0e9eee930a6e1aa0c7a76c) to refactor some of the plugin system, there are some impacts for downstream.

Locally we are upgrading to Mirador 4 and ran into an issue with [our custom plugin](https://github.com/sul-dlss/sul-embed/blob/03ca43f27cfaaaac66b75201c39396f52dd70ed4/app/javascript/src/plugins/shareMenuPlugin.jsx#L20), which reuses the `WindowTopBarPluginMenu` component from Mirador. 

After the Mirador plugin changes linked above, our local plugin no longer works, I think due to this line changed upstream: `const { PluginComponents } = usePlugins('WindowTopBarPluginMenu');` , which hardcodes the plugin name.

Open to thoughts, but changing this and then allowing the downstream app to this worked well:
```
const CustomMenuComponent = (props) => {
  return (
    <WindowTopBarPluginMenu
        menuIcon={<CustomIcon />}
        pluginTarget="CustomMenuComponent"
        windowId={props.windowId}
    />
  );
};
``` 
I would love to get this into Mirador 4 or learn of another solution, otherwise our local plugin doesn't work.