### PR TITLE
Replace Harvard Van Gogh manifest due to failing tests

### DIFF
--- a/__tests__/integration/mirador/constants.js
+++ b/__tests__/integration/mirador/constants.js
@@ -1,0 +1,2 @@
+export const PRIMARY_MANIFEST_FIXTURE_URL = 'https://dms-data.stanford.edu/data/manifests/Parker/nb647fd0133/manifest.json';
+export const PRIMARY_CANVAS_FIXTURE_URL = 'https://dms-data.stanford.edu/data/manifests/Parker/nb647fd0133/canvas/canvas-1';

--- a/__tests__/integration/mirador/mirador-configs/double-van-gogh.js
+++ b/__tests__/integration/mirador/mirador-configs/double-van-gogh.js
@@ -1,3 +1,5 @@
+import { PRIMARY_MANIFEST_FIXTURE_URL } from '../constants';
+
 /**
  * Creates a Mirador config object with two windows:
  * - One with a specific canvas index
@@ -14,7 +16,7 @@ export default function createConfig(id) {
     windows: [
       {
         canvasIndex: 2,
-        loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+        loadedManifest: PRIMARY_MANIFEST_FIXTURE_URL,
       },
       {
         loadedManifest: 'https://media.nga.gov/public/manifests/nga_highlights.json',

--- a/__tests__/integration/mirador/mirador-configs/i18n.js
+++ b/__tests__/integration/mirador/mirador-configs/i18n.js
@@ -1,7 +1,9 @@
+import { PRIMARY_MANIFEST_FIXTURE_URL } from '../constants';
+
 export default {
   catalog: [
+    { manifestId: PRIMARY_MANIFEST_FIXTURE_URL },
     { manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json' },
-    { manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843' },
     { manifestId: 'https://media.nga.gov/public/manifests/nga_highlights.json', provider: 'National Gallery of Art' },
     { manifestId: 'https://wellcomelibrary.org/iiif/b18035723/manifest', provider: 'Wellcome Library' },
     { manifestId: 'https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json', provider: 'Biblissima' },

--- a/__tests__/integration/mirador/mirador-configs/index.js
+++ b/__tests__/integration/mirador/mirador-configs/index.js
@@ -1,8 +1,10 @@
+import { PRIMARY_CANVAS_FIXTURE_URL, PRIMARY_MANIFEST_FIXTURE_URL } from '../constants';
+
 // has 2 windows, one gaugin and one bodleian
 export default {
   catalog: [
+    { manifestId: PRIMARY_MANIFEST_FIXTURE_URL },
     { manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json' },
-    { manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843' },
     { manifestId: 'https://media.nga.gov/public/manifests/nga_highlights.json', provider: 'National Gallery of Art' },
     { manifestId: 'https://wellcomelibrary.org/iiif/b18035723/manifest', provider: 'Wellcome Library' },
     { manifestId: 'https://demos.biblissima.fr/iiif/metadata/florus-dispersus/manifest.json', provider: 'Biblissima' },
@@ -19,8 +21,8 @@ export default {
     transitions: {},
   },
   windows: [{
-    canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
-    manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+    canvasId: PRIMARY_CANVAS_FIXTURE_URL,
+    manifestId: PRIMARY_MANIFEST_FIXTURE_URL,
   },
   {
     canvasId: 'https://iiif.bodleian.ox.ac.uk/iiif/canvas/e58b8c60-005c-4c41-a22f-07d49cb25ede.json',

--- a/__tests__/integration/mirador/mirador-configs/initial-viewer-config.js
+++ b/__tests__/integration/mirador/mirador-configs/initial-viewer-config.js
@@ -1,7 +1,9 @@
+import { PRIMARY_MANIFEST_FIXTURE_URL, PRIMARY_CANVAS_FIXTURE_URL } from '../constants';
+
 export default {
   id: 'mirador',
   windows: [{
-    canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
+    canvasId: PRIMARY_CANVAS_FIXTURE_URL,
     initialViewerConfig: {
       thumbnailNavigationPosition: 'far-bottom',
       x: 934,
@@ -9,6 +11,6 @@ export default {
       // you need to specify zoom for this to look good
       zoom: 0.0007,
     },
-    manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+    manifestId: PRIMARY_MANIFEST_FIXTURE_URL,
   }],
 };

--- a/__tests__/integration/mirador/mirador-configs/minimalist.js
+++ b/__tests__/integration/mirador/mirador-configs/minimalist.js
@@ -1,3 +1,5 @@
+import { PRIMARY_MANIFEST_FIXTURE_URL, PRIMARY_CANVAS_FIXTURE_URL } from '../constants';
+
 export default {
   id: 'mirador',
   theme: {
@@ -10,8 +12,8 @@ export default {
   },
   windows: [{
     allowClose: false,
-    canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
-    manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+    canvasId: PRIMARY_CANVAS_FIXTURE_URL,
+    manifestId: PRIMARY_MANIFEST_FIXTURE_URL,
     thumbnailNavigationPosition: 'far-bottom',
   }],
   workspace: {

--- a/__tests__/integration/mirador/mirador-configs/plugin-state.js
+++ b/__tests__/integration/mirador/mirador-configs/plugin-state.js
@@ -1,11 +1,12 @@
 import { stateDependentPlugin } from '../plugins/index';
+import { PRIMARY_MANIFEST_FIXTURE_URL } from '../constants';
 
 export default {
   config: {
     id: 'mirador',
     windows: [{
       canvasIndex: 2,
-      loadedManifest: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+      loadedManifest: PRIMARY_MANIFEST_FIXTURE_URL,
       thumbnailNavigationPosition: 'far-bottom',
     }],
   },

--- a/__tests__/integration/mirador/mirador-configs/rtl.js
+++ b/__tests__/integration/mirador/mirador-configs/rtl.js
@@ -1,3 +1,5 @@
+import { PRIMARY_MANIFEST_FIXTURE_URL } from '../constants';
+
 export const rtl1 = {
   createGenerateClassNameOptions: {
     seed: 'one',
@@ -32,7 +34,7 @@ export const rtl3 = {
   id: 'instanceThree',
   windows: [
     {
-      manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+      manifestId: PRIMARY_MANIFEST_FIXTURE_URL,
     },
   ],
 };

--- a/__tests__/integration/mirador/mirador-configs/single-van-gogh.js
+++ b/__tests__/integration/mirador/mirador-configs/single-van-gogh.js
@@ -1,3 +1,5 @@
+import { PRIMARY_CANVAS_FIXTURE_URL, PRIMARY_MANIFEST_FIXTURE_URL } from '../constants';
+
 export default {
   id: 'mirador',
   theme: {
@@ -7,7 +9,7 @@ export default {
     defaultPosition: 'far-bottom',
   },
   windows: [{
-    canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
-    manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
+    canvasId: PRIMARY_CANVAS_FIXTURE_URL,
+    manifestId: PRIMARY_MANIFEST_FIXTURE_URL,
   }],
 };

--- a/__tests__/integration/mirador/tests/annotations.test.js
+++ b/__tests__/integration/mirador/tests/annotations.test.js
@@ -12,11 +12,6 @@ import config from '../mirador-configs/single-van-gogh';
 describe('Annotations in Mirador', () => {
   setupIntegrationTestViewer(config);
 
-  it('Loads the manifest', async () => {
-    const element = await screen.findByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i });
-    expect(element).toBeInTheDocument();
-  });
-
   it('stores annotations in state by canvasId', async (context) => {
     // Open the sidebar
     const toggleButtons = await screen.findAllByLabelText(/toggle sidebar/i);

--- a/__tests__/integration/mirador/tests/minimalist.test.js
+++ b/__tests__/integration/mirador/tests/minimalist.test.js
@@ -7,7 +7,7 @@ describe('Minimalist configuration to Mirador', () => {
   setupIntegrationTestViewer(config);
 
   it('Loads a manifest and displays it without some of the default controls', async () => {
-    expect(await screen.findByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).toBeInTheDocument();
 
     const infoButton = await screen.findByRole('tab', { name: /Information/i });
     expect(infoButton).toBeInTheDocument();

--- a/__tests__/integration/mirador/tests/plugin-state.test.js
+++ b/__tests__/integration/mirador/tests/plugin-state.test.js
@@ -7,7 +7,7 @@ describe('how plugins relate to state', () => {
   setupIntegrationTestViewer(settings.config, settings.plugins);
 
   it('plugin can read from state', async () => {
-    const text = 'Plugin:https://iiif.harvardartmuseums.org/manifests/object/299843';
+    const text = 'Plugin:https://dms-data.stanford.edu/data/manifests/Parker/nb647fd0133/manifest.json';
     const elementWithText = await screen.findByText(text);
     expect(elementWithText).toHaveTextContent(text);
   });

--- a/__tests__/integration/mirador/tests/viewer-config.test.js
+++ b/__tests__/integration/mirador/tests/viewer-config.test.js
@@ -8,7 +8,7 @@ describe('initialViewerConfig', () => {
 
   describe('initialViewerConfig', () => {
     it('allows initialViewerConfig to be passed', async (context) => {
-      expect(await screen.findByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).toBeInTheDocument();
+      expect(await screen.findByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).toBeInTheDocument();
 
       let viewerObject;
       await waitFor(() => {

--- a/__tests__/integration/mirador/tests/window-actions.test.js
+++ b/__tests__/integration/mirador/tests/window-actions.test.js
@@ -7,10 +7,10 @@ describe('Window actions', () => {
   setupIntegrationTestViewer(config);
 
   it('Closes a Mirador window', async () => {
-    expect(await screen.findByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).toBeInTheDocument();
     const closeButton = screen.getByRole('button', { name: /Close window/i });
     fireEvent.click(closeButton);
-    await waitFor(() => expect(screen.queryByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).not.toBeInTheDocument());
 
     // No windows should be present
     expect(screen.queryByRole('region')).not.toBeInTheDocument();


### PR DESCRIPTION
This is sad because the painting was the iconic cover of Mirador!
Hopefully just a temporary fix until we can get the access sorted out.
This change is needed due to changes in Harvard's cross-origin policy that was causing requests to fail, thus breaking our tests.
It can be brittle to rely on live manifests but for our integration tests, which dig down into many levels of nested references to manifests and images, I don't really want to try to mock that.
I made the url into a variable so that it is easier to swap out again in the future.

The requirements for a replacement were: be an image with annotations, and be visually interesting. Hopefully we can swap back!

We need to be able to move forward with passing tests though.

<img width="1504" height="772" alt="Screenshot 2025-08-22 at 2 33 37 PM" src="https://github.com/user-attachments/assets/f2b9ca03-b421-45e8-a4b5-52f6cc61edf4" />

