### PR TITLE
Check for client-side error dialog within test suite

### DIFF
--- a/__tests__/integration/mirador/tests/annotations.test.js
+++ b/__tests__/integration/mirador/tests/annotations.test.js
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest';
 import { screen, fireEvent, within } from '@testing-library/react';
-import { setupIntegrationTestViewer } from '@tests/utils/test-utils';
+import { setupIntegrationTestViewer, safeFindByRole } from '@tests/utils/test-utils';
 import config from '../mirador-configs/single-van-gogh';
 
 // TODO: sometimes this is failing with
@@ -42,7 +42,9 @@ describe('Annotations in Mirador', () => {
     expect(annoCountSubtitle).toBeInTheDocument();
     const annotationCount = annoCountSubtitle.innerText.match(/\d+/)[0];
 
-    const annotationPanel = await screen.findByRole('complementary', { name: /annotations/i });
+    // use safeFindByRole here. This specific test is consistently hard to interpret on failure,
+    // since another async operation has happened after setupIntegrationTestViewer
+    const annotationPanel = await safeFindByRole('complementary', { name: /annotations/i });
     expect(annotationPanel).toBeInTheDocument();
 
     const listItems = await within(annotationPanel).findAllByRole('menuitem');

--- a/__tests__/utils/safe-queries.js
+++ b/__tests__/utils/safe-queries.js
@@ -1,0 +1,54 @@
+import { screen, waitFor } from '@testing-library/react';
+
+/**
+ * Detects and fails early if an error dialog is rendered in the app.
+ *
+ * Many rendering failures in the app result in an error dialog that overlays the UI
+ * and sets `aria-hidden="true"` on the main content. When this occurs, Testing Library
+ * queries relying on accessibility roles (e.g., `findByRole`) will silently fail,
+ * resulting in misleading test errors.
+ */
+export async function failIfErrorDialogPresent({ waitForRole, roleOptions } = {}) {
+  await waitFor(() => {
+    const message = getErrorDialogMessage();
+    if (message) {
+      throw new Error(`Content inaccessible due to error dialog: ${message}`);
+    }
+
+    if (waitForRole) {
+      const el = screen.queryAllByRole(waitForRole, roleOptions);
+      if (el) return true;
+      throw new Error(`Waiting for role "${waitForRole}" or error dialog`);
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Helper to extract the error message from the dialog
+ */
+function getErrorDialogMessage() {
+  /* eslint-disable testing-library/no-node-access */
+  const errorDialog = document.querySelector('h2#error-dialog-title');
+  return errorDialog
+    ? errorDialog.closest('[role="dialog"]')?.querySelector('p')?.textContent ?? 'Unknown error'
+    : null;
+  /* eslint-enable testing-library/no-node-access */
+}
+
+/**
+ * Safe version of findByRole that fails early if an error dialog is present.
+ */
+export async function safeFindByRole(role, options = {}, timeout) {
+  await failIfErrorDialogPresent({ roleOptions: options, waitForRole: role });
+  return screen.findByRole(role, options, { timeout });
+}
+
+/**
+ * Safe version of findAllByRole that fails early if an error dialog is present.
+ */
+export async function safeFindAllByRole(role, options = {}, timeout) {
+  await failIfErrorDialogPresent({ roleOptions: options, waitForRole: role });
+  return screen.findAllByRole(role, options, { timeout });
+}

--- a/__tests__/utils/test-utils.js
+++ b/__tests__/utils/test-utils.js
@@ -8,12 +8,13 @@ import { I18nextProvider } from 'react-i18next';
 import createRootReducer from '../../src/state/reducers/rootReducer';
 import settings from '../../src/config/settings';
 import createI18nInstance from '../../src/i18n';
+import { failIfErrorDialogPresent, safeFindByRole, safeFindAllByRole } from './safe-queries';
 
 /** Mirador viewer setup for Integration tests */
 import { viewer as miradorViewer } from '../../src/index';
 
 export * from '@testing-library/react';
-export { renderWithProviders as render };
+export { renderWithProviders as render, safeFindByRole };
 
 const rootReducer = createRootReducer();
 const theme = createTheme(settings.theme);
@@ -88,8 +89,10 @@ export const setupIntegrationTestViewer = (config, plugins) => {
     expect(await screen.findByTestId('mirador')).toBeInTheDocument();
     expect(await screen.findByLabelText('Workspace')).toBeInTheDocument();
 
+    await failIfErrorDialogPresent({ waitForRole: 'main' });
+
     if ((config.windows || []).length > 0) {
-      await screen.findAllByRole('region', { name: /Window:/i });
+      await safeFindAllByRole('region', { name: /Window:/i });
     }
   });
 };


### PR DESCRIPTION
This is really helpful in the case that an error dialog is blocking out the entire app content and generating misleading messages about `findByRole` not working -- in the case that a manifest is not returned from a request, for example, we didn't see that information in the test failures. This works pretty well:


<img width="1511" height="427" alt="Screenshot 2025-08-28 at 6 28 08 PM" src="https://github.com/user-attachments/assets/1d3b8d60-6e2c-42f3-9ff3-6ba9cd46bb12" />




vs the old situation where we only get a `TestingLibraryElementError`

<img width="1512" height="451" alt="Screenshot 2025-08-28 at 6 29 22 PM" src="https://github.com/user-attachments/assets/0b1761ae-1e72-47da-80f4-2ade596cc566" />

