### PR TITLE
Only enforce codecov check on pull requests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,12 @@
-codecov:
-  coverage:
-    precision: 1
-    round: up
+coverage:
+  precision: 1
+  round: up
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: false
   ignore:
     - vite.config.js


### PR DESCRIPTION
This should prevent a red x that we frequently see on the main branch / repository homepage -- making the project-level check information-only.

> the resulting status will pass no matter what the coverage is or what other settings are specified.

For PRs ("patches" in codecov) CI will still break if tests decrease below threshhold.

Also from my reading of the docs and using codecov's validator service, it seemed like they wanted me to rewrite the key structure, removing top level `codecov`:

```
curl --data-binary @.codecov.yml https://codecov.io/validate
Valid!

{
  "coverage": {
    "precision": 1,
    "round": "up",
    "status": {
      "project": {
        "default": {
          "informational": true
        }
      },
      "patch": {
        "default": {
          "informational": false
        }
      }
    }
  },
  "ignore": [
    "^vite.config.js.*"
  ]
}
```

vs.:

```
 curl --data-binary @.codecov.yml https://codecov.io/validate
Error at ['codecov', 'coverage']: 
unknown field
```


