### PR TITLE
Avoid React 19 deprecation warning by using library fork

### DIFF
--- a/__tests__/src/components/Window.test.js
+++ b/__tests__/src/components/Window.test.js
@@ -1,4 +1,4 @@
-import { MosaicWindowContext } from 'react-mosaic-component2';
+import { MosaicWindowContext } from '@lonli-lokli/react-mosaic-component';
 import { render, screen } from '@tests/utils/test-utils';
 
 import { Window } from '../../../src/components/Window';

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-full-screen": "^1.1.1",
     "react-image": "^4.0.1",
     "react-intersection-observer": "^9.0.0",
-    "react-mosaic-component2": "^7.0.0",
+    "@lonli-lokli/react-mosaic-component": "0.18.0",
     "react-redux": "^8.0.0 || ^9.0.0",
     "react-resize-observer": "^1.1.1",
     "react-rnd": "~10.4.0",

--- a/src/components/Window.jsx
+++ b/src/components/Window.jsx
@@ -2,7 +2,7 @@ import { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Paper from '@mui/material/Paper';
-import { MosaicWindowContext } from 'react-mosaic-component2';
+import { MosaicWindowContext } from '@lonli-lokli/react-mosaic-component';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import ns from '../config/css-ns';

--- a/src/components/WorkspaceMosaic.jsx
+++ b/src/components/WorkspaceMosaic.jsx
@@ -5,7 +5,7 @@ import GlobalStyles from '@mui/material/GlobalStyles';
 import { DndContext } from 'react-dnd';
 import {
   Mosaic, MosaicWindow, getLeaves, createBalancedTreeFromLeaves,
-} from 'react-mosaic-component2';
+} from '@lonli-lokli/react-mosaic-component';
 import difference from 'lodash/difference';
 import isEqual from 'lodash/isEqual';
 import classNames from 'classnames';

--- a/src/lib/MosaicLayout.js
+++ b/src/lib/MosaicLayout.js
@@ -1,7 +1,7 @@
 import {
   createRemoveUpdate, updateTree,
   getNodeAtPath, getOtherDirection, getPathToCorner, Corner,
-} from 'react-mosaic-component2';
+} from '@lonli-lokli/react-mosaic-component';
 import dropRight from 'lodash/dropRight';
 
 /** */


### PR DESCRIPTION
See discussion: https://github.com/nomcopter/react-mosaic/issues/225

We will need to address this at some point. The fork is one approach. 
I decided it was important to do because over in the `mirador-integration` repo, this warning actually crashed the parcel dev server. This library was the root cause.


<img width="1156" height="378" alt="Screenshot 2025-09-10 at 1 59 58 PM" src="https://github.com/user-attachments/assets/e64e2a46-ad3a-4b5a-b89c-220ba4465125" />
