### PR TITLE
Pass options to minimize scroll distance for GalleryViewThumbnail

### DIFF
--- a/src/components/GalleryViewThumbnail.jsx
+++ b/src/components/GalleryViewThumbnail.jsx
@@ -61,7 +61,7 @@ export function GalleryViewThumbnail({
 
   useEffect(() => {
     if (selected) {
-      myRef.current?.scrollIntoView(true);
+      myRef.current?.scrollIntoView({ block: 'nearest'});
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
This is an issue when switching into the Gallery view, when Mirador doesn't take up the entire height of its page.

See the video of the reported issue here: https://github.com/sul-dlss/sul-embed/issues/2929

`scrollIntoView` wasn't included until this PR https://github.com/ProjectMirador/mirador/pull/3530, which we didn't get merged into code until Mirador 4 alpha-2, so nobody had the chance to notice this yet.