### PR TITLE
Update types handled by IIIFDropTarget

### DIFF
--- a/__tests__/src/components/IIIFDropTarget.test.js
+++ b/__tests__/src/components/IIIFDropTarget.test.js
@@ -94,4 +94,46 @@ describe('handleDrop', () => {
       );
     });
   });
+
+  it('handles HTML drops by extracting a manifest URL from a link', () => {
+    // This is an example taken from the wild because it contains nested
+    // links to various sources.
+    const htmlString = `
+      <html>
+        <body>
+          <a href="https://iiifviewer.universiteitleiden.nl/?manifest=https://digitalcollections.universiteitleiden.nl/iiif_manifest/item%253A1607191/manifest&canvas=https%3A//digitalcollections.universiteitleiden.nl/iiif_manifest/item%3A1607203/canvas/default" target="_blank" title="Drag and drop to a IIIF-compliant viewer."><div class="iiifbutton" data-manifest="https://digitalcollections.universiteitleiden.nl/iiif_manifest/item%3A1607191/manifest"><img src="https://digitalcollections.universiteitleiden.nl/sites/all/modules/custom/islandora_iiif_manifests/images/iiif-logo.svg" alt=""><div class="iiiftext">Advanced Viewer</div></div></a>
+        </body>
+      </html>
+    `;
+
+    const item = {
+      html: htmlString,
+    };
+
+    const props = { onDrop };
+
+    handleDrop(item, monitor, props);
+
+    expect(onDrop).toHaveBeenCalledWith(
+      { canvasId: 'https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:1607203/canvas/default', manifestId: 'https://digitalcollections.universiteitleiden.nl/iiif_manifest/item%3A1607191/manifest' },
+      props,
+      monitor,
+    );
+  });
+
+  it('warns when dropped URL is invalid', () => {
+    const item = {
+      urls: ['not a valid url'],
+    };
+    const props = { onDrop };
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    handleDrop(item, monitor, props);
+
+    expect(consoleSpy).toHaveBeenCalledWith('Invalid URL:', 'not a valid url');
+    expect(onDrop).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
This PR patches the current implementation of drag and drop.
IIIFDropTarget is currently not working with HTML links such as the one here: https://digitalcollections.universiteitleiden.nl/view/item/1607203

To test, try dragging the IIIF "Advanced viewer" icon from the above link into Mirador
<img width="1164" height="708" alt="Screenshot 2025-09-18 at 4 59 53 PM" src="https://github.com/user-attachments/assets/b36680dd-4a25-4be6-8483-ae3ca065bae7" />
