### PR TITLE
Bump version to rc-5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirador",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "description": "An open-source, web-based 'multi-up' viewer that supports zoom-pan-rotate functionality, ability to display/compare simple images, and images with annotations.",
   "type": "module",
   "main": "./dist/mirador.min.js",


### PR DESCRIPTION
This will put the fixed IIIF drag and drop and suppressed fullscreen button for iPhones into Mirador