### PR TITLE
Fix #4198, make annotation / layers / search result badge visible again

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -50,7 +50,8 @@ export default {
         main: '#b00020',
       },
       notification: { // Color used in MUI Badge dots
-        main: '#ffa224'
+        main: '#ffa224',
+        contrastText: '#ffa224',
       },
       hitCounter: {
         default: '#bdbdbd',


### PR DESCRIPTION
See [this comment](https://github.com/ProjectMirador/mirador/issues/4198#issuecomment-3468752431). I'm not sure if we should provide `dark` and `light` as well.