### PR TITLE
Provide configurable fallback image for failed tile sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ $ npx vitest __tests__/integration/mirador/tests/sequence-switching.test.js --ui
 ```sh
 $ npm run lint
 ```
+## Image Fallback
+
+Mirador automatically displays a simple fallback placeholder when images fail to load. Customize the fallback image via configuration:
+
+```javascript
+const config = {
+  fallbackImage: 'https://example.com/custom-fallback.jpg',
+};
+```
+
+The error message is translatable via the `imageFailedToLoad` translation key. Detailed error information is logged to the console for debugging.
 
 ## Debugging
 

--- a/__tests__/fixtures/version-3/fallback-image.json
+++ b/__tests__/fixtures/version-3/fallback-image.json
@@ -1,0 +1,37 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["Single Image Example"]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+      "type": "Canvas",
+      "height": 1800,
+      "width": 1200,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full-DOES-NOT-EXIST.png",
+                "type": "Image",
+                "format": "image/png",
+                "height": 1800,
+                "width": 1200
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/integration/mirador/fallback-image.html
+++ b/__tests__/integration/mirador/fallback-image.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  </head>
+  <body>
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+    <script type="module">
+      import Mirador from '../../../src';
+      import config from './mirador-configs/fallback-image.js';
+      Mirador.viewer(config)
+    </script>
+  </body>
+</html>

--- a/__tests__/integration/mirador/mirador-configs/fallback-image.js
+++ b/__tests__/integration/mirador/mirador-configs/fallback-image.js
@@ -1,0 +1,14 @@
+export default {
+  id: 'mirador',
+  theme: {
+    transitions: {},
+  },
+  thumbnailNavigation: {
+    defaultPosition: 'far-bottom',
+  },
+  windows: [
+    {
+      manifestId: '/__tests__/fixtures/version-3/fallback-image.json',
+      thumbnailNavigation: 'far-bottom',
+    }],
+};

--- a/__tests__/src/components/IIIFThumbnail.test.js
+++ b/__tests__/src/components/IIIFThumbnail.test.js
@@ -1,6 +1,7 @@
 import { render, screen, act } from '@tests/utils/test-utils';
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import { IIIFThumbnail } from '../../../src/components/IIIFThumbnail';
+import FailedImageContext from '../../../src/contexts/FailedImageContext';
 
 /**
  * Helper function to create a shallow wrapper around IIIFThumbnail
@@ -83,5 +84,71 @@ describe('IIIFThumbnail', () => {
     createWrapper({ children: <span data-testid="hi" />, thumbnail });
 
     expect(screen.getByTestId('hi')).toBeInTheDocument();
+  });
+
+  it('handles image load failure correctly', () => {
+    const notifyFailure = vi.fn();
+    const fallbackImage = 'data:image/svg+xml,fallback';
+    const mockContext = {
+      fallbackImage,
+      hasFailed: false,
+      notifyFailure,
+    };
+
+    const { container } = render(
+      <FailedImageContext.Provider value={mockContext}>
+        <IIIFThumbnail resource={{}} thumbnail={thumbnail} />
+      </FailedImageContext.Provider>,
+    );
+
+    const img = container.querySelector('img');
+
+    // Trigger image to load first
+    act(() => {
+      mockAllIsIntersecting(true);
+    });
+
+    // Simulate image load error
+    act(() => {
+      img.dispatchEvent(new Event('error'));
+    });
+
+    expect(notifyFailure).toHaveBeenCalled();
+    expect(img).toHaveAttribute('src', fallbackImage);
+    expect(img).toHaveAttribute('alt', 'Thumbnail image unavailable');
+  });
+
+  it('applies object-fit contain style when using fallback image', () => {
+    const fallbackImage = 'data:image/svg+xml,fallback';
+    const mockContext = {
+      fallbackImage,
+      hasFailed: false,
+      notifyFailure: vi.fn(),
+    };
+
+    const { container } = render(
+      <FailedImageContext.Provider value={mockContext}>
+        <IIIFThumbnail resource={{}} thumbnail={thumbnail} maxWidth={80} maxHeight={90} />
+      </FailedImageContext.Provider>,
+    );
+
+    const img = container.querySelector('img');
+
+    // Trigger image to load
+    act(() => {
+      mockAllIsIntersecting(true);
+    });
+
+    // Simulate image load error to trigger fallback
+    act(() => {
+      img.dispatchEvent(new Event('error'));
+    });
+
+    // Should apply objectFit: contain with max dimensions
+    expect(img).toHaveStyle({
+      maxHeight: '90px',
+      maxWidth: '80px',
+      objectFit: 'contain',
+    });
   });
 });

--- a/__tests__/src/components/ImageFailureMessage.test.jsx
+++ b/__tests__/src/components/ImageFailureMessage.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@tests/utils/test-utils';
+import { ImageFailureMessage } from '../../../src/components/ImageFailureMessage';
+import FailedImageProvider from '../../../src/contexts/FailedImageProvider';
+import FailedImageContext from '../../../src/contexts/FailedImageContext';
+
+describe('ImageFailureMessage', () => {
+  it('does not render when no images have failed', () => {
+    const { container } = render(
+      <FailedImageProvider>
+        <ImageFailureMessage />
+      </FailedImageProvider>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders default translated message when images have failed', () => {
+    // Mock the context with hasFailed: true
+    const mockContext = {
+      fallbackImage: 'data:image/svg+xml,...',
+      hasFailed: true,
+      notifyFailure: vi.fn(),
+    };
+
+    render(
+      <FailedImageContext.Provider value={mockContext}>
+        <ImageFailureMessage />
+      </FailedImageContext.Provider>,
+    );
+
+    // Should use the default English translation
+    expect(screen.getByText(/Problem loading image/i)).toBeInTheDocument();
+    expect(screen.getByText(/See console for details/i)).toBeInTheDocument();
+  });
+
+  it('has proper accessibility attributes', () => {
+    const mockContext = {
+      fallbackImage: 'data:image/svg+xml,...',
+      hasFailed: true,
+      notifyFailure: vi.fn(),
+    };
+
+    render(
+      <FailedImageContext.Provider value={mockContext}>
+        <ImageFailureMessage />
+      </FailedImageContext.Provider>,
+    );
+
+    const message = screen.getByText(/Problem loading image/i);
+    const container = message.closest('[role="status"]');
+
+    expect(container).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/__tests__/src/components/OpenSeadragonTileSource.test.js
+++ b/__tests__/src/components/OpenSeadragonTileSource.test.js
@@ -1,6 +1,8 @@
 import { act, render } from '@tests/utils/test-utils';
 import TileSource from '../../../src/components/OpenSeadragonTileSource';
 import OpenSeadragonViewerContext from '../../../src/contexts/OpenSeadragonViewerContext';
+import FailedImageProvider from '../../../src/contexts/FailedImageProvider';
+import FailedImageContext from '../../../src/contexts/FailedImageContext';
 
 describe('OpenSeadragonTileSource', () => {
   it('calls addTiledImage with the tile source', () => {
@@ -11,9 +13,11 @@ describe('OpenSeadragonTileSource', () => {
     const tileSource = { '@id': 'http://example.com/image/info.json' };
 
     render(
-      <OpenSeadragonViewerContext.Provider value={ref}>
-        <TileSource tileSource={tileSource} />
-      </OpenSeadragonViewerContext.Provider>,
+      <FailedImageProvider>
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} />
+        </OpenSeadragonViewerContext.Provider>
+      </FailedImageProvider>,
     );
 
     expect(viewer.addTiledImage).toHaveBeenCalledWith(expect.objectContaining({ tileSource }));
@@ -31,15 +35,19 @@ describe('OpenSeadragonTileSource', () => {
     const tileSource = { '@id': 'http://example.com/image/info.json' };
 
     const { rerender } = render(
-      <OpenSeadragonViewerContext.Provider value={ref}>
-        <TileSource tileSource={tileSource} />
-      </OpenSeadragonViewerContext.Provider>,
+      <FailedImageProvider>
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} />
+        </OpenSeadragonViewerContext.Provider>
+      </FailedImageProvider>,
     );
     await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
       rerender(
-        <OpenSeadragonViewerContext.Provider value={ref}>
-          <TileSource tileSource={tileSource} opacity={0.5} />
-        </OpenSeadragonViewerContext.Provider>,
+        <FailedImageProvider>
+          <OpenSeadragonViewerContext.Provider value={ref}>
+            <TileSource tileSource={tileSource} opacity={0.5} />
+          </OpenSeadragonViewerContext.Provider>
+        </FailedImageProvider>,
       );
     });
 
@@ -61,15 +69,19 @@ describe('OpenSeadragonTileSource', () => {
     const tileSource = { '@id': 'http://example.com/image/info.json' };
 
     const { rerender } = render(
-      <OpenSeadragonViewerContext.Provider value={ref}>
-        <TileSource tileSource={tileSource} />
-      </OpenSeadragonViewerContext.Provider>,
+      <FailedImageProvider>
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} />
+        </OpenSeadragonViewerContext.Provider>
+      </FailedImageProvider>,
     );
     await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
       rerender(
-        <OpenSeadragonViewerContext.Provider value={ref}>
-          <TileSource tileSource={tileSource} index={5} />
-        </OpenSeadragonViewerContext.Provider>,
+        <FailedImageProvider>
+          <OpenSeadragonViewerContext.Provider value={ref}>
+            <TileSource tileSource={tileSource} index={5} />
+          </OpenSeadragonViewerContext.Provider>
+        </FailedImageProvider>,
       );
     });
 
@@ -91,15 +103,19 @@ describe('OpenSeadragonTileSource', () => {
     const tileSource = { '@id': 'http://example.com/image/info.json' };
 
     const { rerender } = render(
-      <OpenSeadragonViewerContext.Provider value={ref}>
-        <TileSource tileSource={tileSource} />
-      </OpenSeadragonViewerContext.Provider>,
+      <FailedImageProvider>
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} />
+        </OpenSeadragonViewerContext.Provider>
+      </FailedImageProvider>,
     );
     await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
       rerender(
-        <OpenSeadragonViewerContext.Provider value={ref}>
-          <TileSource tileSource={tileSource} fitBounds={[0, 0, 10, 10]} />
-        </OpenSeadragonViewerContext.Provider>,
+        <FailedImageProvider>
+          <OpenSeadragonViewerContext.Provider value={ref}>
+            <TileSource tileSource={tileSource} fitBounds={[0, 0, 10, 10]} />
+          </OpenSeadragonViewerContext.Provider>
+        </FailedImageProvider>,
       );
     });
 
@@ -119,17 +135,51 @@ describe('OpenSeadragonTileSource', () => {
     const tileSource = { '@id': 'http://example.com/image/info.json' };
 
     const { rerender } = render(
-      <OpenSeadragonViewerContext.Provider value={ref}>
-        <TileSource tileSource={tileSource} />
-      </OpenSeadragonViewerContext.Provider>,
+      <FailedImageProvider>
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} />
+        </OpenSeadragonViewerContext.Provider>
+      </FailedImageProvider>,
     );
 
     await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
       rerender(
-        <OpenSeadragonViewerContext.Provider value={ref} />,
+        <FailedImageProvider>
+          <OpenSeadragonViewerContext.Provider value={ref} />
+        </FailedImageProvider>,
       );
     });
 
+    // Assert removeItem was called
     expect(viewer.world.removeItem).toHaveBeenCalledWith(mockOsdItem);
+  });
+
+  it('loads fallback image when tile load fails', async () => {
+    const addTiledImage = vi
+      .fn()
+      .mockImplementationOnce(({ error }) => error(new Error('fail')))
+      .mockImplementationOnce(({ success }) => success({ item: { id: 'fallback' } }));
+
+    const viewer = {
+      addTiledImage,
+      world: { removeItem: vi.fn() },
+    };
+    const ref = { current: viewer };
+    const tileSource = { '@id': 'http://example.com/image/info.json' };
+
+    render(
+      <FailedImageProvider>
+        <OpenSeadragonViewerContext.Provider value={ref}>
+          <TileSource tileSource={tileSource} />
+        </OpenSeadragonViewerContext.Provider>
+      </FailedImageProvider>,
+    );
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {});
+
+    // Should attempt to load original, then fallback
+    expect(addTiledImage).toHaveBeenCalledTimes(2);
+    expect(addTiledImage.mock.calls[1][0].tileSource.type).toBe('image');
   });
 });

--- a/__tests__/src/contexts/FailedImageProvider.test.jsx
+++ b/__tests__/src/contexts/FailedImageProvider.test.jsx
@@ -1,0 +1,61 @@
+import { act } from '@tests/utils/test-utils';
+import { renderHook } from '@testing-library/react';
+import { useContext } from 'react';
+import FailedImageProvider from '../../../src/contexts/FailedImageProvider';
+import FailedImageContext from '../../../src/contexts/FailedImageContext';
+import config from '../../../src/config/settings.js';
+
+describe('FailedImageProvider', () => {
+  let originalFallback;
+
+  beforeEach(() => {
+    // Save original value
+    originalFallback = config.fallbackImage;
+  });
+
+  afterEach(() => {
+    // Restore original value
+    config.fallbackImage = originalFallback;
+  });
+
+  it('provides the fallbackImage from config if defined', () => {
+    config.fallbackImage = 'http://example.com/config-fallback.jpg';
+
+    const wrapper = ({ children }) => <FailedImageProvider>{children}</FailedImageProvider>;
+    const { result } = renderHook(() => useContext(FailedImageContext), { wrapper });
+
+    expect(result.current.fallbackImage).toBe('http://example.com/config-fallback.jpg');
+  });
+
+  it('provides the default SVG fallback if config.fallbackImage is not set', () => {
+    config.fallbackImage = undefined;
+
+    const wrapper = ({ children }) => <FailedImageProvider>{children}</FailedImageProvider>;
+    const { result } = renderHook(() => useContext(FailedImageContext), { wrapper });
+
+    expect(result.current.fallbackImage).toBeDefined();
+    // Default is an SVG data URI with warning icon
+    expect(result.current.fallbackImage).toContain('data:image/svg+xml');
+    expect(result.current.fallbackImage).toContain('%231967d2'); // Blue color
+  });
+
+  it('provides hasFailed as false initially', () => {
+    const wrapper = ({ children }) => <FailedImageProvider>{children}</FailedImageProvider>;
+    const { result } = renderHook(() => useContext(FailedImageContext), { wrapper });
+
+    expect(result.current.hasFailed).toBe(false);
+  });
+
+  it('sets hasFailed to true after notifyFailure is called', () => {
+    const wrapper = ({ children }) => <FailedImageProvider>{children}</FailedImageProvider>;
+    const { result } = renderHook(() => useContext(FailedImageContext), { wrapper });
+
+    expect(result.current.hasFailed).toBe(false);
+
+    act(() => {
+      result.current.notifyFailure();
+    });
+
+    expect(result.current.hasFailed).toBe(true);
+  });
+});

--- a/src/components/AppProviders.jsx
+++ b/src/components/AppProviders.jsx
@@ -13,6 +13,7 @@ import { prefixer } from 'stylis';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import createI18nInstance from '../i18n';
+import FailedImageProvider from '../contexts/FailedImageProvider';
 import FullScreenContext from '../contexts/FullScreenContext';
 import LocaleContext from '../contexts/LocaleContext';
 
@@ -125,7 +126,9 @@ export function AppProviders({
             <CacheProvider value={theme.direction === 'rtl' ? cacheRtl : cacheDefault}>
               <ThemeProvider theme={createTheme((theme))}>
                 <MaybeDndProvider dndManager={dndManager}>
-                  {children}
+                  <FailedImageProvider>
+                    {children}
+                  </FailedImageProvider>
                 </MaybeDndProvider>
               </ThemeProvider>
             </CacheProvider>

--- a/src/components/IIIFThumbnail.jsx
+++ b/src/components/IIIFThumbnail.jsx
@@ -1,11 +1,12 @@
 import {
-  useMemo, useEffect, useState,
+  useMemo, useEffect, useState, useContext,
 } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { useInView } from 'react-intersection-observer';
 import { IIIFResourceLabel } from './IIIFResourceLabel';
 import { useThumbnailService } from '../hooks';
+import FailedImageContext from '../contexts/FailedImageContext';
 
 const Root = styled('div', { name: 'IIIFThumbnail', slot: 'root' })({});
 
@@ -28,7 +29,10 @@ const LazyLoadedImage = ({
 }) => {
   const { ref, inView } = useInView();
   const [loaded, setLoaded] = useState(false);
+  const [failed, setFailed] = useState(false);
   const thumbnailService = useThumbnailService(maxHeight, maxWidth);
+  const { notifyFailure, fallbackImage } = useContext(FailedImageContext);
+
   /**
    * Handles the intersection (visibility) of a given thumbnail, by requesting
    * the image and then updating the state.
@@ -56,6 +60,17 @@ const LazyLoadedImage = ({
       maxWidth: undefined,
       width: undefined,
     };
+
+    // If we're using a fallback image due to failure, use object-fit to preserve aspect ratio
+    if (failed && fallbackImage) {
+      return {
+        ...styleProps,
+        ...style,
+        maxWidth,
+        maxHeight,
+        objectFit: 'contain',
+      };
+    }
 
     if (!image) return { ...style, height: maxHeight, width: maxWidth };
 
@@ -99,18 +114,24 @@ const LazyLoadedImage = ({
       ...styleProps,
       ...style,
     };
-  }, [image, maxWidth, maxHeight, style]);
+  }, [image, maxWidth, maxHeight, style, failed, fallbackImage]);
 
   const { url: src = placeholder } = (loaded && (thumbnail || image)) || {};
+  // Decide final image source: normal, failed fallback, or placeholder
+  const finalSrc = failed ? fallbackImage || placeholder : src;
 
   return (
     <Image
       ownerState={{ border }}
       ref={ref}
-      alt=""
-      role="presentation"
-      src={src}
+      alt={failed ? 'Thumbnail image unavailable' : ''}
+      role={failed ? undefined : 'presentation'}
+      src={finalSrc}
       style={imageStyles}
+      onError={() => {
+        setFailed(true);
+        notifyFailure();
+      }}
       {...props}
     />
   );

--- a/src/components/ImageFailureMessage.jsx
+++ b/src/components/ImageFailureMessage.jsx
@@ -1,0 +1,37 @@
+import { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import FailedImageContext from '../contexts/FailedImageContext';
+
+const MessageContainer = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(2),
+  left: '50%',
+  transform: 'translateX(-50%)',
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.common.white,
+  padding: theme.spacing(1, 2),
+  borderRadius: theme.shape.borderRadius,
+  zIndex: 1000,
+  pointerEvents: 'none',
+}));
+
+/**
+ * Displays an accessible message when images fail to load in the OSD viewer
+ */
+export function ImageFailureMessage() {
+  const { hasFailed } = useContext(FailedImageContext);
+  const { t } = useTranslation();
+
+  if (!hasFailed) return null;
+
+  return (
+    <MessageContainer role="status" aria-live="polite">
+      <Typography variant="body2">
+        {t('imageFailedToLoad')}
+      </Typography>
+    </MessageContainer>
+  );
+}

--- a/src/components/OpenSeadragonTileSource.jsx
+++ b/src/components/OpenSeadragonTileSource.jsx
@@ -2,12 +2,14 @@ import Openseadragon from 'openseadragon';
 import PropTypes from 'prop-types';
 import { useContext, useEffect, useRef } from 'react';
 import OpenSeadragonViewerContext from '../contexts/OpenSeadragonViewerContext';
+import FailedImageContext from '../contexts/FailedImageContext';
 
 /** OSD tile source shim that adds + updates its tile source data */
 export default function OpenSeadragonTileSource({
   index = undefined, opacity = undefined, fitBounds = undefined, tileSource = {}, url = undefined,
 }) {
   const viewer = useContext(OpenSeadragonViewerContext);
+  const { notifyFailure, fallbackImage } = useContext(FailedImageContext);
   const tiledImage = useRef(undefined);
 
   useEffect(() => {
@@ -31,6 +33,20 @@ export default function OpenSeadragonTileSource({
   useEffect(() => {
     if (!viewer?.current) return undefined;
 
+    const loadFallback = () => {
+      if (!fallbackImage) {
+        return;
+      }
+
+      viewer.current.addTiledImage({
+        tileSource: { type: 'image', url: fallbackImage },
+        index,
+        opacity,
+        fitBounds: fitBounds ? new Openseadragon.Rect(...fitBounds) : undefined,
+        success: (ev) => { tiledImage.current = ev.item; },
+      });
+    };
+
     const promise = new Promise((resolve, reject) => {
       const localTileSource = (url && { type: 'image', url })
         || (((typeof tileSource === 'string' || tileSource instanceof String) && tileSource)
@@ -38,15 +54,23 @@ export default function OpenSeadragonTileSource({
         || { ...tileSource });
 
       viewer.current?.addTiledImage({
-        error: (event) => reject(event),
-        fitBounds: (fitBounds ? new Openseadragon.Rect(...fitBounds) : undefined),
+        tileSource: localTileSource,
         index,
         opacity,
+        fitBounds: fitBounds ? new Openseadragon.Rect(...fitBounds) : undefined,
+
         success: (event) => resolve(event),
-        tileSource: localTileSource,
+
+        error: (event) => {
+          notifyFailure();
+          loadFallback();
+
+          reject(event);
+        },
       });
-    }).then((event) => {
-      tiledImage.current = event.item;
+    }).then((event) => { tiledImage.current = event.item;
+    }).catch((err) => {
+      console.warn('[Mirador: OSD tile image load failed]', err);
     });
 
     const osd = viewer.current;

--- a/src/components/OpenSeadragonViewer.jsx
+++ b/src/components/OpenSeadragonViewer.jsx
@@ -13,6 +13,7 @@ import { PluginHook } from './PluginHook';
 import { OSDReferences } from '../plugins/OSDReferences';
 import OpenSeadragonComponent from './OpenSeadragonComponent';
 import TileSource from './OpenSeadragonTileSource';
+import { ImageFailureMessage } from './ImageFailureMessage';
 
 const StyledSection = styled('section')({
   cursor: 'grab',
@@ -137,6 +138,7 @@ export function OpenSeadragonViewer({
       { drawAnnotations
           && <AnnotationsOverlay viewer={viewer} windowId={windowId} /> }
       { enhancedChildren }
+      <ImageFailureMessage />
       <PluginHook targetName="OpenSeadragonViewer" viewer={viewer} {...pluginProps} />
     </OpenSeadragonComponent>
   );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -31,6 +31,7 @@ export * from './IIIFAuthentication';
 export * from './IIIFDropTarget';
 export * from './IIIFIFrameCommunication';
 export * from './IIIFThumbnail';
+export * from './ImageFailureMessage';
 export * from './LabelValueMetadata';
 export * from './LanguageSettings';
 export * from './LayersPanel';

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -8,6 +8,8 @@ export default {
     height: 50,
     width: 50,
   },
+  // Override the default fallback image with a custom one for loading failures
+  // fallbackImage: 'path/to/your/custom/fallback.jpg',
   selectedTheme: 'light', // dark also available
   themes: {
     dark: {

--- a/src/contexts/FailedImageContext.js
+++ b/src/contexts/FailedImageContext.js
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+const FailedImageContext = createContext({
+  fallbackImage: '',
+  hasFailed: false,
+  notifyFailure: () => {},
+});
+export default FailedImageContext;

--- a/src/contexts/FailedImageProvider.jsx
+++ b/src/contexts/FailedImageProvider.jsx
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+import FailedImageContext from './FailedImageContext';
+import config from '../config/settings.js';
+
+// SVG fallback with Material-UI Warning icon
+// Uses default primary blue (#1967d2) - override entire image via config.fallbackImage if needed
+const defaultFallback = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="400" height="600"%3E%3Crect width="400" height="600" fill="%23f5f5f5"/%3E%3Cpath d="M 200 240 L 254 354 L 146 354 Z M 200 228 L 128 372 L 272 372 Z M 204.5 336 L 195.5 336 L 195.5 345 L 204.5 345 Z M 204.5 309 L 195.5 309 L 195.5 327 L 204.5 327 Z" fill="%231967d2"/%3E%3C/svg%3E';
+
+export default function FailedImageProvider({ children }) {
+  const fallbackImage = config.fallbackImage || defaultFallback;
+  const [hasFailed, setHasFailed] = useState(false);
+
+  const notifyFailure = useCallback(() => {
+    setHasFailed(true);
+  }, []);
+
+  return (
+    <FailedImageContext.Provider value={{
+      fallbackImage,
+      hasFailed,
+      notifyFailure,
+    }}
+    >
+      {children}
+    </FailedImageContext.Provider>
+  );
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -48,6 +48,7 @@
     "errorDialogConfirm": "OK",
     "errorDialogTitle": "An error occurred",
     "exitFullScreen": "Exit full screen",
+    "imageFailedToLoad": "Problem loading image. See console for details.",
     "expandSection": "Expand \"{{section}}\" section",
     "expandSidePanel": "Expand sidebar",
     "exportCopied": "The workspace configuration was copied to your clipboard",


### PR DESCRIPTION
See #4207

Mirador will automatically display a simple fallback placeholder when images fail to load. Customize the fallback image via configuration:

```javascript
const config = {
  fallbackImage: 'https://example.com/custom-fallback.jpg',
};
```

<img width="1509" height="824" alt="Screenshot 2026-03-25 at 5 40 31 PM" src="https://github.com/user-attachments/assets/045e8985-d7f6-4052-b249-d3bd17bc1fb9" />


