### PR TITLE
Safely access hitAnnotation within SearchHit component

### DIFF
--- a/src/containers/SearchHit.js
+++ b/src/containers/SearchHit.js
@@ -42,7 +42,7 @@ const mapStateToProps = (state, {
   const allAnnoIds = [annotationId, ...hit.annotations];
 
   return {
-    adjacent: selectedCanvasIds.includes(hitAnnotation.targetId),
+    adjacent: selectedCanvasIds.includes(hitAnnotation?.targetId),
     annotation: hitAnnotation,
     annotationId: realAnnoId,
     annotationLabel: annotationLabel[0],


### PR DESCRIPTION
Fixes #4214

Small fix for a safe accessor. Now the component can render when the search state isn't there yet. Once hitAnnotation is defined the UI updates correctly with the hits. Please test to confirm this fixes your issue @wdongji and thank you for reporting.
