### PR TITLE
Do not filter annotation motivations by default

### DIFF
--- a/__tests__/src/selectors/annotations.test.js
+++ b/__tests__/src/selectors/annotations.test.js
@@ -154,3 +154,56 @@ it('getSelectedAnnotationId returns the selected annotation ID from state', () =
     'aid1',
   );
 });
+
+it('returns all annotation resources when no motivations are passed and config.filteredMotivations is empty', () => {
+  const state = {
+    annotations: {
+      cid1: {
+        annoId1: {
+          id: 'annoId1',
+          json: {
+            resources: [
+              { '@id': 'annoId1', motivations: ['oa:commenting'] },
+              { '@id': 'annoId2', motivations: ['oa:not-commenting'] },
+              { '@id': 'annoId3', motivations: ['sc:something-else', 'oa:commenting'] },
+            ],
+          },
+        },
+      },
+    },
+    config: {
+      annotations: {
+        filteredMotivations: [], // Empty array
+        htmlSanitizationRuleSet: 'iiif',
+      },
+    },
+    manifests: {
+      mid: {
+        json: {
+          '@context': 'http://iiif.io/api/presentation/2/context.json',
+          '@id': 'http://iiif.io/api/presentation/2.1/example/fixtures/19/manifest.json',
+          '@type': 'sc:Manifest',
+          sequences: [
+            {
+              canvases: [{ '@id': 'cid1' }],
+            },
+          ],
+        },
+      },
+    },
+    windows: {
+      abc123: {
+        manifestId: 'mid',
+        visibleCanvases: ['cid1'],
+      },
+    },
+  };
+
+  // Ask for resources with no motivations provided
+  const result = getAnnotationResourcesByMotivation(state, { windowId: 'abc123' });
+
+  // Returns all three resources
+  expect(result).toHaveLength(3);
+  const resourceIds = result.map(r => r.resource['@id']);
+  expect(resourceIds).toEqual(['annoId1', 'annoId2', 'annoId3']);
+});

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -441,7 +441,9 @@ export default {
   },
   annotations: {
     htmlSanitizationRuleSet: 'iiif', // See src/lib/htmlRules.js for acceptable values
-    filteredMotivations: ['oa:commenting', 'oa:tagging', 'sc:painting', 'commenting', 'tagging'],
+    // filteredMotivations: if empty, all annotation motivations will be shown.
+    // Otherwise, only annotations with motivations listed in the array will be shown.
+    filteredMotivations: [],
   },
   createGenerateClassNameOptions: { // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator
     productionPrefix: 'mirador',

--- a/src/state/selectors/annotations.js
+++ b/src/state/selectors/annotations.js
@@ -14,7 +14,7 @@ import { getWindow } from './getters';
  */
 export const getAnnotations = state => miradorSlice(state).annotations;
 
-const getMotivation = createSelector(
+const getMotivations = createSelector(
   [
     getConfig,
     (state, { motivations }) => motivations,
@@ -88,16 +88,20 @@ export const getPresentAnnotationsOnSelectedCanvases = createSelector(
  * @returns {Array}
  */
 export const getAnnotationResourcesByMotivationForCanvas = createSelector(
-  [
-    getPresentAnnotationsCanvas,
-    getMotivation,
-  ],
-  (annotations, motivations) => filter(
-    flatten(annotations.map(annotation => annotation.resources)),
-    resource => resource.motivations.some(
-      motivation => motivations.includes(motivation),
-    ),
-  ),
+  [getPresentAnnotationsCanvas, getMotivations],
+  (annotations, motivations) => {
+    const resources = flatten(
+      annotations.map(annotation => annotation.resources),
+    );
+
+    // If motivations is empty, null, or undefined, return everything
+    if (!motivations || motivations.length === 0) {
+      return resources;
+    }
+
+    // Otherwise filter by motivations
+    return resources.filter(resource => resource.motivations.some(motivation => motivations.includes(motivation)));
+  },
 );
 
 /**
@@ -109,14 +113,21 @@ export const getAnnotationResourcesByMotivationForCanvas = createSelector(
 export const getAnnotationResourcesByMotivation = createSelector(
   [
     getPresentAnnotationsOnSelectedCanvases,
-    getMotivation,
+    getMotivations,
   ],
-  (annotations, motivations) => filter(
-    flatten(annotations.map(annotation => annotation.resources)),
-    resource => resource.motivations.some(
-      motivation => motivations.includes(motivation),
-    ),
-  ),
+  (annotations, motivations) => {
+    const resources = flatten(
+      annotations.map(annotation => annotation.resources),
+    );
+
+    // If motivations is empty, null, or undefined, return everything
+    if (!motivations || motivations.length === 0) {
+      return resources;
+    }
+
+    // Otherwise filter by motivations
+    return resources.filter(resource => resource.motivations.some(motivation => motivations.includes(motivation)));
+  },
 );
 
 /**


### PR DESCRIPTION
This is a proposal to address #4209, based on the discussion in the 11/20/2025 Mirador community call. During that call I understood that we wanted to stop filtering annotation motivations by default. This PR achieves that while leaving open the option of filtering by motivation if desired.

This is a potentially a breaking change in the case of a blank `filteredMotivations` array in settings. Before this PR, no annotations would be rendered in that case. But in the case that you've added values to this array, the behavior will remain the same. Given that the default setting previously included values, I don't think many people would be operating with an empty array in the wild.

There is probably a lot of history behind this filter, but my knowledge is recent. Open to other proposals.