### PR TITLE
Revert "Restore Harvard Van Gogh image to primary fixture"

### DIFF
--- a/__tests__/integration/mirador/constants.js
+++ b/__tests__/integration/mirador/constants.js
@@ -1,2 +1,2 @@
-export const PRIMARY_MANIFEST_FIXTURE_URL = 'https://iiif.harvardartmuseums.org/manifests/object/299843';
-export const PRIMARY_CANVAS_FIXTURE_URL = 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892';
+export const PRIMARY_MANIFEST_FIXTURE_URL = 'https://dms-data.stanford.edu/data/manifests/Parker/nb647fd0133/manifest.json';
+export const PRIMARY_CANVAS_FIXTURE_URL = 'https://dms-data.stanford.edu/data/manifests/Parker/nb647fd0133/canvas/canvas-1';

--- a/__tests__/integration/mirador/tests/minimalist.test.js
+++ b/__tests__/integration/mirador/tests/minimalist.test.js
@@ -7,7 +7,7 @@ describe('Minimalist configuration to Mirador', () => {
   setupIntegrationTestViewer(config);
 
   it('Loads a manifest and displays it without some of the default controls', async () => {
-    expect(await screen.findByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).toBeInTheDocument();
 
     const infoButton = await screen.findByRole('tab', { name: /Information/i });
     expect(infoButton).toBeInTheDocument();

--- a/__tests__/integration/mirador/tests/plugin-state.test.js
+++ b/__tests__/integration/mirador/tests/plugin-state.test.js
@@ -7,7 +7,7 @@ describe('how plugins relate to state', () => {
   setupIntegrationTestViewer(settings.config, settings.plugins);
 
   it('plugin can read from state', async () => {
-    const text = 'Plugin:https://iiif.harvardartmuseums.org/manifests/object/299843';
+    const text = 'Plugin:https://dms-data.stanford.edu/data/manifests/Parker/nb647fd0133/manifest.json';
     const elementWithText = await screen.findByText(text);
     expect(elementWithText).toHaveTextContent(text);
   });

--- a/__tests__/integration/mirador/tests/viewer-config.test.js
+++ b/__tests__/integration/mirador/tests/viewer-config.test.js
@@ -8,7 +8,7 @@ describe('initialViewerConfig', () => {
 
   describe('initialViewerConfig', () => {
     it('allows initialViewerConfig to be passed', async (context) => {
-      expect(await screen.findByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).toBeInTheDocument();
+      expect(await screen.findByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).toBeInTheDocument();
 
       let viewerObject;
       await waitFor(() => {

--- a/__tests__/integration/mirador/tests/window-actions.test.js
+++ b/__tests__/integration/mirador/tests/window-actions.test.js
@@ -7,10 +7,10 @@ describe('Window actions', () => {
   setupIntegrationTestViewer(config);
 
   it('Closes a Mirador window', async () => {
-    expect(await screen.findByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).toBeInTheDocument();
+    expect(await screen.findByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).toBeInTheDocument();
     const closeButton = screen.getByRole('button', { name: /Close window/i });
     fireEvent.click(closeButton);
-    await waitFor(() => expect(screen.queryByRole('region', { name: /Window: Self-Portrait Dedicated to Paul Gauguin/i })).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('region', { name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i })).not.toBeInTheDocument());
 
     // No windows should be present
     expect(screen.queryByRole('region')).not.toBeInTheDocument();


### PR DESCRIPTION
Reverts ProjectMirador/mirador#4173
This is broken again. It is keeping all other PRs from passing tests.
We should probably stop using this manifest, but the Van Gogh images are iconic to Mirador so we keep coming back...