### PR TITLE
Simplify @hello-pangea/dnd dependency spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "exports": {
     "./src": "./src/index.js",
     ".": {
-        "import": "./dist/mirador.es.js",
-        "require": "./dist/mirador.min.js"
+      "import": "./dist/mirador.es.js",
+      "require": "./dist/mirador.min.js"
     }
   },
   "scripts": {
@@ -36,7 +36,7 @@
   "dependencies": {
     "@custom-react-hooks/use-element-size": "^1.5.1",
     "@emotion/cache": "^11.11.0",
-    "@hello-pangea/dnd": "^16.0.1 || ^17.0.0 || ^18.0.0",
+    "@hello-pangea/dnd": "^18.0.0",
     "@mui/icons-material": "^7.0.0",
     "@mui/utils": "^7.0.0",
     "@mui/x-tree-view": "^7.25.0",


### PR DESCRIPTION
only 18.x works with react 19, so we must use that version