### PR TITLE
Specify Node.js version for Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,12 @@
 [build]
   publish = "dist/"
 
+[context.main.environment]
+  NODE_VERSION = "20.18.1"
+
+[context.deploy-preview.environment]
+  NODE_VERSION = "20.18.1"
+
 [[redirects]]
   from = "/"
   to = "/__tests__/integration/mirador/index.html"


### PR DESCRIPTION
From the Netlify logs -- seems to work ! Using lts/iron -> v20.18.1
```
12:39:00 PM: Downloading and installing node v20.18.1...
12:39:00 PM: Downloading https://nodejs.org/dist/v20.18.1/node-v20.18.1-linux-x64.tar.xz...
12:39:00 PM: Computing checksum with sha256sum
12:39:00 PM: Checksums matched!
12:39:02 PM: Now using node v20.18.1 (npm v10.8.2)
```