### PR TITLE
Remove broken link in README for mirador-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![Node.js CI](https://github.com/ProjectMirador/mirador/workflows/Node.js%20CI/badge.svg)](https://github.com/ProjectMirador/mirador/actions/workflows/node.js.yml) [![codecov](https://codecov.io/gh/ProjectMirador/mirador/branch/main/graph/badge.svg)](https://codecov.io/gh/ProjectMirador/mirador) 
 
 ## For Mirador Users
-You can quickly use and configure Mirador by remixing the [mirador-start](https://mirador-start.glitch.me/) Glitch.
-
 We recommend installing Mirador using a JavaScript package manager like [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/).
 
 ```sh


### PR DESCRIPTION
Closes #4224

This seems like it would have been cool for users. I never saw it in action.

Yes this is my first vibecode, check it out! https://deploy-preview-4250--mirador-dev.netlify.app/playground
If this feature is of interest I can make it nicer. Just an idea.
