### PR TITLE
Upgrade to vitest 4

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.js
+++ b/__tests__/src/components/AnnotationsOverlay.test.js
@@ -59,27 +59,24 @@ describe('AnnotationsOverlay', () => {
       const resize = vi.fn();
       const canvasUpdate = vi.fn();
 
-      OpenSeadragonCanvasOverlay.mockImplementation(() => ({
-        canvasUpdate,
-        clear,
-        resize,
-      }));
+      OpenSeadragonCanvasOverlay.mockImplementation(function () {
+        return {
+          canvasUpdate,
+          clear,
+          resize,
+        };
+      });
 
       const { component, rerender, viewer } = createWrapper({ viewer: null });
 
       const forceRedraw = vi.spyOn(viewer, 'forceRedraw');
 
-      rerender(cloneElement(
-        component,
-        {
-          annotations: [
-            new AnnotationList(
-              { '@id': 'foo', resources: [{ foo: 'bar' }] },
-            ),
-          ],
+      rerender(
+        cloneElement(component, {
+          annotations: [new AnnotationList({ '@id': 'foo', resources: [{ foo: 'bar' }] })],
           viewer,
-        },
-      ));
+        }),
+      );
 
       // OSD ordinarily would fire this event:
       viewer.raiseEvent('update-viewport');
@@ -95,34 +92,46 @@ describe('AnnotationsOverlay', () => {
     it('converts the annotations to canvas and checks that the canvas is displayed', () => {
       const strokeRect = vi.fn();
       const context2d = {
-        restore: () => { },
-        save: () => { },
+        restore: () => {},
+        save: () => {},
         strokeRect,
       };
 
-      OpenSeadragonCanvasOverlay.mockImplementation(() => ({
-        canvasUpdate: (f) => f(),
-        clear: vi.fn(),
-        context2d,
-        resize: vi.fn(),
-      }));
+      OpenSeadragonCanvasOverlay.mockImplementation(function () {
+        return {
+          canvasUpdate: (f) => f(),
+          clear: vi.fn(),
+          context2d,
+          resize: vi.fn(),
+        };
+      });
 
       const palette = {
         default: { strokeStyle: 'yellow' },
       };
-      const { component, rerender, viewer } = createWrapper({ palette: { annotations: palette }, viewer: null });
+      const { component, rerender, viewer } = createWrapper({
+        palette: { annotations: palette },
+        viewer: null,
+      });
 
-      vi.spyOn(viewer.viewport, 'getMaxZoom').mockImplementation(() => (1));
-      vi.spyOn(viewer.viewport, 'getZoom').mockImplementation(() => (0.05));
+      vi.spyOn(viewer.viewport, 'getMaxZoom').mockImplementation(() => 1);
+      vi.spyOn(viewer.viewport, 'getZoom').mockImplementation(() => 0.05);
 
-      rerender(cloneElement(component, {
-        annotations: [
-          new AnnotationList(
-            { '@id': 'foo', resources: [{ on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=10,10,100,200' }] },
-          ),
-        ],
-        viewer,
-      }));
+      rerender(
+        cloneElement(component, {
+          annotations: [
+            new AnnotationList({
+              '@id': 'foo',
+              resources: [
+                {
+                  on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=10,10,100,200',
+                },
+              ],
+            }),
+          ],
+          viewer,
+        }),
+      );
 
       // OSD ordinarily would fire this event:
       viewer.raiseEvent('update-viewport');
@@ -140,17 +149,17 @@ describe('AnnotationsOverlay', () => {
 
       const { viewer } = createWrapper({
         annotations: [
-          new AnnotationList(
-            {
-              '@id': 'foo',
-              resources: [{
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
                 '@id': 'http://example.org/identifier/annotation/anno-line',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
-              }],
-            },
-          ),
+              },
+            ],
+          }),
         ],
         selectAnnotation,
       });
@@ -160,7 +169,10 @@ describe('AnnotationsOverlay', () => {
         position: new OpenSeadragon.Point(101, 101),
       });
 
-      expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
+      expect(selectAnnotation).toHaveBeenCalledWith(
+        'base',
+        'http://example.org/identifier/annotation/anno-line',
+      );
     });
 
     it('triggers a deselectAnnotation for an already-selected annotation', () => {
@@ -168,17 +180,17 @@ describe('AnnotationsOverlay', () => {
 
       const { viewer } = createWrapper({
         annotations: [
-          new AnnotationList(
-            {
-              '@id': 'foo',
-              resources: [{
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
                 '@id': 'http://example.org/identifier/annotation/anno-line',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
-              }],
-            },
-          ),
+              },
+            ],
+          }),
         ],
         deselectAnnotation,
         selectedAnnotationId: 'http://example.org/identifier/annotation/anno-line',
@@ -189,7 +201,10 @@ describe('AnnotationsOverlay', () => {
         position: new OpenSeadragon.Point(101, 101),
       });
 
-      expect(deselectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
+      expect(deselectAnnotation).toHaveBeenCalledWith(
+        'base',
+        'http://example.org/identifier/annotation/anno-line',
+      );
     });
 
     it('selects the closest annotation', () => {
@@ -197,27 +212,29 @@ describe('AnnotationsOverlay', () => {
 
       const { viewer } = createWrapper({
         annotations: [
-          new AnnotationList(
-            {
-              '@id': 'foo',
-              resources: [{
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
                 '@id': 'http://example.org/identifier/annotation/anno-line',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
-              }, {
+              },
+              {
                 '@id': 'http://example.org/identifier/annotation/larger-box',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=0,0,250,250',
-              }, {
+              },
+              {
                 '@id': 'http://example.org/identifier/annotation/on-another-canvas',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/some-other-canvas#xywh=101,101,3,3',
-              }],
-            },
-          ),
+              },
+            ],
+          }),
         ],
         selectAnnotation,
       });
@@ -227,7 +244,10 @@ describe('AnnotationsOverlay', () => {
         position: new OpenSeadragon.Point(101, 101),
       });
 
-      expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
+      expect(selectAnnotation).toHaveBeenCalledWith(
+        'base',
+        'http://example.org/identifier/annotation/anno-line',
+      );
     });
   });
 
@@ -238,27 +258,29 @@ describe('AnnotationsOverlay', () => {
 
       const { viewer } = createWrapper({
         annotations: [
-          new AnnotationList(
-            {
-              '@id': 'foo',
-              resources: [{
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
                 '@id': 'foo',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
-              }, {
+              },
+              {
                 '@id': 'bar',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=0,0,250,250',
-              }, {
+              },
+              {
                 '@id': 'irrelevant-box',
                 '@type': 'oa:Annotation',
                 motivation: 'sc:painting',
                 on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=0,0,50,50',
-              }],
-            },
-          ),
+              },
+            ],
+          }),
         ],
         hoverAnnotation,
       });

--- a/__tests__/src/components/OpenSeadragonComponent.test.js
+++ b/__tests__/src/components/OpenSeadragonComponent.test.js
@@ -13,26 +13,28 @@ describe('OpenSeadragonComponent', () => {
     fitBoundsWithConstraints = vi.fn();
 
     // Mock methods used in the component
-    OpenSeadragon.mockImplementation(() => ({
-      addHandler: vi.fn(),
-      addOnceHandler,
-      canvas: {},
-      destroy: vi.fn(),
-      innerTracker: {},
-      removeAllHandlers: vi.fn(),
-      viewport: {
-        centerSpringX: { target: { value: 0 } },
-        centerSpringY: { target: { value: 0 } },
-        fitBounds: vi.fn(),
-        fitBoundsWithConstraints,
-        zoomSpring: { target: { value: 1 } },
-      },
-      world: { addOnceHandler },
-    }));
+    OpenSeadragon.mockImplementation(function () {
+      return {
+        addHandler: vi.fn(),
+        addOnceHandler,
+        canvas: {},
+        destroy: vi.fn(),
+        innerTracker: {},
+        removeAllHandlers: vi.fn(),
+        viewport: {
+          centerSpringX: { target: { value: 0 } },
+          centerSpringY: { target: { value: 0 } },
+          fitBounds: vi.fn(),
+          fitBoundsWithConstraints,
+          zoomSpring: { target: { value: 1 } },
+        },
+        world: { addOnceHandler },
+      };
+    });
 
-    OpenSeadragon.Rect = vi.fn((x, y, width, height) => ({
-      height, width, x, y,
-    }));
+    OpenSeadragon.Rect = vi.fn(function (x, y, width, height) {
+      return { height, width, x, y };
+    });
   });
 
   /**
@@ -53,9 +55,7 @@ describe('OpenSeadragonComponent', () => {
    * @returns {object} Render result
    */
   function renderAndInitialize(bounds = [0, 0, 5000, 3000]) {
-    const result = render(
-      <OpenSeadragonComponent windowId="test" viewerConfig={{ bounds }} />,
-    );
+    const result = render(<OpenSeadragonComponent windowId="test" viewerConfig={{ bounds }} />);
 
     // Component registers a 'tile-loaded' handler during mount to set initial viewport
     invokeTileLoadedHandler();

--- a/__tests__/src/components/WorkspaceExport.test.js
+++ b/__tests__/src/components/WorkspaceExport.test.js
@@ -19,13 +19,7 @@ describe('WorkspaceExport', () => {
       workspace: {},
     };
 
-    render(
-      <WorkspaceExport
-        open
-        handleClose={handleClose}
-        exportableState={mockState}
-      />,
-    );
+    render(<WorkspaceExport open handleClose={handleClose} exportableState={mockState} />);
   });
 
   it('renders without an error', () => {
@@ -44,10 +38,15 @@ describe('WorkspaceExport', () => {
   it('reveals a snackbar on copy', async () => {
     // jsdom doesn't support the clipboard API or prompt (used as a fallback)
     // so we mock the prompt at least to avoid a warning in the test output
-    vi.spyOn(window, 'prompt').mockImplementation(() => true);
+    vi.stubGlobal(
+      'prompt',
+      vi.fn(() => true),
+    );
 
     await user.click(screen.getByRole('button', { name: 'Copy' }));
-    expect(screen.getByRole('alert')).toHaveTextContent('The workspace configuration was copied to your clipboard');
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The workspace configuration was copied to your clipboard',
+    );
 
     await user.click(screen.getByRole('button', { name: 'Dismiss' }));
     expect(handleClose).toHaveBeenCalled();
@@ -55,7 +54,8 @@ describe('WorkspaceExport', () => {
 
   it('renders an exportable version of state', async () => {
     await user.click(screen.getByRole('button', { name: 'View workspace configuration' }));
-    expect(screen.getByRole('region').querySelector('pre')).toHaveTextContent( // eslint-disable-line testing-library/no-node-access
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(screen.getByRole('region').querySelector('pre')).toHaveTextContent(
       '{ "companionWindows": {}, "config": {}, "elasticLayout": {}, "viewers": {}, "windows": {}, "workspace": {} }',
     );
   });

--- a/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
+++ b/__tests__/src/lib/OpenSeadragonCanvasOverlay.test.js
@@ -10,36 +10,38 @@ describe('OpenSeadragonCanvasOverlay', () => {
     document.body.innerHTML = '<div id="canvas"><canvas></div>';
     ref.current = document.getElementById('canvas');
     OpenSeadragon.mockClear();
-    OpenSeadragon.mockImplementation(() => ({
-      canvas: ref,
-      container: {
-        clientHeight: 100,
-        clientWidth: 200,
-      },
-      viewport: {
-        getBoundsNoRotateWithMargins: vi.fn(() => ({
-          height: 300,
-          width: 200,
-          x: 40,
-          y: 80,
-        })),
-        getCenter: () => ({ x: 0, y: 0 }),
-        getFlip: () => false,
-        getRotation: () => 0,
-        getZoom: vi.fn(() => (0.75)),
-      },
-      world: {
-        getItemAt: vi.fn(() => ({
-          source: {
-            dimensions: {
-              x: 1000,
-              y: 2000,
+    OpenSeadragon.mockImplementation(function () {
+      return {
+        canvas: ref,
+        container: {
+          clientHeight: 100,
+          clientWidth: 200,
+        },
+        viewport: {
+          getBoundsNoRotateWithMargins: vi.fn(() => ({
+            height: 300,
+            width: 200,
+            x: 40,
+            y: 80,
+          })),
+          getCenter: () => ({ x: 0, y: 0 }),
+          getFlip: () => false,
+          getRotation: () => 0,
+          getZoom: vi.fn(() => 0.75),
+        },
+        world: {
+          getItemAt: vi.fn(() => ({
+            source: {
+              dimensions: {
+                x: 1000,
+                y: 2000,
+              },
             },
-          },
-          viewportToImageZoom: vi.fn(() => (0.075)),
-        })),
-      },
-    }));
+            viewportToImageZoom: vi.fn(() => 0.075),
+          })),
+        },
+      };
+    });
     canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon(), ref);
   });
   describe('constructor', () => {
@@ -85,19 +87,21 @@ describe('OpenSeadragonCanvasOverlay', () => {
     });
     it('when image is undefined returns early', () => {
       OpenSeadragon.mockClear();
-      OpenSeadragon.mockImplementation(() => ({
-        canvas: document.getElementById('canvas'),
-        container: {
-          clientHeight: 100,
-          clientWidth: 200,
-        },
-        viewport: {
-          getBoundsNoRotateWithMargins: vi.fn(() => (new OpenSeadragon.Rect(0, 0, 200, 200))),
-        },
-        world: {
-          getItemAt: vi.fn(),
-        },
-      }));
+      OpenSeadragon.mockImplementation(function () {
+        return {
+          canvas: document.getElementById('canvas'),
+          container: {
+            clientHeight: 100,
+            clientWidth: 200,
+          },
+          viewport: {
+            getBoundsNoRotateWithMargins: vi.fn(() => new OpenSeadragon.Rect(0, 0, 200, 200)),
+          },
+          world: {
+            getItemAt: vi.fn(),
+          },
+        };
+      });
       canvasOverlay = new OpenSeadragonCanvasOverlay(new OpenSeadragon(), ref);
       canvasOverlay.resize();
       expect(canvasOverlay.imgHeight).toEqual(undefined);

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@vitejs/plugin-react": "^5.2.0",
-    "@vitest/coverage-v8": "^3.0.5",
-    "@vitest/ui": "^3.0.5",
+    "@vitest/coverage-v8": "^4.1.2",
+    "@vitest/ui": "^4.1.2",
     "bundlewatch": "^0.4.0",
     "chalk": "^5.3.0",
     "eslint": "^9.39.4",
@@ -114,7 +114,7 @@
     "redux-mock-store": "^1.5.1",
     "redux-saga-test-plan": "^4.0.0-rc.3",
     "vite": "^7.3.1",
-    "vitest": "^3.0.5",
+    "vitest": "^4.1.2",
     "vitest-fetch-mock": "^0.4.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Vitest 4 introduced a breaking change: `vi.fn()` mocks using arrow functions as their implementation can no longer be called with `new`. Arrow functions in JavaScript are non-constructable and Vitest 4 now enforces this strictly,  but Vitest 3 silently allowed it.