### PR TITLE
Remove unnecessary ARIA attributes from WindowSideBarButtons

### DIFF
--- a/src/components/WindowSideBarButtons.jsx
+++ b/src/components/WindowSideBarButtons.jsx
@@ -101,8 +101,6 @@ export function WindowSideBarButtons({
       indicatorColor="primary"
       textColor="primary"
       orientation="vertical"
-      aria-orientation="vertical"
-      aria-label={t('sidebarPanelsNavigation')}
     >
       { panels.info && (
         <TabButton


### PR DESCRIPTION
Addressing Accessibility issue: 

https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html
https://axe.deque.com/issues/54bf4280-088f-4415-ba90-46c7e42959fe

Fixes: https://github.com/ProjectMirador/mirador/issues/4268