### PR TITLE
Adjust ESLint settings; use testing-library/utils-module setting

### DIFF
--- a/__tests__/src/components/ImageFailureMessage.test.jsx
+++ b/__tests__/src/components/ImageFailureMessage.test.jsx
@@ -47,7 +47,7 @@ describe('ImageFailureMessage', () => {
     );
 
     const message = screen.getByText(/Problem loading image/i);
-    const container = message.closest('[role="status"]');
+    const container = message.closest('[role="status"]'); // eslint-disable-line testing-library/no-node-access
 
     expect(container).toHaveAttribute('aria-live', 'polite');
   });

--- a/__tests__/src/components/LocalePicker.test.jsx
+++ b/__tests__/src/components/LocalePicker.test.jsx
@@ -20,7 +20,7 @@ describe('LocalePicker', () => {
   it('hides the control if there are not locales to switch to', () => {
     const { container } = createWrapper({ availableLocales: ['en'] });
 
-    expect(container).toBeEmptyDOMElement(); // eslint-disable-line testing-library/no-container
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('renders a select with the current value', () => {

--- a/__tests__/src/components/OpenSeadragonTileSource.test.jsx
+++ b/__tests__/src/components/OpenSeadragonTileSource.test.jsx
@@ -41,7 +41,7 @@ describe('OpenSeadragonTileSource', () => {
         </OpenSeadragonViewerContext.Provider>
       </FailedImageProvider>,
     );
-    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+    await act(async () => {
       rerender(
         <FailedImageProvider>
           <OpenSeadragonViewerContext.Provider value={ref}>
@@ -75,7 +75,7 @@ describe('OpenSeadragonTileSource', () => {
         </OpenSeadragonViewerContext.Provider>
       </FailedImageProvider>,
     );
-    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+    await act(async () => {
       rerender(
         <FailedImageProvider>
           <OpenSeadragonViewerContext.Provider value={ref}>
@@ -109,7 +109,7 @@ describe('OpenSeadragonTileSource', () => {
         </OpenSeadragonViewerContext.Provider>
       </FailedImageProvider>,
     );
-    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+    await act(async () => {
       rerender(
         <FailedImageProvider>
           <OpenSeadragonViewerContext.Provider value={ref}>
@@ -142,7 +142,7 @@ describe('OpenSeadragonTileSource', () => {
       </FailedImageProvider>,
     );
 
-    await act(async () => { // eslint-disable-line testing-library/no-unnecessary-act
+    await act(async () => {
       rerender(
         <FailedImageProvider>
           <OpenSeadragonViewerContext.Provider value={ref} />

--- a/__tests__/src/components/ThumbnailNavigation.test.jsx
+++ b/__tests__/src/components/ThumbnailNavigation.test.jsx
@@ -27,7 +27,7 @@ function Subject({ fixture = manifestJson, ...props }) {
 }
 
 Subject.propTypes = {
-  fixture: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  fixture: PropTypes.object,
 };
 
 describe('ThumbnailNavigation', () => {
@@ -46,7 +46,7 @@ describe('ThumbnailNavigation', () => {
     render(<Subject position="far-bottom" />);
     // Grid component renders with role="grid" inside the Thumbnails wrapper
     const thumbnailWrapper = screen.getByLabelText('Thumbnails');
-    const grid = thumbnailWrapper.querySelector('[role="grid"]');
+    const grid = thumbnailWrapper.querySelector('[role="grid"]'); // eslint-disable-line testing-library/no-node-access
     expect(grid).toBeInTheDocument();
     // Grid should have 3 gridcells (all in one row)
     expect(screen.getAllByRole('gridcell')).toHaveLength(3);
@@ -56,7 +56,7 @@ describe('ThumbnailNavigation', () => {
     render(<Subject position="far-right" />);
     // List component renders with role="list" inside the Thumbnails wrapper
     const thumbnailWrapper = screen.getByLabelText('Thumbnails');
-    const list = thumbnailWrapper.querySelector('[role="list"]');
+    const list = thumbnailWrapper.querySelector('[role="list"]'); // eslint-disable-line testing-library/no-node-access
     expect(list).toBeInTheDocument();
     // List should have 3 gridcells (each as a separate item)
     expect(screen.getAllByRole('gridcell')).toHaveLength(3);
@@ -144,7 +144,7 @@ describe('ThumbnailNavigation', () => {
     it('sets up react-window to be rtl', () => {
       render(<Subject viewingDirection="right-to-left" />);
 
-      expect(screen.getByRole('row').children[0]).toHaveStyle({ direction: 'rtl' }); // eslint-disable-line testing-library/no-node-access
+      expect(screen.getByRole('row').children[0]).toHaveStyle({ direction: 'rtl' });
     });
   });
 });

--- a/__tests__/src/components/WindowAuthenticationBar.test.jsx
+++ b/__tests__/src/components/WindowAuthenticationBar.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@tests/utils/test-utils';
 import userEvent from '@testing-library/user-event';
-import { config } from 'react-transition-group'; // eslint-disable-line import/no-extraneous-dependencies
+import { config } from 'react-transition-group';
 import { WindowAuthenticationBar } from '../../../src/components/WindowAuthenticationBar';
 
 /**

--- a/__tests__/src/components/WindowSideBar.test.jsx
+++ b/__tests__/src/components/WindowSideBar.test.jsx
@@ -34,10 +34,10 @@ describe('WindowSideBar when open', () => {
   });
   it('Renders drawer ltr by default', () => {
     createWrapper({ sideBarOpen: true });
-    expect(screen.queryByRole('navigation', { accessibleName: 'sidebarPanelsNavigation' })).toHaveClass('MuiDrawer-paperAnchorLeft'); // eslint-disable-line testing-library/no-node-access
+    expect(screen.queryByRole('navigation', { accessibleName: 'sidebarPanelsNavigation' })).toHaveClass('MuiDrawer-paperAnchorLeft');
   });
   it('Renders drawer rtl when specified', () => {
     createWrapper({ direction: 'rtl', sideBarOpen: true });
-    expect(screen.queryByRole('navigation', { accessibleName: 'sidebarPanelsNavigation' })).toHaveClass('MuiDrawer-paperAnchorRight'); // eslint-disable-line testing-library/no-node-access
+    expect(screen.queryByRole('navigation', { accessibleName: 'sidebarPanelsNavigation' })).toHaveClass('MuiDrawer-paperAnchorRight');
   });
 });

--- a/__tests__/src/components/WindowTopMenuButton.test.jsx
+++ b/__tests__/src/components/WindowTopMenuButton.test.jsx
@@ -40,13 +40,13 @@ describe('WindowTopMenuButton', () => {
   it('the open attribute of the button is null without being clicked', async () => {
     render(<Subject />);
     // without a click, the button is not open and therefore doesn't have aria-owns attr
-    expect(screen.getByLabelText('Window views & thumbnail display')).not.toHaveAttribute('aria-owns'); // eslint-disable-line testing-library/no-node-access
+    expect(screen.getByLabelText('Window views & thumbnail display')).not.toHaveAttribute('aria-owns');
   });
 
   it('the open attribute of the button is applied once it is clicked', async () => {
     render(<Subject />);
     await user.click(screen.getByLabelText('Window views & thumbnail display'));
     // when 'open' is true, aria-owns is set to the id of the window
-    expect(screen.getByLabelText('Window views & thumbnail display')).toHaveAttribute('aria-owns'); // eslint-disable-line testing-library/no-node-access
+    expect(screen.getByLabelText('Window views & thumbnail display')).toHaveAttribute('aria-owns');
   });
 });

--- a/__tests__/src/lib/MiradorViewer.test.jsx
+++ b/__tests__/src/lib/MiradorViewer.test.jsx
@@ -15,14 +15,12 @@ describe('MiradorViewer', () => {
     it('returns viewer store', () => {
       const instance = new MiradorViewer({});
 
-      // eslint-disable-next-line testing-library/no-unnecessary-act
       act(() => { instance.renderInto(container); });
       expect(instance.store.dispatch).toBeDefined();
     });
     it('renders via ReactDOM', () => {
       const instance = new MiradorViewer({});
 
-      // eslint-disable-next-line testing-library/no-unnecessary-act
       act(() => { instance.renderInto(container); });
 
       expect(screen.getByTestId('container')).not.toBeEmptyDOMElement();
@@ -59,7 +57,6 @@ describe('MiradorViewer', () => {
         },
       );
 
-      // eslint-disable-next-line testing-library/no-unnecessary-act
       act(() => { instance.renderInto(container); });
 
       const { windows, catalog, config } = instance.store.getState();
@@ -140,10 +137,8 @@ describe('MiradorViewer', () => {
     it('unmounts via ReactDOM', () => {
       const instance = new MiradorViewer({});
 
-      // eslint-disable-next-line testing-library/no-unnecessary-act
       act(() => { instance.renderInto(container); });
       expect(container).not.toBeEmptyDOMElement();
-      // eslint-disable-next-line testing-library/no-unnecessary-act
       act(() => { instance.unmount(); });
       expect(container).toBeEmptyDOMElement();
     });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -144,6 +144,7 @@ export default [
       react: {
         version: 'detect',
       },
+      'testing-library/utils-module': '@tests/utils/test-utils',
     },
   },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -105,7 +105,7 @@ export default [
       'no-shadow': ['error', { builtinGlobals: false, hoist: 'functions' }],
       'no-undef': 'error',
       'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
-      'no-unused-vars': 'warn',
+      'no-unused-vars': 'off',
       'no-use-before-define': ['warn', { functions: false, classes: false, variables: false }],
       'no-useless-return': 'error',
       'no-var': 'error',

--- a/src/components/PluginHook.jsx
+++ b/src/components/PluginHook.jsx
@@ -7,13 +7,17 @@ import { usePlugins } from '../extend/usePlugins';
 export const PluginHook = forwardRef(({ classes = {}, targetName, ...otherProps }, ref) => {
   const { PluginComponents } = usePlugins(targetName);
 
-  /* eslint-disable react/no-array-index-key */
   return PluginComponents ? (
     PluginComponents.map((PluginComponent, index) => (
       (isValidElement(PluginComponent) ? cloneElement(PluginComponent, { ...otherProps, ref }) : (
         <PluginComponent
           ref={ref}
           {...otherProps}
+          /**
+           * Currently disabling react/no-array-index-key is causing a warning: "Unused eslint-disable directive"
+           * This should resolve when eslint-plugin-react upgrades to support ESLint 10.
+           */ 
+          // eslint-disable-next-line react/no-array-index-key -- here index is the only viable key
           key={index}
         />
       ))

--- a/src/components/SidebarIndexTableOfContents.jsx
+++ b/src/components/SidebarIndexTableOfContents.jsx
@@ -57,7 +57,6 @@ const CollapseIcon = (props) => <ExpandMoreIcon {...props} color="action" />;
 /** */
 const ExpandIcon = (props) => <ChevronRightIcon {...props} color="action" />;
 /** */
-// eslint-disable-next-line max-params
 export function SidebarIndexTableOfContents({
   toggleNode,
   expandNodes,
@@ -154,7 +153,6 @@ export function SidebarIndexTableOfContents({
   );
 }
 
-/* eslint-disable react/no-unused-prop-types */
 SidebarIndexTableOfContents.propTypes = {
   containerRef: PropTypes.oneOfType([
     PropTypes.func,
@@ -179,4 +177,3 @@ SidebarIndexTableOfContents.propTypes = {
   visibleNodeIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   windowId: PropTypes.string.isRequired,
 };
-/* eslint-enable react/no-unused-prop-types */

--- a/src/components/ThumbnailCanvasGrouping.jsx
+++ b/src/components/ThumbnailCanvasGrouping.jsx
@@ -126,7 +126,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
 }
 
 ThumbnailCanvasGrouping.propTypes = {
-  canvasGroupings: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  canvasGroupings: PropTypes.array.isRequired,
   columnIndex: PropTypes.number,
   currentCanvasId: PropTypes.string.isRequired,
   height: PropTypes.number.isRequired,
@@ -134,7 +134,7 @@ ThumbnailCanvasGrouping.propTypes = {
   position: PropTypes.string.isRequired,
   setCanvas: PropTypes.func.isRequired,
   showThumbnailLabels: PropTypes.bool.isRequired,
-  style: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  style: PropTypes.object.isRequired,
 };
 
 ThumbnailCanvasGrouping.defaultProps = {


### PR DESCRIPTION
- **Configure testing-library/utils-module for custom test utils**
- **Turn off enforcement of eslint/no-unused-vars**

Some testing-library eslint rule weren't being enforced. This moves us from "Agressive" to precise/utils mode.
See: https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/migration-guides/v4.md#testing-libraryutils-module
https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/migration-guides/v4.md#aggressive-reporting

This points the plugin at the project's custom @tests/utils/test-utils wrapper. Without this, rules that require a confirmed testing-library import — in this case no-node-access — were not firing in unit tests.
This also surfaced some eslint-disable comments that were not needed, that I cleaned up.

Also, I turned off the `no-unused-vars` -- this created a ton of warnings and we didn't have it enforced before. See 
https://github.com/ProjectMirador/mirador/pull/4249