### PR TITLE
Support percent-based media fragment selectors for annotations

### DIFF
--- a/__tests__/src/lib/AnnotationItem.test.js
+++ b/__tests__/src/lib/AnnotationItem.test.js
@@ -138,6 +138,23 @@ describe('AnnotationItem', () => {
       expect(new AnnotationItem({ target: 'www.example.com' })
         .fragmentSelector).toEqual(null);
     });
+    it('percent-based fragment', () => {
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentSelector).toEqual([25, 25, 50, 50]);
+    });
+  });
+  describe('fragmentUnit', () => {
+    it('defaults to pixel', () => {
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=10,10,100,200' })
+        .fragmentUnit).toEqual('pixel');
+    });
+    it('detects percent', () => {
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentUnit).toEqual('percent');
+    });
+    it('is null without a fragment', () => {
+      expect(new AnnotationItem({ target: 'www.example.com' }).fragmentUnit).toEqual(null);
+    });
   });
   describe('svgSelector', () => {
     it('simple string', () => {

--- a/__tests__/src/lib/AnnotationResource.test.js
+++ b/__tests__/src/lib/AnnotationResource.test.js
@@ -156,6 +156,21 @@ describe('AnnotationResource', () => {
       expect(new AnnotationResource({ on: { selector: { value: 'www.example.com' } } })
         .fragmentSelector).toEqual(null);
     });
+
+    it('percent-based fragment', () => {
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentSelector).toEqual([25, 25, 50, 50]);
+    });
+  });
+  describe('fragmentUnit', () => {
+    it('defaults to pixel', () => {
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=10,10,100,200' })
+        .fragmentUnit).toEqual('pixel');
+    });
+    it('detects percent', () => {
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentUnit).toEqual('percent');
+    });
   });
   describe('svgSelector', () => {
     it('simple string', () => {

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -127,5 +127,23 @@ describe('CanvasAnnotationDisplay', () => {
       expect(context.strokeStyle).toEqual('blue');
       expect(context.lineWidth).toEqual(2);
     });
+
+    it('scales percent-based fragment selectors against the canvas dimensions', () => {
+      const context = {
+        restore: vi.fn(),
+        save: vi.fn(),
+        strokeRect: vi.fn(),
+      };
+      const subject = createSubject({
+        canvasHeight: 3000,
+        canvasWidth: 4000,
+        hovered: true,
+        resource: new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' }),
+      });
+      subject.context = context;
+      subject.fragmentContext();
+      // 25% of 4000 = 1000, plus the -100 offset = 900; 25% of 3000 = 750
+      expect(context.strokeRect).toHaveBeenCalledWith(900, 750, 2000, 1500);
+    });
   });
 });

--- a/__tests__/src/lib/MiradorCanvas.test.js
+++ b/__tests__/src/lib/MiradorCanvas.test.js
@@ -103,6 +103,14 @@ describe('MiradorCanvas', () => {
         instance.onFragment('https://images.prtd.app/iiif/2/hamilton%2fHL_524_1r_00_PC17/full/739,521/0/default.jpg'),
       ).toEqual([552, 1584, 3360, 2368]);
     });
+    it('scales percent-based fragment selectors against the canvas dimensions', () => {
+      instance.resourceAnnotation = () => ({
+        getProperty: prop => (prop === 'on' ? 'www.example.com/#xywh=percent:25,25,50,50' : undefined),
+      });
+      instance.getWidth = () => 4000;
+      instance.getHeight = () => 3000;
+      expect(instance.onFragment('foo')).toEqual([1000, 750, 2000, 1500]);
+    });
   });
   describe('videoResources', () => {
     it('returns video', () => {

--- a/__tests__/src/lib/parseFragmentSelector.test.js
+++ b/__tests__/src/lib/parseFragmentSelector.test.js
@@ -1,0 +1,38 @@
+import parseFragmentSelector from '../../../src/lib/parseFragmentSelector';
+
+describe('parseFragmentSelector', () => {
+  it('parses a bare xywh fragment as pixels', () => {
+    expect(parseFragmentSelector('www.example.com/#xywh=10,10,100,200')).toEqual({
+      dimensions: [10, 10, 100, 200],
+      unit: 'pixel',
+    });
+  });
+
+  it('parses an explicit pixel: prefix', () => {
+    expect(parseFragmentSelector('www.example.com/#xywh=pixel:10,10,100,200')).toEqual({
+      dimensions: [10, 10, 100, 200],
+      unit: 'pixel',
+    });
+  });
+
+  it('parses a percent: prefix without scaling the values', () => {
+    expect(parseFragmentSelector('www.example.com/#xywh=percent:25,25,50,50')).toEqual({
+      dimensions: [25, 25, 50, 50],
+      unit: 'percent',
+    });
+  });
+
+  it('supports fractional values', () => {
+    expect(parseFragmentSelector('#xywh=percent:12.5,0,75,50').dimensions)
+      .toEqual([12.5, 0, 75, 50]);
+  });
+
+  it('returns null when there is no fragment', () => {
+    expect(parseFragmentSelector('www.example.com')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(parseFragmentSelector(undefined)).toBeNull();
+    expect(parseFragmentSelector(null)).toBeNull();
+  });
+});

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -13,7 +13,8 @@ import CanvasAnnotationDisplay from '../lib/CanvasAnnotationDisplay';
 
 /** @private */
 function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, point) {
-  const [canvasX, canvasY] = canvasWorld.canvasToWorldCoordinates(canvas.id);
+  const [canvasX, canvasY, canvasWidth, canvasHeight] = canvasWorld
+    .canvasToWorldCoordinates(canvas.id);
   const relativeX = point.x - canvasX;
   const relativeY = point.y - canvasY;
 
@@ -26,7 +27,13 @@ function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, po
   }
 
   if (resource.fragmentSelector) {
-    const [x, y, w, h] = resource.fragmentSelector;
+    let [x, y, w, h] = resource.fragmentSelector;
+    if (resource.fragmentUnit === 'percent') {
+      x = (x / 100) * canvasWidth;
+      y = (y / 100) * canvasHeight;
+      w = (w / 100) * canvasWidth;
+      h = (h / 100) * canvasHeight;
+    }
     return x <= relativeX && relativeX <= (x + w)
       && y <= relativeY && relativeY <= (y + h);
   }
@@ -65,7 +72,11 @@ export function AnnotationsOverlay({
       annotation.resources.forEach((resource) => {
         if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
         const offset = canvasWorld.offsetByCanvas(resource.targetId);
+        const [, , canvasWidth, canvasHeight] = canvasWorld
+          .canvasToWorldCoordinates(resource.targetId);
         const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
+          canvasHeight,
+          canvasWidth,
           hovered: hoveredAnnotationIds.includes(resource.id),
           offset,
           palette: {

--- a/src/lib/AnnotationItem.js
+++ b/src/lib/AnnotationItem.js
@@ -1,6 +1,7 @@
 import compact from 'lodash/compact';
 import flatten from 'lodash/flatten';
 import { v4 as uuid } from 'uuid';
+import parseFragmentSelector from './parseFragmentSelector';
 
 /**
  * A modeled WebAnnotation item
@@ -97,25 +98,34 @@ export default class AnnotationItem {
     }
   }
 
-  /** */
-  get fragmentSelector() {
+  /** @private */
+  get fragmentSelectorValue() {
     const { selector } = this;
-
-    let match;
-    let fragmentSelector;
 
     switch (typeof selector) {
       case 'string':
-        match = selector.match(/xywh=(.*)$/);
-        break;
-      case 'object':
-        fragmentSelector = selector.find(s => s.type && s.type === 'FragmentSelector');
-        match = fragmentSelector && fragmentSelector.value.match(/xywh=(.*)$/);
-        break;
+        return selector;
+      case 'object': {
+        const fragmentSelector = selector.find(s => s.type && s.type === 'FragmentSelector');
+        return fragmentSelector && fragmentSelector.value;
+      }
       default:
         return null;
     }
+  }
 
-    return match && match[1].split(',').map(str => parseInt(str, 10));
+  /** */
+  get fragmentSelector() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.dimensions;
+  }
+
+  /**
+   * The unit (`pixel` or `percent`) of the fragment selector, per the W3C Media
+   * Fragments spec. `percent` values need scaling against the canvas dimensions.
+   */
+  get fragmentUnit() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.unit;
   }
 }

--- a/src/lib/AnnotationResource.js
+++ b/src/lib/AnnotationResource.js
@@ -1,6 +1,7 @@
 import compact from 'lodash/compact';
 import flatten from 'lodash/flatten';
 import { v4 as uuid } from 'uuid';
+import parseFragmentSelector from './parseFragmentSelector';
 
 /** */
 export default class AnnotationResource {
@@ -101,23 +102,32 @@ export default class AnnotationResource {
     }
   }
 
-  /** */
-  get fragmentSelector() {
+  /** @private */
+  get fragmentSelectorValue() {
     const { selector } = this;
-
-    let match;
 
     switch (typeof selector) {
       case 'string':
-        match = selector.match(/xywh=(.*)$/);
-        break;
+        return selector;
       case 'object':
-        match = selector.value.match(/xywh=(.*)$/);
-        break;
+        return selector.value;
       default:
         return null;
     }
+  }
 
-    return match && match[1].split(',').map(str => parseInt(str, 10));
+  /** */
+  get fragmentSelector() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.dimensions;
+  }
+
+  /**
+   * The unit (`pixel` or `percent`) of the fragment selector, per the W3C Media
+   * Fragments spec. `percent` values need scaling against the canvas dimensions.
+   */
+  get fragmentUnit() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.unit;
   }
 }

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -5,7 +5,7 @@
 export default class CanvasAnnotationDisplay {
   /** */
   constructor({
-    resource, palette, zoomRatio, offset, selected, hovered,
+    resource, palette, zoomRatio, offset, selected, hovered, canvasWidth, canvasHeight,
   }) {
     this.resource = resource;
     this.palette = palette;
@@ -13,6 +13,8 @@ export default class CanvasAnnotationDisplay {
     this.offset = offset;
     this.selected = selected;
     this.hovered = hovered;
+    this.canvasWidth = canvasWidth;
+    this.canvasHeight = canvasHeight;
   }
 
   /** */
@@ -102,9 +104,25 @@ export default class CanvasAnnotationDisplay {
     });
   }
 
+  /**
+   * The fragment selector dimensions in canvas pixels, scaling `percent:` based
+   * selectors against the canvas dimensions.
+   */
+  get fragmentDimensions() {
+    const fragment = this.resource.fragmentSelector;
+    if (this.resource.fragmentUnit !== 'percent') return [...fragment];
+
+    return [
+      (fragment[0] / 100) * this.canvasWidth,
+      (fragment[1] / 100) * this.canvasHeight,
+      (fragment[2] / 100) * this.canvasWidth,
+      (fragment[3] / 100) * this.canvasHeight,
+    ];
+  }
+
   /** */
   fragmentContext() {
-    const fragment = this.resource.fragmentSelector;
+    const fragment = this.fragmentDimensions;
     fragment[0] += this.offset.x;
     fragment[1] += this.offset.y;
 

--- a/src/lib/MiradorCanvas.js
+++ b/src/lib/MiradorCanvas.js
@@ -2,6 +2,7 @@ import flatten from 'lodash/flatten';
 import flattenDeep from 'lodash/flattenDeep';
 import { Canvas, AnnotationPage, Annotation } from 'manifesto.js';
 import { getIiifResourceImageService } from './iiif';
+import parseFragmentSelector from './parseFragmentSelector';
 
 /**
  * MiradorCanvas - adds additional, testable logic around Manifesto's Canvas
@@ -184,9 +185,19 @@ export default class MiradorCanvas {
     const on = resourceAnnotation.getProperty('on');
     // IIIF v3
     const target = resourceAnnotation.getProperty('target');
-    const fragmentMatch = (on || target).match(/xywh=(.*)$/);
-    if (!fragmentMatch) return undefined;
-    return fragmentMatch[1].split(',').map(str => parseInt(str, 10));
+    const parsed = parseFragmentSelector(on || target);
+    if (!parsed) return undefined;
+    const { dimensions, unit } = parsed;
+    if (unit === 'percent') {
+      const [x, y, w, h] = dimensions;
+      return [
+        (x / 100) * this.getWidth(),
+        (y / 100) * this.getHeight(),
+        (w / 100) * this.getWidth(),
+        (h / 100) * this.getHeight(),
+      ];
+    }
+    return dimensions;
   }
 
   /** */

--- a/src/lib/parseFragmentSelector.js
+++ b/src/lib/parseFragmentSelector.js
@@ -1,0 +1,25 @@
+const FRAGMENT_REGEX = /xywh=(?:(pixel|percent):)?(.+)$/;
+
+/**
+ * Parse the `xywh` value of a W3C Media Fragment (used by IIIF/WebAnnotation
+ * targets and OpenAnnotation selectors). Supports the optional `pixel:` and
+ * `percent:` prefixes defined by https://www.w3.org/TR/media-frags/#naming-space.
+ *
+ * `percent:` values are returned verbatim (0-100) along with their unit; callers
+ * are responsible for scaling them against the canvas dimensions, since those are
+ * not known at this layer.
+ *
+ * @param {String} fragmentString e.g. "www.example.com/#xywh=percent:25,25,50,50"
+ * @returns {?{dimensions: number[], unit: ('pixel'|'percent')}}
+ */
+export default function parseFragmentSelector(fragmentString) {
+  if (typeof fragmentString !== 'string') return null;
+
+  const match = fragmentString.match(FRAGMENT_REGEX);
+  if (!match) return null;
+
+  return {
+    dimensions: match[2].split(',').map(str => parseFloat(str)),
+    unit: match[1] === 'percent' ? 'percent' : 'pixel',
+  };
+}


### PR DESCRIPTION
## Summary

[W3C Media Fragments](https://www.w3.org/TR/media-frags/#naming-space) allow the spatial dimension to be expressed as a percentage — `xywh=percent:x,y,w,h` — in addition to the bare `xywh=x,y,w,h` (pixel) form and the explicit `xywh=pixel:...` form. Mirador's annotation target parsers only handled the bare form: they captured everything after `xywh=` and ran `parseInt` over it.

As a result, a target like `#xywh=percent:25,25,50,50` produced `parseInt('percent:25', 10)` → `NaN` for the first coordinate, and the remaining values were treated as raw pixels with no scaling. Percent-based annotations therefore rendered in the wrong place, or not at all.

## Changes

- Add a shared `parseFragmentSelector` helper that strips the optional `pixel:` / `percent:` prefix and reports the `unit` alongside the parsed dimensions.
- Use it in the three parsing sites that previously duplicated the regex/`parseInt` logic: `AnnotationItem`, `AnnotationResource`, and `MiradorCanvas.onFragment`.
- Scale `percent:` values against the canvas dimensions where those are known:
  - `MiradorCanvas.onFragment` resolves against its own canvas size.
  - The annotation overlay drawing (`CanvasAnnotationDisplay`) and hit-testing (`AnnotationsOverlay`) resolve against the canvas world coordinates.

Bare and explicit `pixel:` fragments are unchanged in behaviour.

## Tests

- New `parseFragmentSelector` unit tests.
- Added percent cases to `AnnotationItem`, `AnnotationResource`, `MiradorCanvas`, and `CanvasAnnotationDisplay` tests, plus `fragmentUnit` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
