### PR TITLE
fix: Encode default and suggested search queries.

### DIFF
--- a/__tests__/src/components/SearchPanel.test.jsx
+++ b/__tests__/src/components/SearchPanel.test.jsx
@@ -79,6 +79,21 @@ describe('SearchPanel', () => {
     expect(fetchSearch).toHaveBeenCalledWith('http://example.com/search?q=abc', 'abc');
   });
 
+  it('encodes special characters in suggested search URLs', async () => {
+    const user = userEvent.setup();
+    const fetchSearch = vi.fn();
+    createWrapper({
+      fetchSearch,
+      query: '',
+      suggestedSearches: ['hel^lo'],
+      t,
+    });
+
+    expect(screen.getByRole('button', { name: 'Search this document for "hel^lo"' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Search this document for "hel^lo"' }));
+    expect(fetchSearch).toHaveBeenCalledWith('http://example.com/search?q=hel%5Elo', 'hel^lo');
+  });
+
   it('does not suggest searches if the user has made a query', () => {
     const fetchSearch = vi.fn();
     createWrapper({ fetchSearch, query: 'blah', suggestedSearches: ['abc'] });

--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -214,6 +214,31 @@ describe('window-level sagas', () => {
         .then(({ allEffects }) => allEffects.length === 0);
     });
 
+    it('encodes special characters in the default search query', () => {
+      const action = {
+        window: {
+          defaultSearchQuery: 'hel^lo',
+          id: 'x',
+          manifestId: 'manifest.json',
+        },
+      };
+
+      return expectSaga(setWindowDefaultSearchQuery, action)
+        .provide([
+          [select(getManifestSearchService, { windowId: 'x' }), { id: 'http://search/' }],
+          [select(getCompanionWindowIdsForPosition, { position: 'left', windowId: 'x' }), ['left']],
+        ])
+        .put({
+          companionWindowId: 'left',
+          query: 'hel^lo',
+          searchId: 'http://search/?q=hel%5Elo',
+          type: ActionTypes.REQUEST_SEARCH,
+          windowId: 'x',
+        })
+        .run()
+        .then(({ allEffects }) => allEffects.length === 1);
+    });
+
     it('initiates a search', () => {
       const action = {
         window: {

--- a/src/components/SearchPanel.jsx
+++ b/src/components/SearchPanel.jsx
@@ -54,7 +54,11 @@ export function SearchPanel({
         query === '' &&
         suggestedSearches.map((search) => (
           <Typography component="p" key={search} variant="body1" sx={{ margin: 2 }}>
-            <Button variant="inlineText" color="secondary" onClick={() => fetchSearch(`${searchService.id}?q=${search}`, search)}>
+            <Button
+              variant="inlineText"
+              color="secondary"
+              onClick={() => fetchSearch(`${searchService.id}?${new URLSearchParams({ q: search })}`, search)}
+            >
               {t('suggestSearch', { query: search })}
             </Button>
           </Typography>

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -134,7 +134,7 @@ export function* setWindowDefaultSearchQuery(action) {
   const companionWindowId = companionWindowIds[0];
 
   if (searchService && companionWindowId) {
-    const searchId = searchService && `${searchService.id}?q=${defaultSearchQuery}`;
+    const searchId = searchService && `${searchService.id}?${new URLSearchParams({ q: defaultSearchQuery })}`;
     yield put(fetchSearch(windowId, companionWindowId, searchId, defaultSearchQuery));
   }
 }


### PR DESCRIPTION
Suggested searches in the search panel and the default search query for the companion window were passed unescaped to the content search service, which caused issues when the query contained special characters (like `^` for boosting).