### PR TITLE
Supporting copying of selected annotation text

### DIFF
--- a/__tests__/src/components/CanvasAnnotations.test.jsx
+++ b/__tests__/src/components/CanvasAnnotations.test.jsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@tests/utils/test-utils';
+import { render, screen, act, fireEvent } from '@tests/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 
 import { CanvasAnnotations } from '../../../src/components/CanvasAnnotations';
 import { ScrollTo } from '../../../src/components/ScrollTo';
+
+vi.mock('copy-to-clipboard', () => ({ default: vi.fn() }));
 
 /** Utility function to wrap CanvasAnnotations */
 function createWrapper(props) {
@@ -180,6 +182,71 @@ describe('CanvasAnnotations', () => {
 
       await user.hover(screen.getByRole('menu'));
       expect(hoverAnnotation).toHaveBeenCalledWith('abc', []);
+    });
+  });
+  describe('annotation copy button', () => {
+    const annotations = [
+      {
+        content: 'First Annotation',
+        id: 'abc123',
+        tags: [],
+        targetId: 'example.com/iiif/12345',
+      },
+    ];
+
+    it('does not render the copy button when enableAnnotationCopy is not set', () => {
+      createWrapper({ annotations, selectedAnnotationId: 'abc123' });
+
+      expect(screen.queryByRole('button', { name: /copy annotation text/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render the copy button when annotation is not selected', () => {
+      createWrapper({ annotations, enableAnnotationCopy: true });
+
+      expect(screen.queryByRole('button', { name: /copy annotation text/i })).not.toBeInTheDocument();
+    });
+
+    it('renders the copy button when enabled and annotation is selected', () => {
+      createWrapper({ annotations, enableAnnotationCopy: true, selectedAnnotationId: 'abc123' });
+
+      expect(screen.getByRole('button', { name: /copy annotation text/i })).toBeInTheDocument();
+    });
+
+    it('does not trigger deselectAnnotation when the copy button is clicked', async () => {
+      const deselectAnnotation = vi.fn();
+      const user = userEvent.setup();
+
+      createWrapper({
+        annotations,
+        deselectAnnotation,
+        enableAnnotationCopy: true,
+        selectedAnnotationId: 'abc123',
+      });
+
+      await user.click(screen.getByRole('button', { name: /copy annotation text/i }));
+
+      expect(deselectAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('shows a tick icon after clicking the copy button and reverts after the confirm duration', () => {
+      vi.useFakeTimers();
+
+      createWrapper({
+        annotations,
+        enableAnnotationCopy: true,
+        annotationCopyConfirmDuration: 2000,
+        selectedAnnotationId: 'abc123',
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /copy annotation text/i }));
+
+      expect(screen.getByRole('button', { name: /annotation text copied/i })).toBeInTheDocument();
+
+      act(() => vi.advanceTimersByTime(2000));
+
+      expect(screen.getByRole('button', { name: /copy annotation text/i })).toBeInTheDocument();
+
+      vi.useRealTimers();
     });
   });
 });

--- a/src/components/CanvasAnnotations.jsx
+++ b/src/components/CanvasAnnotations.jsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
+import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
@@ -8,6 +9,10 @@ import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 import SanitizedHtml from '../containers/SanitizedHtml';
 import { ScrollTo } from './ScrollTo';
+import { MiradorMenuButton } from './MiradorMenuButton';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import copy from 'copy-to-clipboard';
 
 /**
  * CanvasAnnotations ~
@@ -17,6 +22,8 @@ export function CanvasAnnotations({
   index,
   label,
   selectedAnnotationId = undefined,
+  enableAnnotationCopy = false,
+  annotationCopyConfirmDuration = 2000,
   totalSize,
   listContainerComponent = 'li',
   htmlSanitizationRuleSet = 'iiif',
@@ -28,6 +35,7 @@ export function CanvasAnnotations({
   hoverAnnotation,
 }) {
   const { t } = useTranslation();
+  const [copiedAnnotationId, setCopiedAnnotationId] = useState(null);
   const handleClick = useCallback(
     (_event, annotation) => {
       if (selectedAnnotationId === annotation.id) {
@@ -49,6 +57,16 @@ export function CanvasAnnotations({
   const handleAnnotationBlur = useCallback(() => {
     hoverAnnotation(windowId, []);
   }, [hoverAnnotation, windowId]);
+
+  const handleCopyClick = useCallback(
+    (annotation) => (e) => {
+      e.stopPropagation();
+      copy(annotation.content);
+      setCopiedAnnotationId(annotation.id);
+      setTimeout(() => setCopiedAnnotationId(null), annotationCopyConfirmDuration);
+    },
+    [annotationCopyConfirmDuration],
+  );
 
   if (annotations.length === 0) return null;
 
@@ -84,13 +102,25 @@ export function CanvasAnnotations({
               onMouseEnter={() => handleAnnotationHover(annotation)}
               onMouseLeave={handleAnnotationBlur}
             >
-              <ListItemText
-                primaryTypographyProps={{ variant: 'body2' }}
-                primary={<SanitizedHtml ruleSet={htmlSanitizationRuleSet} htmlString={annotation.content} />}
-                secondary={annotation.tags.map((tag) => (
-                  <Chip component="span" size="small" variant="outlined" label={tag} id={tag} key={tag.toString()} />
-                ))}
-              />
+              <Box sx={{ display: 'block' }}>
+                {enableAnnotationCopy && selectedAnnotationId === annotation.id && (
+                  <MiradorMenuButton
+                    aria-label={copiedAnnotationId === annotation.id ? t('copiedAnnotationText') : t('copyAnnotationText')}
+                    sx={{ float: 'right', padding: '0', marginLeft: '0', marginBottom: '0' }}
+                    size="small"
+                    onClick={handleCopyClick(annotation)}
+                  >
+                    {copiedAnnotationId === annotation.id ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
+                  </MiradorMenuButton>
+                )}
+                <ListItemText
+                  primaryTypographyProps={{ variant: 'body2' }}
+                  primary={<SanitizedHtml ruleSet={htmlSanitizationRuleSet} htmlString={annotation.content} />}
+                  secondary={annotation.tags.map((tag) => (
+                    <Chip component="span" size="small" variant="outlined" label={tag} id={tag} key={tag.toString()} />
+                  ))}
+                />
+              </Box>
             </MenuItem>
           </ScrollTo>
         ))}
@@ -116,6 +146,8 @@ CanvasAnnotations.propTypes = {
   listContainerComponent: PropTypes.elementType,
   selectAnnotation: PropTypes.func.isRequired,
   selectedAnnotationId: PropTypes.string,
+  enableAnnotationCopy: PropTypes.bool,
+  annotationCopyConfirmDuration: PropTypes.number,
   totalSize: PropTypes.number.isRequired,
   windowId: PropTypes.string.isRequired,
 };

--- a/src/components/CanvasAnnotations.jsx
+++ b/src/components/CanvasAnnotations.jsx
@@ -6,6 +6,7 @@ import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import SanitizedHtml from '../containers/SanitizedHtml';
 import { ScrollTo } from './ScrollTo';
@@ -13,6 +14,23 @@ import { MiradorMenuButton } from './MiradorMenuButton';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import copy from 'copy-to-clipboard';
+
+const AnnotationCopyButton = styled(MiradorMenuButton, {
+  name: 'AnnotationCopyButton',
+  slot: 'root',
+})({
+  float: 'right',
+  padding: '0',
+  marginLeft: '0',
+  marginBottom: '0',
+});
+
+const AnnotationBody = styled(Box, {
+  name: 'AnnotationBody',
+  slot: 'root',
+})({
+  display: 'block',
+});
 
 /**
  * CanvasAnnotations ~
@@ -102,16 +120,15 @@ export function CanvasAnnotations({
               onMouseEnter={() => handleAnnotationHover(annotation)}
               onMouseLeave={handleAnnotationBlur}
             >
-              <Box sx={{ display: 'block' }}>
+              <AnnotationBody>
                 {enableAnnotationCopy && selectedAnnotationId === annotation.id && (
-                  <MiradorMenuButton
+                  <AnnotationCopyButton
                     aria-label={copiedAnnotationId === annotation.id ? t('copiedAnnotationText') : t('copyAnnotationText')}
-                    sx={{ float: 'right', padding: '0', marginLeft: '0', marginBottom: '0' }}
                     size="small"
                     onClick={handleCopyClick(annotation)}
                   >
                     {copiedAnnotationId === annotation.id ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
-                  </MiradorMenuButton>
+                  </AnnotationCopyButton>
                 )}
                 <ListItemText
                   primaryTypographyProps={{ variant: 'body2' }}
@@ -120,7 +137,7 @@ export function CanvasAnnotations({
                     <Chip component="span" size="small" variant="outlined" label={tag} id={tag} key={tag.toString()} />
                   ))}
                 />
-              </Box>
+              </AnnotationBody>
             </MenuItem>
           </ScrollTo>
         ))}

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -452,7 +452,7 @@ export default {
     // filteredMotivations: if empty, all annotation motivations will be shown.
     // Otherwise, only annotations with motivations listed in the array will be shown.
     filteredMotivations: [],
-    enableAnnotationCopy: true,
+    enableAnnotationCopy: false,
     annotationCopyConfirmDuration: 2000,
   },
   createGenerateClassNameOptions: {

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -452,6 +452,8 @@ export default {
     // filteredMotivations: if empty, all annotation motivations will be shown.
     // Otherwise, only annotations with motivations listed in the array will be shown.
     filteredMotivations: [],
+    enableAnnotationCopy: true,
+    annotationCopyConfirmDuration: 2000,
   },
   createGenerateClassNameOptions: {
     // Options passed directly to createGenerateClassName in Material-UI https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator

--- a/src/containers/CanvasAnnotations.js
+++ b/src/containers/CanvasAnnotations.js
@@ -27,6 +27,8 @@ function getIdAndContentOfResources(resources) {
 const mapStateToProps = (state, { canvasId, windowId }) => ({
   annotations: getIdAndContentOfResources(getAnnotationResourcesByMotivationForCanvas(state, { canvasId, windowId })),
   htmlSanitizationRuleSet: getConfig(state).annotations.htmlSanitizationRuleSet,
+  enableAnnotationCopy: getConfig(state).annotations.enableAnnotationCopy,
+  annotationCopyConfirmDuration: getConfig(state).annotations.annotationCopyConfirmDuration,
   label: getCanvasLabel(state, {
     canvasId,
     windowId,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -32,6 +32,8 @@
     "collection": "Collection",
     "continue": "Continue",
     "copy": "Copy",
+    "copyAnnotationText": "Copy annotation text",
+    "copiedAnnotationText": "Annotation text copied",
     "currentItem": "Current item",
     "currentItem_1/1": "Current item",
     "currentItem_1/2": "Left",


### PR DESCRIPTION
A copy button appears for selected annotation text in the sidebar.  When clicked it copies the annotation text to the clipboard and shows a tick for two seconds.  Addressing the issue raised here:

https://github.com/ProjectMirador/mirador/issues/3590