### PR TITLE
Generate language labels for each locale code

### DIFF
--- a/__tests__/src/components/LocalePicker.test.jsx
+++ b/__tests__/src/components/LocalePicker.test.jsx
@@ -41,6 +41,33 @@ describe('LocalePicker', () => {
     expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument();
   });
 
+  it('renders a human-readable label for locale codes not in the configured language list', async () => {
+    const user = userEvent.setup();
+    // 'fi' (Finnish) is not in Mirador's availableLanguages config
+    createWrapper({ availableLocales: ['en', 'fi'], locale: 'en' });
+    const dropdownTitle = screen.getByRole('combobox');
+    await user.click(dropdownTitle);
+    const menu = screen.getByRole('listbox');
+    // 'fi' should be resolved to a display name (e.g. "Finnish"), not shown as the raw code
+    expect(menu).not.toHaveTextContent('fi');
+    expect(screen.getByRole('option', { name: /finnish/i })).toBeInTheDocument();
+  });
+
+  it('falls back to the raw locale code when Intl.DisplayNames is unavailable', async () => {
+    const user = userEvent.setup();
+    // Intl.DisplayNames could error in older browser environments
+    // Fallback to the raw locale code in those cases.
+    vi.spyOn(Intl, 'DisplayNames').mockImplementation(() => {
+      throw new Error('not supported');
+    });
+    // 'fi' is not in availableLanguages; DisplayNames unavailable, so raw code is shown
+    createWrapper({ availableLocales: ['en', 'fi'], locale: 'en' });
+    const dropdownTitle = screen.getByRole('combobox');
+    await user.click(dropdownTitle);
+    expect(screen.getByRole('option', { name: 'fi' })).toBeInTheDocument();
+    vi.restoreAllMocks();
+  });
+
   it('triggers setLocale prop when clicking a list item', async () => {
     const user = userEvent.setup();
     const setLocale = vi.fn();

--- a/src/components/LocalePicker.jsx
+++ b/src/components/LocalePicker.jsx
@@ -31,6 +31,9 @@ export function LocalePicker({ availableLocales = [], locale = '', setLocale = u
     }
   };
 
+  // Resolve the label shown for a locale: manifest-provided label, then Intl.DisplayNames, then raw code
+  const getLocaleLabel = (code) => labels[code]?.label || getDisplayName(code) || code;
+
   return (
     <FormControl variant="standard">
       <InputLabel>{t('language')}</InputLabel>
@@ -51,7 +54,7 @@ export function LocalePicker({ availableLocales = [], locale = '', setLocale = u
       >
         {availableLocales.map((l) => (
           <MenuItem key={l} value={l}>
-            <Typography variant="body2">{labels[l]?.label || getDisplayName(l) || l}</Typography>
+            <Typography variant="body2">{getLocaleLabel(l)}</Typography>
           </MenuItem>
         ))}
       </Select>

--- a/src/components/LocalePicker.jsx
+++ b/src/components/LocalePicker.jsx
@@ -21,6 +21,16 @@ export function LocalePicker({ availableLocales = [], locale = '', setLocale = u
   const selectedLocale = availableLocales.indexOf(locale) >= 0 ? locale : availableLocales[0];
   const labels = keyBy(languages, (o) => o.locale);
 
+  /** Resolve an RFC 5646 language code to a human-readable name using the browser's
+   * Intl.DisplayNames API, displayed in the current manifest locale. */
+  const getDisplayName = (code) => {
+    try {
+      return new Intl.DisplayNames([selectedLocale], { type: 'language' }).of(code);
+    } catch (e) {
+      return undefined;
+    }
+  };
+
   return (
     <FormControl variant="standard">
       <InputLabel>{t('language')}</InputLabel>
@@ -41,7 +51,7 @@ export function LocalePicker({ availableLocales = [], locale = '', setLocale = u
       >
         {availableLocales.map((l) => (
           <MenuItem key={l} value={l}>
-            <Typography variant="body2">{labels[l]?.label || l}</Typography>
+            <Typography variant="body2">{labels[l]?.label || getDisplayName(l) || l}</Typography>
           </MenuItem>
         ))}
       </Select>


### PR DESCRIPTION
Closes #2475
This browser API of `Intl` wasn't available before. This covers the case where the language isn't already in our settings config, such as Finnish.