### PR TITLE
Don't re-create removed windows on UPDATE_WINDOW

### DIFF
--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -165,6 +165,22 @@ describe('windows reducer', () => {
       };
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);
     });
+
+    it('does not re-create a window that no longer exists', () => {
+      const action = {
+        id: 'gone',
+        payload: {
+          foo: 11,
+        },
+        type: ActionTypes.UPDATE_WINDOW,
+      };
+      const beforeState = {
+        abc123: {
+          bar: 2,
+        },
+      };
+      expect(windowsReducer(beforeState, action)).toBe(beforeState);
+    });
   });
 
   it('should handle SET_WINDOW_SIZE', () => {

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -29,6 +29,8 @@ export const windowsReducer = (state = {}, action) => {
       };
 
     case ActionTypes.UPDATE_WINDOW:
+      if (!state[action.id]) return state;
+
       return update([action.id], (orig) => ({ ...(orig || {}), ...action.payload }), state);
 
     case ActionTypes.REMOVE_WINDOW:


### PR DESCRIPTION
## Purpose

When an `UPDATE_WINDOW` action arrives for a window that has already been removed from the state (e.g. a deferred `updateWindow` dispatch from a plugin resolving a fetch after the user closed the window), the reducer re-creates the window as a stub containing only the action payload. Such a ghost window has no `companionWindowIds`, which makes `getCompanionWindowsByWindowAndPosition` throw for every window in the workspace and breaks rendering:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'map')
    at src/state/selectors/companionWindows.js:79:40
    at Array.reduce (<anonymous>)
    at src/state/selectors/companionWindows.js:75:32
```

## Approach

In the `UPDATE_WINDOW` case of the windows reducer, return the state unchanged if `state[action.id]` does not exist, mirroring the existing guard on `SET_CANVAS`. A reducer test covers this case.