### PR TITLE
Allow text selection within annotation list items

### DIFF
--- a/__tests__/src/components/CanvasAnnotations.test.jsx
+++ b/__tests__/src/components/CanvasAnnotations.test.jsx
@@ -159,6 +159,30 @@ describe('CanvasAnnotations', () => {
       expect(hoverAnnotation).toHaveBeenCalledWith('abc', ['annoId2']);
     });
 
+    it('does not toggle annotation selection when the user has highlighted text', async () => {
+      const selectAnnotation = vi.fn();
+      const deselectAnnotation = vi.fn();
+      const user = userEvent.setup();
+
+      const getSelectionSpy = vi.spyOn(window, 'getSelection').mockReturnValue({
+        toString: () => 'highlighted text',
+      });
+
+      wrapper = createWrapper({
+        annotations,
+        deselectAnnotation,
+        selectAnnotation,
+        selectedAnnotationId: 'abc123',
+      });
+
+      await user.click(screen.getByRole('menuitem', { name: /First Annotation/ }));
+
+      expect(selectAnnotation).not.toHaveBeenCalled();
+      expect(deselectAnnotation).not.toHaveBeenCalled();
+
+      getSelectionSpy.mockRestore();
+    });
+
     it('sets the highlighted annotation to null on mouse leave', async () => {
       const hoverAnnotation = vi.fn();
       const user = userEvent.setup();

--- a/src/components/CanvasAnnotations.jsx
+++ b/src/components/CanvasAnnotations.jsx
@@ -30,6 +30,7 @@ export function CanvasAnnotations({
   const { t } = useTranslation();
   const handleClick = useCallback(
     (_event, annotation) => {
+      if (window.getSelection()?.toString()) return;
       if (selectedAnnotationId === annotation.id) {
         deselectAnnotation(windowId, annotation.id);
       } else {
@@ -75,6 +76,7 @@ export function CanvasAnnotations({
                   backgroundColor: 'action.hover',
                 },
                 backgroundColor: hoveredAnnotationIds.includes(annotation.id) ? 'action.hover' : '',
+                userSelect: 'text',
               }}
               key={annotation.id}
               annotationid={annotation.id}


### PR DESCRIPTION
**The Gist**

* Prevent toggling annotation selection if the user has highlighted text by returning early in handleClick when window.getSelection()?.toString() is non-empty.
* Add userSelect: 'text' style so text can be selected inside annotation items.
* Add a unit test to assert select/deselect are not called when text is highlighted and restore the mocked selection after the test.

---

# Allow text selection within annotation list items

## Summary

Fixes GitHub issue [#4270](https://github.com/ProjectMirador/mirador/issues/4270) — annotation text in the side panel can now be selected and copied.

Previously, MUI `MenuItem` (via `ButtonBase`) applied `user-select: none` to annotation list items, so users couldn't drag-select annotation text. They had to retype it or open devtools — a real accessibility/usability problem flagged by
researchers.

## Changes

- `MenuItem` now has `userSelect: 'text'` so drag-select works.
- `handleClick` no-ops when `window.getSelection()` is non-empty, so the
  mouseup at the end of a drag doesn't toggle the annotation.
- Added a test for the click-with-active-selection case.

## Browser caveat

- Chrome / Safari: drag-select, Cmd/Ctrl+C, AND right-click → Copy all work.
- Firefox: drag-select and Cmd/Ctrl+C work; right-click → Copy collapses the
  selection. This is a Firefox-specific quirk where it clears selections on
  right-click inside focusable interactive elements; keyboard copy is fully accessible.

## Test plan

- [ ] `npm test -- CanvasAnnotations` passes
- [ ] Open annotation panel in Chrome: drag-select text, Cmd/Ctrl+C, paste — works
- [ ] Click annotation toggles selection as before
- [ ] Click after drag-selecting does NOT toggle the annotation
- [ ] Keyboard arrow nav still highlights/hovers annotations
- [ ] Firefox: drag-select + Cmd/Ctrl+C works (right-click caveat acknowledged)
