### PR TITLE
Fixes #3109 (insufficient contrast on the "Add resource" button's focused state)

### DIFF
--- a/src/components/WorkspaceAddButton.jsx
+++ b/src/components/WorkspaceAddButton.jsx
@@ -26,6 +26,14 @@ function useWidth() {
 
 const Root = styled(Fab, { name: 'WorkspaceAddButton', slot: 'root' })(({ theme }) => ({
   marginBottom: theme.spacing(1),
+  '&:hover, &.Mui-focusVisible': {
+    backgroundColor: (theme.vars || theme).palette.primary.dark,
+  },
+  ...theme.applyStyles('dark', {
+    '&:hover, &.Mui-focusVisible': {
+      backgroundColor: (theme.vars || theme).palette.primary.light,
+    },
+  }),
 }));
 
 /**
@@ -40,6 +48,7 @@ export function WorkspaceAddButton({ setWorkspaceAddVisibility, isWorkspaceAddVi
         size="medium"
         color="primary"
         id="addBtn"
+        focusRipple={false}
         aria-label={
           isWorkspaceAddVisible
             ? t('closeAddResourceMenu')


### PR DESCRIPTION
This is a fix for Issue #3109 

In `WorkspaceAddButton.jsx`:

- I disabled the Fab's focus ripple (`focusRipple={false}`), since the ripple
  overlay was part of what reduced the contrast.
- I set the hover and `.Mui-focusVisible` background colors to the same value
  to keep those states in sync.
- I noticed that in dark mode the hover state also reduced contrast (darkening
  the background instead of lightening it), so I made a corresponding change
  there. Happy to revert that portion if you'd prefer.

No hardcoded colors; the change uses palette tokens, so it respects theme
overrides.

Before/after label contrast (WCAG 1.4.3), measured with WebAIM's contrast
checker:
- Light, focused: 3.1:1 → 8.85:1
- Dark, focused: 4.45:1 → 8.8:1

## Screenshots

| State | Before | After |
|---|---|---|
| Light, focused | <img width="96" height="89" alt="Screenshot From 2026-07-14 12-08-21" src="https://github.com/user-attachments/assets/707277ba-5e10-4ba3-bf94-340cc7171187" />|<img width="96" height="89" alt="Screenshot From 2026-07-14 12-09-09" src="https://github.com/user-attachments/assets/597cfb8f-a3b3-4a90-b207-1dc0ffde4443" /> |
| Dark, focused | <img width="96" height="89" alt="Screenshot From 2026-07-14 12-57-53" src="https://github.com/user-attachments/assets/4a1a7773-7c39-49d4-b515-765a6a2a7b74" /> | <img width="86" height="76" alt="Screenshot From 2026-07-14 13-07-06" src="https://github.com/user-attachments/assets/a6780b50-1e38-4554-8a5f-ca464ffc6c02" /> |

Linting and the existing test suite pass with no regressions. I didn't add new
unit tests since this is a style-only change with no logic to assert, but I'm
happy to add a style assertion if that's preferred. Please let me know if
there's anything else I can do to bring this up to Mirador's standards.

Thank you for your work and your time,

Greg