### PR TITLE
Fix additional companionWindowId crashes

### DIFF
--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -166,7 +166,7 @@ describe('windows reducer', () => {
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);
     });
 
-     it('does not re-create a window that no longer exists', () => {
+    it('does not re-create a window that no longer exists', () => {
       const action = {
         id: 'gone',
         payload: {

--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -166,7 +166,7 @@ describe('windows reducer', () => {
       expect(windowsReducer(beforeState, action)).toEqual(expectedState);
     });
 
-    it('does not re-create a window that no longer exists', () => {
+     it('does not re-create a window that no longer exists', () => {
       const action = {
         id: 'gone',
         payload: {
@@ -180,6 +180,24 @@ describe('windows reducer', () => {
         },
       };
       expect(windowsReducer(beforeState, action)).toBe(beforeState);
+    });
+
+    // https://github.com/ProjectMirador/mirador/issues/3930
+    it('does not let an explicit undefined value in the payload clobber existing state', () => {
+      const action = {
+        id: 'abc123',
+        payload: {
+          companionWindowIds: undefined,
+        },
+        type: ActionTypes.UPDATE_WINDOW,
+      };
+      const beforeState = {
+        abc123: {
+          companionWindowIds: ['cw1', 'cw2'],
+        },
+      };
+
+      expect(windowsReducer(beforeState, action)).toEqual(beforeState);
     });
   });
 

--- a/__tests__/src/selectors/companionWindows.test.js
+++ b/__tests__/src/selectors/companionWindows.test.js
@@ -91,6 +91,27 @@ describe('getCompanionWindowsForPosition', () => {
 
     expect(received).toBe(expected);
   });
+
+  // https://github.com/ProjectMirador/mirador/issues/3930
+  it('does not throw for any window when a different, unrelated window has a corrupted companionWindowIds', () => {
+    const corruptedState = {
+      companionWindows: {
+        abc: { id: 'abc', position: 'right' },
+      },
+      windows: {
+        a: { companionWindowIds: ['abc'] },
+        // simulates a plugin dispatch clobbering this window's companionWindowIds with undefined
+        b: { companionWindowIds: undefined },
+      },
+    };
+
+    expect(() =>
+      getCompanionWindowsForPosition(corruptedState, {
+        position: 'right',
+        windowId: 'a',
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe('getCompanionWindow', () => {

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -31,7 +31,15 @@ export const windowsReducer = (state = {}, action) => {
     case ActionTypes.UPDATE_WINDOW:
       if (!state[action.id]) return state;
 
-      return update([action.id], (orig) => ({ ...(orig || {}), ...action.payload }), state);
+      return update(
+        [action.id],
+        (orig) => ({
+          ...(orig || {}),
+          // drop explicit `undefined` values so they can't clobber existing keys on spread (#3930)
+          ...Object.fromEntries(Object.entries(action.payload).filter(([, value]) => value !== undefined)),
+        }),
+        state,
+      );
 
     case ActionTypes.REMOVE_WINDOW:
       return omit(state, [action.windowId]);

--- a/src/state/selectors/companionWindows.js
+++ b/src/state/selectors/companionWindows.js
@@ -60,7 +60,10 @@ const getCompanionWindowIndexByWindowAndPosition = createSelector(
     (Object.keys(windows) || []).reduce(
       (obj, id) => ({
         ...obj,
-        [id]: groupBy(windows[id].companionWindowIds, (cwid) => companionWindows[cwid] && companionWindows[cwid].position),
+        [id]: groupBy(
+          windows[id].companionWindowIds || EMPTY_ARRAY,
+          (cwid) => companionWindows[cwid] && companionWindows[cwid].position,
+        ),
       }),
       {},
     ),
@@ -76,7 +79,7 @@ const getCompanionWindowsByWindowAndPosition = createSelector([getWindows, getCo
     (obj, id) => ({
       ...obj,
       [id]: groupBy(
-        windows[id].companionWindowIds.map((cwid) => companionWindows[cwid]),
+        (windows[id].companionWindowIds || EMPTY_ARRAY).map((cwid) => companionWindows[cwid]),
         (cw) => cw.position,
       ),
     }),


### PR DESCRIPTION
These are test cases that reproduce https://github.com/ProjectMirador/mirador/issues/3930
Closes https://github.com/ProjectMirador/mirador/issues/3930

UPDATE_WINDOW now drops undefined-valued keys from the payload before merging, so an undefined can't clobber an existing window's companionWindowIds. 

The companion window selectors also now fall back to an empty array instead of throwing when a window's companionWindowIds is missing, so one corrupted window can no longer break rendering for the whole workspace.

related to https://github.com/ProjectMirador/mirador/pull/4352/