### PR TITLE
Remove redundant window title announcement

### DIFF
--- a/__tests__/integration/tests/minimalist.test.js
+++ b/__tests__/integration/tests/minimalist.test.js
@@ -8,8 +8,9 @@ describe('Minimalist configuration to Mirador', () => {
 
   it('Loads a manifest and displays it without some of the default controls', async () => {
     expect(
-      await screen.findByRole('region', {
-        name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+      await screen.findByRole('heading', {
+        level: 2,
+        name: /Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
       }),
     ).toBeInTheDocument();
 

--- a/__tests__/integration/tests/thumbnail-navigation.test.js
+++ b/__tests__/integration/tests/thumbnail-navigation.test.js
@@ -10,11 +10,14 @@ describe('Canvas navigation by clicking thumbnails', () => {
 
   it.skip('navigates a manifest using thumbnail navigation', async (context) => {
     // Make sure we have the manifest
-    const windowElement = await screen.findByRole('region', {
-      name: /Window: Bodleian Library MS. Ind. Inst. Misc. 22/i,
+    const windowTitle = await screen.findByRole('heading', {
+      level: 2,
+      name: /Bodleian Library MS. Ind. Inst. Misc. 22/i,
     });
-    expect(windowElement).toBeInTheDocument();
+    expect(windowTitle).toBeInTheDocument();
 
+    // eslint-disable-next-line testing-library/no-node-access
+    const windowElement = windowTitle.closest('section');
     const windowId = windowElement.getAttribute('id');
     const storedCanvasId = context.miradorInstance.store.getState().windows[windowId].canvasId;
 

--- a/__tests__/integration/tests/viewer-config.test.js
+++ b/__tests__/integration/tests/viewer-config.test.js
@@ -9,8 +9,9 @@ describe('initialViewerConfig', () => {
   describe('initialViewerConfig', () => {
     it('allows initialViewerConfig to be passed', async (context) => {
       expect(
-        await screen.findByRole('region', {
-          name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+        await screen.findByRole('heading', {
+          level: 2,
+          name: /Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
         }),
       ).toBeInTheDocument();
 

--- a/__tests__/integration/tests/window-actions.test.js
+++ b/__tests__/integration/tests/window-actions.test.js
@@ -8,21 +8,23 @@ describe('Window actions', () => {
 
   it('Closes a Mirador window', async () => {
     expect(
-      await screen.findByRole('region', {
-        name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+      await screen.findByRole('heading', {
+        level: 2,
+        name: /Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
       }),
     ).toBeInTheDocument();
     const closeButton = screen.getByRole('button', { name: /Close window/i });
     fireEvent.click(closeButton);
     await waitFor(() =>
       expect(
-        screen.queryByRole('region', {
-          name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
         }),
       ).not.toBeInTheDocument(),
     );
 
     // No windows should be present
-    expect(screen.queryByRole('region')).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Window navigation' })).not.toBeInTheDocument();
   });
 });

--- a/__tests__/src/components/Window.test.jsx
+++ b/__tests__/src/components/Window.test.jsx
@@ -1,5 +1,6 @@
 import { MosaicWindowContext } from 'react-mosaic-component';
 import { render, screen } from '@tests/utils/test-utils';
+import textManifest from '../../fixtures/version-3/text-pdf.json';
 
 import { Window } from '../../../src/components/Window';
 
@@ -9,10 +10,13 @@ function createWrapper(props, state, renderOptions) {
     <Window windowId="xyz" manifestId="foo" classes={{}} {...props} />,
     {
       preloadedState: {
+        ...state,
         windows: {
+          ...state?.windows,
           xyz: {
             collectionDialogOn: false,
             companionWindowIds: [],
+            ...state?.windows?.xyz,
           },
         },
       },
@@ -22,9 +26,25 @@ function createWrapper(props, state, renderOptions) {
 }
 
 describe('Window', () => {
-  it('should render outer element', () => {
-    createWrapper();
-    expect(screen.getByLabelText('Window:')).toHaveClass('mirador-window');
+  it('renders the outer section without repeating the window title as its accessible name', () => {
+    const manifestId = textManifest.id;
+    const { container } = createWrapper(
+      {},
+      {
+        manifests: {
+          [manifestId]: {
+            id: manifestId,
+            json: textManifest,
+          },
+        },
+        windows: { xyz: { manifestId } },
+      },
+    );
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const windowElement = container.querySelector('section.mirador-window');
+
+    expect(windowElement).not.toHaveAttribute('aria-label');
+    expect(screen.getByRole('heading', { level: 2, name: 'Simplest Text Example 1' })).toBeInTheDocument();
   });
   it('should render <WindowTopBar>', () => {
     createWrapper();

--- a/__tests__/src/components/Workspace.test.jsx
+++ b/__tests__/src/components/Workspace.test.jsx
@@ -59,18 +59,18 @@ describe('Workspace', () => {
   });
   describe('if workspace type is unknown', () => {
     it('should render <Window/> components as list', () => {
-      createWrapper({ workspaceType: 'bubu' });
+      const { container } = createWrapper({ workspaceType: 'bubu' });
 
       expect(screen.getByRole('heading', { name: 'Mirador viewer' })).toBeInTheDocument();
-      expect(screen.getAllByLabelText('Window:')).toHaveLength(2);
+      expect(container.querySelectorAll('.mirador-window')).toHaveLength(2);
     });
   });
   describe('if any windows are maximized', () => {
     it('should render only maximized <Window/> components', () => {
-      createWrapper({ maximizedWindowIds: ['1'] });
+      const { container } = createWrapper({ maximizedWindowIds: ['1'] });
 
       expect(screen.getByRole('heading', { name: 'Mirador viewer' })).toBeInTheDocument();
-      expect(screen.getByLabelText('Window:')).toHaveAttribute('id', '1');
+      expect(container.querySelector('.mirador-window')).toHaveAttribute('id', '1');
     });
   });
 

--- a/__tests__/src/components/WorkspaceElastic.test.jsx
+++ b/__tests__/src/components/WorkspaceElastic.test.jsx
@@ -55,8 +55,8 @@ describe('WorkspaceElastic', () => {
   };
 
   it('should render properly with an initialValue', () => {
-    createWrapper({ elasticLayout });
-    expect(screen.getAllByLabelText('Window:')).toHaveLength(2);
+    const { container } = createWrapper({ elasticLayout });
+    expect(container.querySelectorAll('.mirador-window')).toHaveLength(2);
   });
   describe('workspace behaviour', () => {
     it('when workspace itself is dragged', async () => {

--- a/__tests__/src/components/WorkspaceMosaic.test.jsx
+++ b/__tests__/src/components/WorkspaceMosaic.test.jsx
@@ -119,9 +119,10 @@ describe('WorkspaceMosaic', () => {
   describe('tile rendering', () => {
     it('when window is available', () => {
       wrapper = createWrapper({ windowIds });
+      const windows = wrapper.container.querySelectorAll('.mirador-window');
 
-      expect(screen.getAllByLabelText('Window:', { container: 'section' })[0]).toHaveAttribute('id', '1');
-      expect(screen.getAllByLabelText('Window:', { container: 'section' })[1]).toHaveAttribute('id', '2');
+      expect(windows[0]).toHaveAttribute('id', '1');
+      expect(windows[1]).toHaveAttribute('id', '2');
 
       expect(wrapper.container.querySelector('.mosaic-window-title')).toBeEmptyDOMElement();
       expect(wrapper.container.querySelector('.mosaic-window-controls')).toBeEmptyDOMElement();

--- a/__tests__/utils/test-utils.jsx
+++ b/__tests__/utils/test-utils.jsx
@@ -95,7 +95,7 @@ export const setupIntegrationTestViewer = (config, plugins) => {
     await failIfErrorDialogPresent({ waitForRole: 'main' });
 
     if ((config.windows || []).length > 0) {
-      await safeFindAllByRole('region', { name: /Window:/i });
+      await safeFindAllByRole('navigation', { name: 'Window navigation' });
     }
   });
 };

--- a/src/components/Window.jsx
+++ b/src/components/Window.jsx
@@ -4,7 +4,6 @@ import { styled } from '@mui/material/styles';
 import Paper from '@mui/material/Paper';
 import { MosaicWindowContext } from 'react-mosaic-component';
 import { ErrorBoundary } from 'react-error-boundary';
-import { useTranslation } from 'react-i18next';
 import ns from '../config/css-ns';
 import WindowTopBar from '../containers/WindowTopBar';
 import PrimaryWindow from '../containers/PrimaryWindow';
@@ -89,7 +88,6 @@ export function Window({
   workspaceType = null,
   manifestError = null,
 }) {
-  const { t } = useTranslation();
   // eslint-disable-next-line prefer-rest-params
   const ownerState = arguments[0];
   const ErrorWindow = useCallback(
@@ -110,7 +108,6 @@ export function Window({
         elevation={1}
         id={windowId}
         className={ns('window')}
-        aria-label={t('window', { label })}
       >
         <WindowTopBar
           component={workspaceType === 'mosaic' && windowDraggable ? DraggableNavBar : undefined}


### PR DESCRIPTION
## Summary

- remove the window section's redundant `aria-label`
- keep the manifest title available as an `h2` for heading and rotor navigation
- update affected tests to use the retained heading or window structure instead of the removed named region

This prevents screen readers from announcing the window title twice in close succession.

Fixes #3904.

## Testing

- focused component suite — 23 passed
- affected integration tests — 3 passed, 1 pre-existing test skipped
- ESLint and Prettier checks for all changed files — passed
- repository-wide lint reports the same pre-existing formatting error in unchanged `setupTest.js:36` on both the exact base and patched trees

## Limitation

No assistive-technology session was run; the regression asserts the accessible DOM contract while retaining the heading.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1051:start -->
### Verification

[Northset proof-of-pass receipt M-1051](https://northset-oss.github.io/verification-pilot/receipts/M-1051/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1051:end -->
