### PR TITLE
Fix SVG annotation fill and stroke order

### DIFF
--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -110,6 +110,74 @@ describe('CanvasAnnotationDisplay', () => {
       expect(subject.context.strokeStyle).toBe('yellow');
     });
   });
+  describe('svgContext paint order', () => {
+    it('draws the fill before the stroke with their respective opacity', () => {
+      const operations = [];
+      const context = {
+        fill: vi.fn(() => operations.push(['fill', context.globalAlpha])),
+        restore: vi.fn(),
+        save: vi.fn(),
+        setLineDash: vi.fn(),
+        stroke: vi.fn(() => operations.push(['stroke', context.globalAlpha])),
+        translate: vi.fn(),
+      };
+      const subject = createSubject({
+        resource: {
+          svgSelector: { value: '<svg />' },
+        },
+      });
+      vi.spyOn(subject, 'svgPaths', 'get').mockReturnValue([
+        {
+          attributes: {
+            d: { nodeValue: 'M0,0 L10,0 L10,10 Z' },
+            fill: { nodeValue: 'green' },
+            'fill-opacity': { nodeValue: 0.25 },
+            stroke: { nodeValue: 'yellow' },
+            'stroke-opacity': { nodeValue: 0.75 },
+          },
+        },
+      ]);
+      subject.context = context;
+
+      subject.svgContext();
+
+      expect(operations).toEqual([
+        ['fill', 0.25],
+        ['stroke', 0.75],
+      ]);
+    });
+
+    it('does not fill a path whose fill is none', () => {
+      const context = {
+        fill: vi.fn(),
+        restore: vi.fn(),
+        save: vi.fn(),
+        setLineDash: vi.fn(),
+        stroke: vi.fn(),
+        translate: vi.fn(),
+      };
+      const subject = createSubject({
+        resource: {
+          svgSelector: { value: '<svg />' },
+        },
+      });
+      vi.spyOn(subject, 'svgPaths', 'get').mockReturnValue([
+        {
+          attributes: {
+            d: { nodeValue: 'M0,0 L10,0 L10,10 Z' },
+            fill: { nodeValue: 'none' },
+            stroke: { nodeValue: 'yellow' },
+          },
+        },
+      ]);
+      subject.context = context;
+
+      subject.svgContext();
+
+      expect(context.fill).not.toHaveBeenCalled();
+      expect(context.stroke).toHaveBeenCalledOnce();
+    });
+  });
   describe('fragmentContext', () => {
     it('draws the fragment with selected arguments', () => {
       const context = {

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -79,15 +79,7 @@ export default class CanvasAnnotationDisplay {
         this.context.strokeStyle = currentPalette.strokeStyle || currentPalette.fillStyle;
       }
 
-      if (element.attributes['stroke-opacity']) {
-        this.context.globalAlpha = currentPalette.globalAlpha * element.attributes['stroke-opacity'].nodeValue;
-      } else {
-        this.context.globalAlpha = currentPalette.globalAlpha;
-      }
-
-      this.context.stroke(p);
-
-      // Wait to set the fill, so we can adjust the globalAlpha value if we need to
+      // Draw the fill first so it does not cover the inner half of the stroke.
       if (element.attributes.fill && element.attributes.fill.nodeValue !== 'none') {
         if (element.attributes['fill-opacity']) {
           this.context.globalAlpha = currentPalette.globalAlpha * element.attributes['fill-opacity'].nodeValue;
@@ -96,6 +88,14 @@ export default class CanvasAnnotationDisplay {
         }
         this.context.fill(p);
       }
+
+      if (element.attributes['stroke-opacity']) {
+        this.context.globalAlpha = currentPalette.globalAlpha * element.attributes['stroke-opacity'].nodeValue;
+      } else {
+        this.context.globalAlpha = currentPalette.globalAlpha;
+      }
+
+      this.context.stroke(p);
       this.context.restore();
     });
   }


### PR DESCRIPTION
## Summary

- draw SVG annotation fills before their strokes so selected borders remain visible
- preserve independent fill and stroke opacity while changing the paint order
- add regression coverage for fill/stroke ordering and `fill=none`

The change does not alter selector parsing or public APIs.

## Testing

- `npx vitest run __tests__/src/lib/CanvasAnnotationDisplay.test.js` (7 passed, 2 skipped)
- `npx vitest run __tests__/src --coverage` (1168 passed, 8 skipped)
- `npm run build`
- `npm run lint:containers`
- `npm run size`
- `npx prettier --check src/lib/CanvasAnnotationDisplay.js __tests__/src/lib/CanvasAnnotationDisplay.test.js`
- `npx eslint src/lib/CanvasAnnotationDisplay.js __tests__/src/lib/CanvasAnnotationDisplay.test.js`
- `git diff --check upstream/main...HEAD`

## Local environment notes

- A complete Vitest run reached 1184 passing tests and 12 skipped tests; two external-network integration tests failed because their remote IIIF data did not load in this environment.
- `npm test -- --coverage` built successfully, then stopped because its `node_modules/.bin/eslint` command is not executable from this Windows shell. The translation linter also does not resolve Windows path separators. The changed files pass Prettier and ESLint directly.

Closes #4130