### PR TITLE
Rebased and reformatted: support percent-based fragment annotations

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.jsx
+++ b/__tests__/src/components/AnnotationsOverlay.test.jsx
@@ -172,6 +172,35 @@ describe('AnnotationsOverlay', () => {
       expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
     });
 
+    it('triggers a selectAnnotation for a percent-based fragment selector', () => {
+      const selectAnnotation = vi.fn();
+
+      const { viewer } = createWrapper({
+        annotations: [
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
+                '@id': 'http://example.org/identifier/annotation/anno-percent',
+                '@type': 'oa:Annotation',
+                motivation: 'sc:painting',
+                // canvas c1 is 1200x1800, so this covers x:[120,360] y:[180,540]
+                on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=percent:10,10,20,20',
+              },
+            ],
+          }),
+        ],
+        selectAnnotation,
+      });
+
+      viewer.raiseEvent('canvas-click', {
+        eventSource: { viewport: viewer.viewport },
+        position: new OpenSeadragon.Point(150, 200),
+      });
+
+      expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-percent');
+    });
+
     it('triggers a deselectAnnotation for an already-selected annotation', () => {
       const deselectAnnotation = vi.fn();
 

--- a/__tests__/src/lib/AnnotationItem.test.js
+++ b/__tests__/src/lib/AnnotationItem.test.js
@@ -132,18 +132,17 @@ describe('AnnotationItem', () => {
       expect(new AnnotationItem({ target: 'www.example.com' }).fragmentSelector).toEqual(null);
     });
     it('percent-based fragment', () => {
-      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' })
-        .fragmentSelector).toEqual([25, 25, 50, 50]);
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' }).fragmentSelector).toEqual([
+        25, 25, 50, 50,
+      ]);
     });
   });
   describe('fragmentUnit', () => {
     it('defaults to pixel', () => {
-      expect(new AnnotationItem({ target: 'www.example.com/#xywh=10,10,100,200' })
-        .fragmentUnit).toEqual('pixel');
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=10,10,100,200' }).fragmentUnit).toEqual('pixel');
     });
     it('detects percent', () => {
-      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' })
-        .fragmentUnit).toEqual('percent');
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' }).fragmentUnit).toEqual('percent');
     });
     it('is null without a fragment', () => {
       expect(new AnnotationItem({ target: 'www.example.com' }).fragmentUnit).toEqual(null);

--- a/__tests__/src/lib/AnnotationItem.test.js
+++ b/__tests__/src/lib/AnnotationItem.test.js
@@ -131,6 +131,23 @@ describe('AnnotationItem', () => {
     it('url without a fragment', () => {
       expect(new AnnotationItem({ target: 'www.example.com' }).fragmentSelector).toEqual(null);
     });
+    it('percent-based fragment', () => {
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentSelector).toEqual([25, 25, 50, 50]);
+    });
+  });
+  describe('fragmentUnit', () => {
+    it('defaults to pixel', () => {
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=10,10,100,200' })
+        .fragmentUnit).toEqual('pixel');
+    });
+    it('detects percent', () => {
+      expect(new AnnotationItem({ target: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentUnit).toEqual('percent');
+    });
+    it('is null without a fragment', () => {
+      expect(new AnnotationItem({ target: 'www.example.com' }).fragmentUnit).toEqual(null);
+    });
   });
   describe('svgSelector', () => {
     it('simple string', () => {

--- a/__tests__/src/lib/AnnotationResource.test.js
+++ b/__tests__/src/lib/AnnotationResource.test.js
@@ -178,6 +178,21 @@ describe('AnnotationResource', () => {
     it('url without a fragment', () => {
       expect(new AnnotationResource({ on: { selector: { value: 'www.example.com' } } }).fragmentSelector).toEqual(null);
     });
+
+    it('percent-based fragment', () => {
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentSelector).toEqual([25, 25, 50, 50]);
+    });
+  });
+  describe('fragmentUnit', () => {
+    it('defaults to pixel', () => {
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=10,10,100,200' })
+        .fragmentUnit).toEqual('pixel');
+    });
+    it('detects percent', () => {
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' })
+        .fragmentUnit).toEqual('percent');
+    });
   });
   describe('svgSelector', () => {
     it('simple string', () => {

--- a/__tests__/src/lib/AnnotationResource.test.js
+++ b/__tests__/src/lib/AnnotationResource.test.js
@@ -180,18 +180,17 @@ describe('AnnotationResource', () => {
     });
 
     it('percent-based fragment', () => {
-      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' })
-        .fragmentSelector).toEqual([25, 25, 50, 50]);
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' }).fragmentSelector).toEqual([
+        25, 25, 50, 50,
+      ]);
     });
   });
   describe('fragmentUnit', () => {
     it('defaults to pixel', () => {
-      expect(new AnnotationResource({ on: 'www.example.com/#xywh=10,10,100,200' })
-        .fragmentUnit).toEqual('pixel');
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=10,10,100,200' }).fragmentUnit).toEqual('pixel');
     });
     it('detects percent', () => {
-      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' })
-        .fragmentUnit).toEqual('percent');
+      expect(new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' }).fragmentUnit).toEqual('percent');
     });
   });
   describe('svgSelector', () => {

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -127,5 +127,23 @@ describe('CanvasAnnotationDisplay', () => {
       expect(context.strokeStyle).toEqual('blue');
       expect(context.lineWidth).toEqual(2);
     });
+
+    it('scales percent-based fragment selectors against the canvas dimensions', () => {
+      const context = {
+        restore: vi.fn(),
+        save: vi.fn(),
+        strokeRect: vi.fn(),
+      };
+      const subject = createSubject({
+        canvasHeight: 3000,
+        canvasWidth: 4000,
+        hovered: true,
+        resource: new AnnotationResource({ on: 'www.example.com/#xywh=percent:25,25,50,50' }),
+      });
+      subject.context = context;
+      subject.fragmentContext();
+      // 25% of 4000 = 1000, plus the -100 offset = 900; 25% of 3000 = 750
+      expect(context.strokeRect).toHaveBeenCalledWith(900, 750, 2000, 1500);
+    });
   });
 });

--- a/__tests__/src/lib/MiradorCanvas.test.js
+++ b/__tests__/src/lib/MiradorCanvas.test.js
@@ -91,6 +91,14 @@ describe('MiradorCanvas', () => {
         instance.onFragment('https://images.prtd.app/iiif/2/hamilton%2fHL_524_1r_00_PC17/full/739,521/0/default.jpg'),
       ).toEqual([552, 1584, 3360, 2368]);
     });
+    it('scales percent-based fragment selectors against the canvas dimensions', () => {
+      instance.resourceAnnotation = () => ({
+        getProperty: prop => (prop === 'on' ? 'www.example.com/#xywh=percent:25,25,50,50' : undefined),
+      });
+      instance.getWidth = () => 4000;
+      instance.getHeight = () => 3000;
+      expect(instance.onFragment('foo')).toEqual([1000, 750, 2000, 1500]);
+    });
   });
   describe('videoResources', () => {
     it('returns video', () => {

--- a/__tests__/src/lib/MiradorCanvas.test.js
+++ b/__tests__/src/lib/MiradorCanvas.test.js
@@ -93,7 +93,7 @@ describe('MiradorCanvas', () => {
     });
     it('scales percent-based fragment selectors against the canvas dimensions', () => {
       instance.resourceAnnotation = () => ({
-        getProperty: prop => (prop === 'on' ? 'www.example.com/#xywh=percent:25,25,50,50' : undefined),
+        getProperty: (prop) => (prop === 'on' ? 'www.example.com/#xywh=percent:25,25,50,50' : undefined),
       });
       instance.getWidth = () => 4000;
       instance.getHeight = () => 3000;

--- a/__tests__/src/lib/parseFragmentSelector.test.js
+++ b/__tests__/src/lib/parseFragmentSelector.test.js
@@ -1,0 +1,38 @@
+import parseFragmentSelector from '../../../src/lib/parseFragmentSelector';
+
+describe('parseFragmentSelector', () => {
+  it('parses a bare xywh fragment as pixels', () => {
+    expect(parseFragmentSelector('www.example.com/#xywh=10,10,100,200')).toEqual({
+      dimensions: [10, 10, 100, 200],
+      unit: 'pixel',
+    });
+  });
+
+  it('parses an explicit pixel: prefix', () => {
+    expect(parseFragmentSelector('www.example.com/#xywh=pixel:10,10,100,200')).toEqual({
+      dimensions: [10, 10, 100, 200],
+      unit: 'pixel',
+    });
+  });
+
+  it('parses a percent: prefix without scaling the values', () => {
+    expect(parseFragmentSelector('www.example.com/#xywh=percent:25,25,50,50')).toEqual({
+      dimensions: [25, 25, 50, 50],
+      unit: 'percent',
+    });
+  });
+
+  it('supports fractional values', () => {
+    expect(parseFragmentSelector('#xywh=percent:12.5,0,75,50').dimensions)
+      .toEqual([12.5, 0, 75, 50]);
+  });
+
+  it('returns null when there is no fragment', () => {
+    expect(parseFragmentSelector('www.example.com')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(parseFragmentSelector(undefined)).toBeNull();
+    expect(parseFragmentSelector(null)).toBeNull();
+  });
+});

--- a/__tests__/src/lib/parseFragmentSelector.test.js
+++ b/__tests__/src/lib/parseFragmentSelector.test.js
@@ -23,8 +23,7 @@ describe('parseFragmentSelector', () => {
   });
 
   it('supports fractional values', () => {
-    expect(parseFragmentSelector('#xywh=percent:12.5,0,75,50').dimensions)
-      .toEqual([12.5, 0, 75, 50]);
+    expect(parseFragmentSelector('#xywh=percent:12.5,0,75,50').dimensions).toEqual([12.5, 0, 75, 50]);
   });
 
   it('returns null when there is no fragment', () => {

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -11,8 +11,7 @@ import CanvasAnnotationDisplay from '../lib/CanvasAnnotationDisplay';
 
 /** @private */
 function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, point) {
-  const [canvasX, canvasY, canvasWidth, canvasHeight] = canvasWorld
-    .canvasToWorldCoordinates(canvas.id);
+  const [canvasX, canvasY, canvasWidth, canvasHeight] = canvasWorld.canvasToWorldCoordinates(canvas.id);
   const relativeX = point.x - canvasX;
   const relativeY = point.y - canvasY;
 
@@ -30,8 +29,7 @@ function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, po
       w = (w / 100) * canvasWidth;
       h = (h / 100) * canvasHeight;
     }
-    return x <= relativeX && relativeX <= (x + w)
-      && y <= relativeY && relativeY <= (y + h);
+    return x <= relativeX && relativeX <= x + w && y <= relativeY && relativeY <= y + h;
   }
   return false;
 }
@@ -74,25 +72,26 @@ export function AnnotationsOverlay({
   /**
    * annotationsToContext - converts anontations to a canvas context
    */
-  const annotationsToContext = useCallback((renderedAnnotations, currentPalette) => {
-    const context = osdCanvasOverlay.context2d;
-    const zoomRatio = viewer.viewport.getZoom(true) / viewer.viewport.getMaxZoom();
-    renderedAnnotations.forEach((annotation) => {
-      annotation.resources.forEach((resource) => {
-        if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
-        const offset = canvasWorld.offsetByCanvas(resource.targetId);
-        const [, , canvasWidth, canvasHeight] = canvasWorld
-          .canvasToWorldCoordinates(resource.targetId);
-        const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
-          canvasHeight,
-          canvasWidth,
-          hovered: hoveredAnnotationIds.includes(resource.id),
-          offset,
-          palette: {
-            ...currentPalette,
-            default: {
-              ...currentPalette.default,
-              ...(!highlightAllAnnotations && currentPalette.hidden),
+  const annotationsToContext = useCallback(
+    (renderedAnnotations, currentPalette) => {
+      const context = osdCanvasOverlay.context2d;
+      const zoomRatio = viewer.viewport.getZoom(true) / viewer.viewport.getMaxZoom();
+      renderedAnnotations.forEach((annotation) => {
+        annotation.resources.forEach((resource) => {
+          if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
+          const offset = canvasWorld.offsetByCanvas(resource.targetId);
+          const [, , canvasWidth, canvasHeight] = canvasWorld.canvasToWorldCoordinates(resource.targetId);
+          const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
+            canvasHeight,
+            canvasWidth,
+            hovered: hoveredAnnotationIds.includes(resource.id),
+            offset,
+            palette: {
+              ...currentPalette,
+              default: {
+                ...currentPalette.default,
+                ...(!highlightAllAnnotations && currentPalette.hidden),
+              },
             },
             resource,
             selected: selectedAnnotationId === resource.id,

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -11,7 +11,8 @@ import CanvasAnnotationDisplay from '../lib/CanvasAnnotationDisplay';
 
 /** @private */
 function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, point) {
-  const [canvasX, canvasY] = canvasWorld.canvasToWorldCoordinates(canvas.id);
+  const [canvasX, canvasY, canvasWidth, canvasHeight] = canvasWorld
+    .canvasToWorldCoordinates(canvas.id);
   const relativeX = point.x - canvasX;
   const relativeY = point.y - canvasY;
 
@@ -22,8 +23,15 @@ function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, po
   }
 
   if (resource.fragmentSelector) {
-    const [x, y, w, h] = resource.fragmentSelector;
-    return x <= relativeX && relativeX <= x + w && y <= relativeY && relativeY <= y + h;
+    let [x, y, w, h] = resource.fragmentSelector;
+    if (resource.fragmentUnit === 'percent') {
+      x = (x / 100) * canvasWidth;
+      y = (y / 100) * canvasHeight;
+      w = (w / 100) * canvasWidth;
+      h = (h / 100) * canvasHeight;
+    }
+    return x <= relativeX && relativeX <= (x + w)
+      && y <= relativeY && relativeY <= (y + h);
   }
   return false;
 }
@@ -66,23 +74,25 @@ export function AnnotationsOverlay({
   /**
    * annotationsToContext - converts anontations to a canvas context
    */
-  const annotationsToContext = useCallback(
-    (renderedAnnotations, currentPalette) => {
-      const context = osdCanvasOverlay.context2d;
-      const zoomRatio = viewer.viewport.getZoom(true) / viewer.viewport.getMaxZoom();
-      renderedAnnotations.forEach((annotation) => {
-        annotation.resources.forEach((resource) => {
-          if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
-          const offset = canvasWorld.offsetByCanvas(resource.targetId);
-          const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
-            hovered: hoveredAnnotationIds.includes(resource.id),
-            offset,
-            palette: {
-              ...currentPalette,
-              default: {
-                ...currentPalette.default,
-                ...(!highlightAllAnnotations && currentPalette.hidden),
-              },
+  const annotationsToContext = useCallback((renderedAnnotations, currentPalette) => {
+    const context = osdCanvasOverlay.context2d;
+    const zoomRatio = viewer.viewport.getZoom(true) / viewer.viewport.getMaxZoom();
+    renderedAnnotations.forEach((annotation) => {
+      annotation.resources.forEach((resource) => {
+        if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
+        const offset = canvasWorld.offsetByCanvas(resource.targetId);
+        const [, , canvasWidth, canvasHeight] = canvasWorld
+          .canvasToWorldCoordinates(resource.targetId);
+        const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
+          canvasHeight,
+          canvasWidth,
+          hovered: hoveredAnnotationIds.includes(resource.id),
+          offset,
+          palette: {
+            ...currentPalette,
+            default: {
+              ...currentPalette.default,
+              ...(!highlightAllAnnotations && currentPalette.hidden),
             },
             resource,
             selected: selectedAnnotationId === resource.id,

--- a/src/lib/AnnotationItem.js
+++ b/src/lib/AnnotationItem.js
@@ -109,7 +109,7 @@ export default class AnnotationItem {
       case 'string':
         return selector;
       case 'object': {
-        const fragmentSelector = selector.find(s => s.type && s.type === 'FragmentSelector');
+        const fragmentSelector = selector.find((s) => s.type && s.type === 'FragmentSelector');
         return fragmentSelector && fragmentSelector.value;
       }
       default:

--- a/src/lib/AnnotationItem.js
+++ b/src/lib/AnnotationItem.js
@@ -1,6 +1,7 @@
 import compact from 'lodash/compact';
 import flatten from 'lodash/flatten';
 import { v4 as uuid } from 'uuid';
+import parseFragmentSelector from './parseFragmentSelector';
 
 /**
  * A modeled WebAnnotation item
@@ -100,25 +101,34 @@ export default class AnnotationItem {
     }
   }
 
-  /** */
-  get fragmentSelector() {
+  /** @private */
+  get fragmentSelectorValue() {
     const { selector } = this;
-
-    let match;
-    let fragmentSelector;
 
     switch (typeof selector) {
       case 'string':
-        match = selector.match(/xywh=(.*)$/);
-        break;
-      case 'object':
-        fragmentSelector = selector.find((s) => s.type && s.type === 'FragmentSelector');
-        match = fragmentSelector && fragmentSelector.value.match(/xywh=(.*)$/);
-        break;
+        return selector;
+      case 'object': {
+        const fragmentSelector = selector.find(s => s.type && s.type === 'FragmentSelector');
+        return fragmentSelector && fragmentSelector.value;
+      }
       default:
         return null;
     }
+  }
 
-    return match && match[1].split(',').map((str) => parseInt(str, 10));
+  /** */
+  get fragmentSelector() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.dimensions;
+  }
+
+  /**
+   * The unit (`pixel` or `percent`) of the fragment selector, per the W3C Media
+   * Fragments spec. `percent` values need scaling against the canvas dimensions.
+   */
+  get fragmentUnit() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.unit;
   }
 }

--- a/src/lib/AnnotationResource.js
+++ b/src/lib/AnnotationResource.js
@@ -1,6 +1,7 @@
 import compact from 'lodash/compact';
 import flatten from 'lodash/flatten';
 import { v4 as uuid } from 'uuid';
+import parseFragmentSelector from './parseFragmentSelector';
 
 /** */
 export default class AnnotationResource {
@@ -101,23 +102,32 @@ export default class AnnotationResource {
     }
   }
 
-  /** */
-  get fragmentSelector() {
+  /** @private */
+  get fragmentSelectorValue() {
     const { selector } = this;
-
-    let match;
 
     switch (typeof selector) {
       case 'string':
-        match = selector.match(/xywh=(.*)$/);
-        break;
+        return selector;
       case 'object':
-        match = selector.value.match(/xywh=(.*)$/);
-        break;
+        return selector.value;
       default:
         return null;
     }
+  }
 
-    return match && match[1].split(',').map((str) => parseInt(str, 10));
+  /** */
+  get fragmentSelector() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.dimensions;
+  }
+
+  /**
+   * The unit (`pixel` or `percent`) of the fragment selector, per the W3C Media
+   * Fragments spec. `percent` values need scaling against the canvas dimensions.
+   */
+  get fragmentUnit() {
+    const parsed = parseFragmentSelector(this.fragmentSelectorValue);
+    return parsed && parsed.unit;
   }
 }

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -4,13 +4,17 @@
  */
 export default class CanvasAnnotationDisplay {
   /** */
-  constructor({ resource, palette, zoomRatio, offset, selected, hovered }) {
+  constructor({
+    resource, palette, zoomRatio, offset, selected, hovered, canvasWidth, canvasHeight,
+  }) {
     this.resource = resource;
     this.palette = palette;
     this.zoomRatio = zoomRatio;
     this.offset = offset;
     this.selected = selected;
     this.hovered = hovered;
+    this.canvasWidth = canvasWidth;
+    this.canvasHeight = canvasHeight;
   }
 
   /** */
@@ -100,9 +104,25 @@ export default class CanvasAnnotationDisplay {
     });
   }
 
+  /**
+   * The fragment selector dimensions in canvas pixels, scaling `percent:` based
+   * selectors against the canvas dimensions.
+   */
+  get fragmentDimensions() {
+    const fragment = this.resource.fragmentSelector;
+    if (this.resource.fragmentUnit !== 'percent') return [...fragment];
+
+    return [
+      (fragment[0] / 100) * this.canvasWidth,
+      (fragment[1] / 100) * this.canvasHeight,
+      (fragment[2] / 100) * this.canvasWidth,
+      (fragment[3] / 100) * this.canvasHeight,
+    ];
+  }
+
   /** */
   fragmentContext() {
-    const fragment = this.resource.fragmentSelector;
+    const fragment = this.fragmentDimensions;
     fragment[0] += this.offset.x;
     fragment[1] += this.offset.y;
 

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -4,9 +4,7 @@
  */
 export default class CanvasAnnotationDisplay {
   /** */
-  constructor({
-    resource, palette, zoomRatio, offset, selected, hovered, canvasWidth, canvasHeight,
-  }) {
+  constructor({ resource, palette, zoomRatio, offset, selected, hovered, canvasWidth, canvasHeight }) {
     this.resource = resource;
     this.palette = palette;
     this.zoomRatio = zoomRatio;

--- a/src/lib/MiradorCanvas.js
+++ b/src/lib/MiradorCanvas.js
@@ -2,6 +2,7 @@ import flatten from 'lodash/flatten';
 import flattenDeep from 'lodash/flattenDeep';
 import { Canvas, AnnotationPage, Annotation } from 'manifesto.js';
 import { getIiifResourceImageService } from './iiif';
+import parseFragmentSelector from './parseFragmentSelector';
 
 /**
  * MiradorCanvas - adds additional, testable logic around Manifesto's Canvas
@@ -183,9 +184,19 @@ export default class MiradorCanvas {
     const on = resourceAnnotation.getProperty('on');
     // IIIF v3
     const target = resourceAnnotation.getProperty('target');
-    const fragmentMatch = (on || target).match(/xywh=(.*)$/);
-    if (!fragmentMatch) return undefined;
-    return fragmentMatch[1].split(',').map((str) => parseInt(str, 10));
+    const parsed = parseFragmentSelector(on || target);
+    if (!parsed) return undefined;
+    const { dimensions, unit } = parsed;
+    if (unit === 'percent') {
+      const [x, y, w, h] = dimensions;
+      return [
+        (x / 100) * this.getWidth(),
+        (y / 100) * this.getHeight(),
+        (w / 100) * this.getWidth(),
+        (h / 100) * this.getHeight(),
+      ];
+    }
+    return dimensions;
   }
 
   /** */

--- a/src/lib/parseFragmentSelector.js
+++ b/src/lib/parseFragmentSelector.js
@@ -1,0 +1,25 @@
+const FRAGMENT_REGEX = /xywh=(?:(pixel|percent):)?(.+)$/;
+
+/**
+ * Parse the `xywh` value of a W3C Media Fragment (used by IIIF/WebAnnotation
+ * targets and OpenAnnotation selectors). Supports the optional `pixel:` and
+ * `percent:` prefixes defined by https://www.w3.org/TR/media-frags/#naming-space.
+ *
+ * `percent:` values are returned verbatim (0-100) along with their unit; callers
+ * are responsible for scaling them against the canvas dimensions, since those are
+ * not known at this layer.
+ *
+ * @param {String} fragmentString e.g. "www.example.com/#xywh=percent:25,25,50,50"
+ * @returns {?{dimensions: number[], unit: ('pixel'|'percent')}}
+ */
+export default function parseFragmentSelector(fragmentString) {
+  if (typeof fragmentString !== 'string') return null;
+
+  const match = fragmentString.match(FRAGMENT_REGEX);
+  if (!match) return null;
+
+  return {
+    dimensions: match[2].split(',').map(str => parseFloat(str)),
+    unit: match[1] === 'percent' ? 'percent' : 'pixel',
+  };
+}

--- a/src/lib/parseFragmentSelector.js
+++ b/src/lib/parseFragmentSelector.js
@@ -19,7 +19,7 @@ export default function parseFragmentSelector(fragmentString) {
   if (!match) return null;
 
   return {
-    dimensions: match[2].split(',').map(str => parseFloat(str)),
+    dimensions: match[2].split(',').map((str) => parseFloat(str)),
     unit: match[1] === 'percent' ? 'percent' : 'pixel',
   };
 }


### PR DESCRIPTION
- **Support percent-based media fragment selectors for annotations**
- **Reformat files related to percent based fragment annotations**

@nakamura196 please take a look. I rebased and reformatted your PR, but I don't want to have messed up any of the logic. Thank you for work and well-scoped PR. We are auditing all our open PRs and trying to move forward. Thanks!

Supersedes https://github.com/ProjectMirador/mirador/pull/4319 if accepted