### PR TITLE
Give CompanionWindow's aside role="region" instead of the implicit complementary landmark

### DIFF
--- a/__tests__/integration/tests/annotations.test.js
+++ b/__tests__/integration/tests/annotations.test.js
@@ -44,7 +44,7 @@ describe('Annotations in Mirador', () => {
 
     // use safeFindByRole here. This specific test is consistently hard to interpret on failure,
     // since another async operation has happened after setupIntegrationTestViewer
-    const annotationPanel = await safeFindByRole('complementary', { name: /annotations/i });
+    const annotationPanel = await safeFindByRole('region', { name: /annotations/i });
     expect(annotationPanel).toBeInTheDocument();
 
     const listItems = await within(annotationPanel).findAllByRole('menuitem');

--- a/__tests__/integration/tests/companion-windows.test.js
+++ b/__tests__/integration/tests/companion-windows.test.js
@@ -11,19 +11,19 @@ describe('Basic end to end Mirador', () => {
     fireEvent.click(toggleButtons[0]);
 
     // Companion window is on the left
-    expect(await screen.findByRole('complementary', { name: /About this item/i })).toHaveClass('mirador-companion-window-left');
+    expect(await screen.findByRole('region', { name: /About this item/i })).toHaveClass('mirador-companion-window-left');
 
     const openButton = screen.getByRole('button', { name: /Open in separate panel/i });
     fireEvent.click(openButton);
 
     // Companion window is on the right
-    expect(await screen.findByRole('complementary', { name: /About this item/i })).toHaveClass('mirador-companion-window-right');
+    expect(await screen.findByRole('region', { name: /About this item/i })).toHaveClass('mirador-companion-window-right');
 
     // Close the panel
     const closeButton = screen.getByRole('button', { name: /Close panel/i });
     fireEvent.click(closeButton);
 
     // The companion window is removed
-    expect(screen.queryByRole('complementary', { name: /About this item/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /About this item/i })).not.toBeInTheDocument();
   });
 });

--- a/__tests__/src/components/CompanionArea.test.jsx
+++ b/__tests__/src/components/CompanionArea.test.jsx
@@ -25,9 +25,12 @@ function createWrapper(props) {
 
 describe('CompanionArea', () => {
   it('should render all <CompanionWindow>', () => {
-    createWrapper();
+    const { container } = createWrapper();
 
-    expect(screen.getAllByRole('complementary')).toHaveLength(2);
+    // CompanionWindow content can include its own nested role="region" elements
+    // (e.g. MUI Accordion), so scope this to the CompanionWindow root landmarks themselves.
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    expect(container.querySelectorAll('aside[role="region"]')).toHaveLength(2);
   });
 
   it('should add the appropriate classes when the companion area fills the full width', () => {
@@ -56,7 +59,7 @@ describe('CompanionArea', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Expand sidebar' })).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Expand sidebar' }));
 

--- a/__tests__/src/components/CompanionWindow.test.jsx
+++ b/__tests__/src/components/CompanionWindow.test.jsx
@@ -15,12 +15,12 @@ describe('CompanionWindow', () => {
     it('has an aria-label for the landmark derived from the title', () => {
       createWrapper({ title: 'some title' });
 
-      expect(screen.getByRole('complementary')).toHaveAccessibleName('some title');
+      expect(screen.getByRole('region')).toHaveAccessibleName('some title');
     });
     it('can be overridden with an explicit ariaLabel prop', () => {
       createWrapper({ ariaLabel: 'some label', title: 'some title' });
 
-      expect(screen.getByRole('complementary')).toHaveAccessibleName('some label');
+      expect(screen.getByRole('region')).toHaveAccessibleName('some label');
     });
   });
 
@@ -89,7 +89,7 @@ describe('CompanionWindow', () => {
         updateCompanionWindow,
       });
 
-      expect(screen.getByRole('complementary')).toHaveClass('mirador-companion-window-right');
+      expect(screen.getByRole('region')).toHaveClass('mirador-companion-window-right');
 
       await user.click(screen.getByRole('button', { name: 'Move to bottom' }));
 
@@ -107,7 +107,7 @@ describe('CompanionWindow', () => {
         updateCompanionWindow,
       });
 
-      expect(screen.getByRole('complementary')).toHaveClass('mirador-companion-window-bottom ');
+      expect(screen.getByRole('region')).toHaveClass('mirador-companion-window-bottom ');
 
       await user.click(screen.getByRole('button', { name: 'Move to right' }));
 

--- a/__tests__/src/components/SearchPanel.test.jsx
+++ b/__tests__/src/components/SearchPanel.test.jsx
@@ -23,7 +23,7 @@ function createWrapper(props) {
 describe('SearchPanel', () => {
   it('renders a CompanionWindow', () => {
     createWrapper();
-    expect(screen.getByRole('complementary')).toBeInTheDocument();
+    expect(screen.getByRole('region')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Search' })).toBeInTheDocument();
   });
 

--- a/src/components/CompanionWindow.jsx
+++ b/src/components/CompanionWindow.jsx
@@ -126,6 +126,7 @@ export const CompanionWindow = forwardRef((props, innerRef) => {
       ].join(' ')}
       square
       component="aside"
+      role="region"
       aria-label={ariaLabel || title}
     >
       <LocaleContext.Provider value={locale}>


### PR DESCRIPTION
## Summary
Closes #4225.

The sliding panels for "about this item", "rights", and "index" use `<aside>`, which needs to be at the top level per WAI-ARIA landmark rules, but is nested several component layers inside `<main>` (`CompanionWindow.jsx` -> ... -> `WorkspaceArea.jsx`'s `<main>`).

## Approach
The issue thread had two suggestions from maintainers after it was opened:
- @jcoyne: assign `role="region"` to the `<aside>` tag
- @lhenze: or use a different HTML tag (`section`, `div`)
- @marlo-longley: "Developer action: chose one of the ideas above and implement."

I went with `role="region"` rather than physically hoisting the `<aside>` out of `<main>` in the DOM. Structurally, `CompanionWindow`'s `<aside>` is wired up several layers deep via absolute/flex positioning, `react-rnd` drag-resize, and animation (`WorkspaceArea.jsx` -> `ViewerArea` styled as `main` -> `Workspace` -> `WorkspaceMosaic`/`Window` -> `CompanionWindow`) -- physically moving it out via a portal would have been a much higher-risk change to that resize/position/animation behavior for a landmark-only fix.

## Change
`src/components/CompanionWindow.jsx`: added `role="region"` to the root `<Paper component="aside" ...>` element (1 line). Keeps the `<aside>` tag, all CSS classes, positioning, drag/resize, and z-index untouched -- only the exposed ARIA role changes, from the implicit "complementary" (which requires top-level placement per the WAI-ARIA APG, the actual bug) to "region" (no top-level constraint, valid nested). The element already has an accessible name via `aria-label={ariaLabel || title}`, satisfying `region`'s naming requirement.

Updated 5 test files that asserted the old `complementary` role to assert `region` instead:
- `__tests__/src/components/CompanionWindow.test.jsx`
- `__tests__/src/components/CompanionArea.test.jsx` (also had to scope one assertion to `aside[role="region"]` specifically -- MUI's `Accordion` independently renders its own nested `role="region"` divs for expandable content inside the panels, so `getAllByRole('region')` was over-matching)
- `__tests__/src/components/SearchPanel.test.jsx`
- `__tests__/integration/tests/companion-windows.test.js`
- `__tests__/integration/tests/annotations.test.js`

## How I tested this
- `npm install` (this repo uses npm/package-lock.json)
- `npx vitest run __tests__/src` -- full unit suite: 176 files, 1177 tests passed, 8 skipped, 0 failed
- `npx eslint` on all changed files -- 0 errors
- `npm run lint` (full project) -- exits 0; only pre-existing i18n key-completeness warnings on unrelated locale files
- Integration tests `companion-windows.test.js`/`annotations.test.js` have 2 network-dependent failures (fetch aborts to external endpoints) in a sandboxed environment -- verified via `git stash` that these same 2 failures occur identically on unmodified `main`, i.e. pre-existing sandbox/network limitations, not caused by this change

No DOM structure, CSS, or tag-name changes -- only an ARIA attribute was added, so there's no layout or animation regression surface.

## One nuance worth flagging for review
Because MUI's `Accordion` (used inside some panel contents) already uses `role="region"` for its own expandable sections, screen-reader landmark navigation will now show nested "region" landmarks (the CompanionWindow itself, plus any accordion sections inside it). This is spec-valid (only `complementary`/`banner`/`contentinfo` require top-level placement; `region` permits nesting) but is a minor semantic wrinkle worth being aware of, since @jcoyne's suggestion vs. @lhenze's `section`/`div` alternative would behave slightly differently here.