### PR TITLE
 Fix unclickable canvas metadata links by memoizing the canvas metadata selector

### DIFF
--- a/src/containers/CanvasInfo.js
+++ b/src/containers/CanvasInfo.js
@@ -1,7 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withPlugins } from '../extend/withPlugins';
-import { getDestructuredMetadata, getCanvas, getCanvasLabel, getCanvasDescription } from '../state/selectors';
+import { getCanvasMetadata, getCanvasLabel, getCanvasDescription } from '../state/selectors';
 import { CanvasInfo } from '../components/CanvasInfo';
 
 /**
@@ -12,7 +12,7 @@ import { CanvasInfo } from '../components/CanvasInfo';
 const mapStateToProps = (state, { canvasId, companionWindowId, windowId }) => ({
   canvasDescription: getCanvasDescription(state, { canvasId, companionWindowId, windowId }),
   canvasLabel: getCanvasLabel(state, { canvasId, companionWindowId, windowId }),
-  canvasMetadata: getDestructuredMetadata(getCanvas(state, { canvasId, companionWindowId, windowId })),
+  canvasMetadata: getCanvasMetadata(state, { canvasId, companionWindowId, windowId }),
 });
 
 const enhance = compose(connect(mapStateToProps), withPlugins('CanvasInfo'));

--- a/src/state/selectors/canvases.js
+++ b/src/state/selectors/canvases.js
@@ -7,7 +7,7 @@ import { miradorSlice, EMPTY_ARRAY } from './utils';
 import { getWindow } from './getters';
 import { getSequence } from './sequences';
 import { getWindowViewType } from './windows';
-import { getManifestLocale } from './manifests';
+import { getManifestLocale, getDestructuredMetadata } from './manifests';
 
 /**
  * Returns the info response.
@@ -148,6 +148,19 @@ export const getPreviousCanvasGrouping = createSelector([getCanvasGroupings, get
 export const getCanvasLabel = createSelector(
   [getCanvas, getManifestLocale],
   (canvas, locale) => canvas && (canvas.getLabel().length > 0 ? canvas.getLabel().getValue(locale) : String(canvas.index + 1)),
+);
+
+/**
+ * Return canvas metadata in a label / value structure
+ * @param {object} state
+ * @param {object} props
+ * @param {string} props.canvasId
+ * @param {string} props.windowId
+ * @returns {Array[Object]}
+ */
+export const getCanvasMetadata = createSelector(
+  [getCanvas, getManifestLocale],
+  (canvas, locale) => canvas && getDestructuredMetadata(canvas, locale),
 );
 
 /**


### PR DESCRIPTION
Closes #4391 4391
