### PR TITLE
Ignore non-quick touch/pen gestures over annotations in onCanvasClick

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.jsx
+++ b/__tests__/src/components/AnnotationsOverlay.test.jsx
@@ -240,6 +240,96 @@ describe('AnnotationsOverlay', () => {
 
       expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
     });
+
+    it('ignores a non-quick touch gesture (pinch/pan) over an annotation', () => {
+      const selectAnnotation = vi.fn();
+
+      const { viewer } = createWrapper({
+        annotations: [
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
+                '@id': 'http://example.org/identifier/annotation/anno-line',
+                '@type': 'oa:Annotation',
+                motivation: 'sc:painting',
+                on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+              },
+            ],
+          }),
+        ],
+        selectAnnotation,
+      });
+
+      viewer.raiseEvent('canvas-click', {
+        eventSource: { viewport: viewer.viewport },
+        isTouchEvent: true,
+        position: new OpenSeadragon.Point(101, 101),
+        quick: false,
+      });
+
+      expect(selectAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('ignores a non-quick pen gesture over an annotation', () => {
+      const selectAnnotation = vi.fn();
+
+      const { viewer } = createWrapper({
+        annotations: [
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
+                '@id': 'http://example.org/identifier/annotation/anno-line',
+                '@type': 'oa:Annotation',
+                motivation: 'sc:painting',
+                on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+              },
+            ],
+          }),
+        ],
+        selectAnnotation,
+      });
+
+      viewer.raiseEvent('canvas-click', {
+        eventSource: { viewport: viewer.viewport },
+        originalEvent: { pointerType: 'pen' },
+        position: new OpenSeadragon.Point(101, 101),
+        quick: false,
+      });
+
+      expect(selectAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('still selects on a quick touch tap over an annotation', () => {
+      const selectAnnotation = vi.fn();
+
+      const { viewer } = createWrapper({
+        annotations: [
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
+                '@id': 'http://example.org/identifier/annotation/anno-line',
+                '@type': 'oa:Annotation',
+                motivation: 'sc:painting',
+                on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+              },
+            ],
+          }),
+        ],
+        selectAnnotation,
+      });
+
+      viewer.raiseEvent('canvas-click', {
+        eventSource: { viewport: viewer.viewport },
+        isTouchEvent: true,
+        position: new OpenSeadragon.Point(101, 101),
+        quick: true,
+      });
+
+      expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
+    });
   });
 
   describe('onCanvasMouseMove', () => {

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -129,6 +129,18 @@ export function AnnotationsOverlay({
 
   const onCanvasClick = useCallback(
     (event) => {
+      // OpenSeadragon fires canvas-click at the end of touch/pen gestures
+      // too (pinch-zoom, pan, press-and-hold), not just quick taps.
+      // event.quick === false means the pointer was down for a "slow"
+      // gesture rather than a tap, so treat that as a non-click -- otherwise
+      // panning or pinch-zooming over an annotation toggles its selection
+      // the moment the finger lifts. See:
+      // https://openseadragon.github.io/docs/OpenSeadragon.Viewer.html#.event:canvas-click
+      const pointerType = event.originalEvent?.pointerType;
+      if ((event.isTouchEvent || pointerType === 'touch' || pointerType === 'pen') && event.quick === false) {
+        return;
+      }
+
       const {
         position: webPosition,
         eventSource: { viewport },


### PR DESCRIPTION
## Summary
Closes #4184.

OpenSeadragon fires `canvas-click` at the end of touch/pen gestures too, not just quick taps -- a pinch-zoom or pan over an annotation was being interpreted as a click the moment the finger lifted, toggling the annotation's selection.

## Fix
`canvas-click` carries `event.quick` (`false` for a "slow" gesture) and `event.isTouchEvent` / `event.originalEvent.pointerType`, which distinguish a real tap from a gesture ([docs](https://openseadragon.github.io/docs/OpenSeadragon.Viewer.html#.event:canvas-click)). Added the maintainer-approved early exit from the issue thread: skip toggling selection when `(isTouchEvent || pointerType is touch/pen) && quick === false`.

## Tests
Added 3 tests to `AnnotationsOverlay.test.jsx`:
- a non-quick touch gesture over an annotation doesn't select it
- a non-quick pen gesture over an annotation doesn't select it
- a genuine quick touch tap still selects, same as before

Confirmed these are real regression tests, not just passing coincidentally: reverting the fix makes the two "ignores" tests fail (`selectAnnotation` gets called when it shouldn't).

## How I tested this
- `npx vitest run __tests__/src` -- 176 files, 1181 tests passed, 8 skipped (pre-existing, network-dependent, unrelated to this change)
- `npx eslint` on both changed files -- clean

Developer checklist from the issue:
- [x] Add the suggested early-exit condition
- [x] Write a test for this
- [x] Test manually -- via the added Testing Library tests exercising the real `onCanvasClick` handler through `viewer.raiseEvent('canvas-click', ...)`, same pattern as the existing tests in this file