### PR TITLE
Reorder canvas nav controls: prev/next before zoom controls

### DIFF
--- a/__tests__/src/components/WindowCanvasNavigationControls.test.jsx
+++ b/__tests__/src/components/WindowCanvasNavigationControls.test.jsx
@@ -40,4 +40,10 @@ describe('WindowCanvasNavigationControls', () => {
     expect(screen.getByRole('button', { name: 'Zoom out' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reset zoom' })).toBeInTheDocument();
   });
+
+  it('orders the nav controls before the zoom controls (issue #3190)', () => {
+    render(<Subject showZoomControls />);
+    const labels = screen.getAllByRole('button').map((button) => button.getAttribute('aria-label'));
+    expect(labels).toEqual(['Previous item', 'Next item', 'Zoom in', 'Zoom out', 'Reset zoom']);
+  });
 });

--- a/src/components/WindowCanvasNavigationControls.jsx
+++ b/src/components/WindowCanvasNavigationControls.jsx
@@ -68,8 +68,8 @@ export const WindowCanvasNavigationControls = forwardRef(
           divider={<Divider orientation={canvasNavControlsAreStacked ? 'horizontal' : 'vertical'} variant="middle" flexItem />}
           spacing={0}
         >
-          {showZoomControls && <ZoomControls windowId={windowId} zoomToWorld={zoomToWorld} />}
           <ViewerNavigation windowId={windowId} />
+          {showZoomControls && <ZoomControls windowId={windowId} zoomToWorld={zoomToWorld} />}
         </Stack>
         <ViewerInfo windowId={windowId} />
 


### PR DESCRIPTION
## Summary
Closes #3190.

Swaps the two control groups in `WindowCanvasNavigationControls`' `Stack` so navigation (Previous/Next item) renders before the zoom controls, matching the order the maintainers settled on in the issue thread ([comment](https://github.com/ProjectMirador/mirador/issues/3190#issuecomment-653164913), re-affirmed [here](https://github.com/ProjectMirador/mirador/issues/3190#issuecomment-4937660711)):

```
[ Previous item | Next item ][ Zoom in | Zoom out | Reset zoom ]
```

(previously zoom controls came first). The internal order within each group is unchanged -- `ZoomControls` already renders zoom in, zoom out, reset zoom in that order, matching what was requested.

## Change
One-line swap in `src/components/WindowCanvasNavigationControls.jsx` -- `ViewerNavigation` now renders before the conditional `ZoomControls`.

## Tests
Added a test asserting the full button order via `aria-label`. Confirmed it's a genuine regression test: reverting the swap makes it fail (previous/next end up after the zoom buttons instead of before).

## How I tested this
- `npx vitest run __tests__/src` -- 176 files, 1179 tests passed, 8 skipped (pre-existing, unrelated to this change)
- `npx eslint` on both changed files -- clean