### PR TITLE
Convert ThumbnailCanvasGrouping to a functional component

### DIFF
--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.jsx
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.jsx
@@ -36,10 +36,6 @@ describe('ThumbnailCanvasGrouping', () => {
     setCanvas = vi.fn();
     wrapper = createWrapper({ setCanvas });
   });
-  const spyCurrentCanvasClass = vi.spyOn(ThumbnailCanvasGrouping.prototype, 'currentCanvasClass');
-  afterEach(() => {
-    spyCurrentCanvasClass.mockClear();
-  });
   it('renders', () => {
     expect(screen.getByRole('gridcell')).toBeInTheDocument();
   });
@@ -51,9 +47,9 @@ describe('ThumbnailCanvasGrouping', () => {
     const user = userEvent.setup();
     wrapper = createWrapper({ index: 0, setCanvas });
     // eslint-disable-next-line testing-library/no-node-access
-    await user.click(wrapper.container.querySelector('.mirador-thumbnail-nav-canvas-0'));
-    expect(spyCurrentCanvasClass).toHaveBeenCalledWith([0]);
-    expect(spyCurrentCanvasClass).toHaveReturnedWith('current-canvas-grouping');
+    const canvasButton = wrapper.container.querySelector('.mirador-thumbnail-nav-canvas-0');
+    expect(canvasButton).toHaveClass('mirador-current-canvas-grouping');
+    await user.click(canvasButton);
     expect(setCanvas).toHaveBeenCalledWith('http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json');
   });
   describe('attributes based off far-bottom position', () => {

--- a/src/components/ThumbnailCanvasGrouping.jsx
+++ b/src/components/ThumbnailCanvasGrouping.jsx
@@ -1,4 +1,4 @@
-import { PureComponent } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import classNames from 'classnames';
@@ -12,107 +12,107 @@ const StyledCanvas = styled('div')(({ theme }) => ({
   display: 'inline-block',
   whiteSpace: 'nowrap',
 }));
+
+/**
+ * Determines whether the current index is the rendered canvas, providing
+ * a useful class.
+ * @private
+ */
+function currentCanvasClass(index, canvasIndices) {
+  if (canvasIndices.includes(index)) return 'current-canvas-grouping';
+  return '';
+}
+
 /** */
-export class ThumbnailCanvasGrouping extends PureComponent {
-  /** */
-  constructor(props) {
-    super(props);
-    this.setCanvas = this.setCanvas.bind(this);
+export function ThumbnailCanvasGrouping({
+  index = undefined,
+  columnIndex = undefined,
+  style,
+  canvasGroupings,
+  position,
+  height,
+  currentCanvasId,
+  showThumbnailLabels,
+  setCanvas,
+}) {
+  const handleSetCanvas = useCallback((e) => setCanvas(e.currentTarget.dataset.canvasId), [setCanvas]);
+
+  // For Grid (horizontal), use columnIndex; for List (vertical), use index
+  const itemIndex = columnIndex !== undefined ? columnIndex : index;
+  const currentGroupings = canvasGroupings[itemIndex];
+  const SPACING = 12;
+
+  // In react-window v2 Grid (horizontal layout), columnWidth is passed as style.height
+  // For List (vertical layout), rowHeight is passed as style.height
+  const isHorizontal = position === 'far-bottom';
+  let calculatedWidth = null;
+  if (isHorizontal && style.height) {
+    calculatedWidth = style.height - SPACING;
+  } else if (Number.isInteger(style.width)) {
+    calculatedWidth = style.width - SPACING;
   }
 
-  /** */
-  setCanvas(e) {
-    const { setCanvas } = this.props;
-    setCanvas(e.currentTarget.dataset.canvasId);
-  }
+  const isSelected = currentGroupings.map((canvas) => canvas.id).includes(currentCanvasId);
 
-  /**
-   * Determines whether the current index is the rendered canvas, providing
-   * a useful class.
-   */
-  currentCanvasClass(canvasIndices) {
-    const { index } = this.props;
-    if (canvasIndices.includes(index)) return 'current-canvas-grouping';
-    return '';
-  }
-
-  /** */
-  render() {
-    const { index, columnIndex, style, canvasGroupings, position, height, currentCanvasId, showThumbnailLabels } = this.props;
-    // For Grid (horizontal), use columnIndex; for List (vertical), use index
-    const itemIndex = columnIndex !== undefined ? columnIndex : index;
-    const currentGroupings = canvasGroupings[itemIndex];
-    const SPACING = 12;
-
-    // In react-window v2 Grid (horizontal layout), columnWidth is passed as style.height
-    // For List (vertical layout), rowHeight is passed as style.height
-    const isHorizontal = position === 'far-bottom';
-    let calculatedWidth = null;
-    if (isHorizontal && style.height) {
-      calculatedWidth = style.height - SPACING;
-    } else if (Number.isInteger(style.width)) {
-      calculatedWidth = style.width - SPACING;
-    }
-
-    const isSelected = currentGroupings.map((canvas) => canvas.id).includes(currentCanvasId);
-
-    return (
-      <div
-        style={{
-          ...style,
-          boxSizing: 'content-box',
-          height: Number.isInteger(style.height) ? style.height - SPACING : null,
-          left: Number.isInteger(style.left) ? style.left + SPACING / 2 : null,
-          padding: SPACING / 2,
-          top: Number.isInteger(style.top) ? style.top + SPACING / 2 : null,
-          width: calculatedWidth,
-        }}
-        className={ns('thumbnail-nav-container')}
-        role="gridcell"
-        aria-selected={isSelected}
-        aria-colindex={itemIndex + 1}
+  return (
+    <div
+      style={{
+        ...style,
+        boxSizing: 'content-box',
+        height: Number.isInteger(style.height) ? style.height - SPACING : null,
+        left: Number.isInteger(style.left) ? style.left + SPACING / 2 : null,
+        padding: SPACING / 2,
+        top: Number.isInteger(style.top) ? style.top + SPACING / 2 : null,
+        width: calculatedWidth,
+      }}
+      className={ns('thumbnail-nav-container')}
+      role="gridcell"
+      aria-selected={isSelected}
+      aria-colindex={itemIndex + 1}
+    >
+      <StyledCanvas
+        role="button"
+        data-canvas-id={currentGroupings[0].id}
+        data-canvas-index={currentGroupings[0].index}
+        onClick={handleSetCanvas}
+        tabIndex={-1}
+        sx={(theme) => ({
+          '&:not(:hover)': {
+            outline: isSelected ? `2px solid ${theme.palette.primary.main}` : 0,
+            ...(isSelected && {
+              outlineOffset: '3px',
+            }),
+          },
+          '&:hover': {
+            outline: isSelected ? `2px solid ${theme.palette.primary.main}` : `2px solid ${theme.palette.action.hover}`,
+            outlineOffset: isSelected ? '3px' : '-2px',
+          },
+          height: position === 'far-right' ? 'auto' : `${height - SPACING}px`,
+          width: position === 'far-bottom' ? 'auto' : `${style.width}px`,
+        })}
+        className={classNames(
+          ns([
+            'thumbnail-nav-canvas',
+            `thumbnail-nav-canvas-${itemIndex}`,
+            currentCanvasClass(
+              index,
+              currentGroupings.map((canvas) => canvas.index),
+            ),
+          ]),
+        )}
       >
-        <StyledCanvas
-          role="button"
-          data-canvas-id={currentGroupings[0].id}
-          data-canvas-index={currentGroupings[0].index}
-          onClick={this.setCanvas}
-          tabIndex={-1}
-          sx={(theme) => ({
-            '&:not(:hover)': {
-              outline: isSelected ? `2px solid ${theme.palette.primary.main}` : 0,
-              ...(isSelected && {
-                outlineOffset: '3px',
-              }),
-            },
-            '&:hover': {
-              outline: isSelected ? `2px solid ${theme.palette.primary.main}` : `2px solid ${theme.palette.action.hover}`,
-              outlineOffset: isSelected ? '3px' : '-2px',
-            },
-            height: position === 'far-right' ? 'auto' : `${height - SPACING}px`,
-            width: position === 'far-bottom' ? 'auto' : `${style.width}px`,
-          })}
-          className={classNames(
-            ns([
-              'thumbnail-nav-canvas',
-              `thumbnail-nav-canvas-${itemIndex}`,
-              this.currentCanvasClass(currentGroupings.map((canvas) => canvas.index)),
-            ]),
-          )}
-        >
-          {currentGroupings.map((canvas, i) => (
-            <IIIFThumbnail
-              key={canvas.id}
-              resource={canvas}
-              labelled={showThumbnailLabels}
-              maxHeight={position === 'far-right' ? style.height - 1.5 * SPACING : height - 1.5 * SPACING}
-              variant="inside"
-            />
-          ))}
-        </StyledCanvas>
-      </div>
-    );
-  }
+        {currentGroupings.map((canvas) => (
+          <IIIFThumbnail
+            key={canvas.id}
+            resource={canvas}
+            labelled={showThumbnailLabels}
+            maxHeight={position === 'far-right' ? style.height - 1.5 * SPACING : height - 1.5 * SPACING}
+            variant="inside"
+          />
+        ))}
+      </StyledCanvas>
+    </div>
+  );
 }
 
 ThumbnailCanvasGrouping.propTypes = {
@@ -125,9 +125,4 @@ ThumbnailCanvasGrouping.propTypes = {
   setCanvas: PropTypes.func.isRequired,
   showThumbnailLabels: PropTypes.bool.isRequired,
   style: PropTypes.object.isRequired,
-};
-
-ThumbnailCanvasGrouping.defaultProps = {
-  columnIndex: undefined,
-  index: undefined,
 };


### PR DESCRIPTION
Closes #4370

## What

`ThumbnailCanvasGrouping` was the last remaining class component under `src/` (a `PureComponent`). Converted it to a plain function component matching the rest of the codebase's current style — destructured props with default values instead of static `defaultProps`, `useCallback` for the click handler.

`currentCanvasClass()` didn't use `this` for anything, so it's now a top-level pure helper function instead of an instance method.

## Test change

The existing test spied on `ThumbnailCanvasGrouping.prototype.currentCanvasClass`, which doesn't exist on a function component (no prototype with instance methods). Replaced that with a behavioral assertion — checking the rendered element actually has the `current-canvas-grouping` class after the relevant click — which is arguably a better test anyway since it verifies observable behavior rather than an implementation detail.

## Testing

- `ThumbnailCanvasGrouping.test.jsx` — 5/5 pass
- `ThumbnailNavigation.test.jsx` — 15/15 pass (exercises this component inside the real virtualized list/grid, so this covers both the Grid and List usage paths)
- `eslint` clean on both changed files