### PR TITLE
Remove unused workspace.exposeModeOn config option

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -540,7 +540,6 @@ export default {
   workspace: {
     allowNewWindows: true,
     draggingEnabled: true,
-    exposeModeOn: false, // unused?
     height: 5000, // height of the elastic mode's virtual canvas
     id: uuid(),
     isWorkspaceAddVisible: false, // Catalog/Workspace add window feature visible by default


### PR DESCRIPTION
Closes #4387

## What

Removed `workspace.exposeModeOn` from `src/config/settings.js`. It was already marked `// unused?` in the source, and a repo-wide search confirms there are no other references anywhere — no reads of `config.workspace.exposeModeOn`, no PropTypes, no docs. As noted in the issue, it looks like a leftover from the original Elastic mode design (#1839), which described an "Expose all windows" feature that was never implemented.

## Testing

Ran the tests that actually exercise `config/settings.js`: `reducers/config.test.js`, `AppProviders.test.jsx`, `FailedImageProvider.test.jsx` — 15/15 pass, no fallout from the removal.