### PR TITLE
Restore blue open-window indicator bar in the catalog

### DIFF
--- a/__tests__/src/components/ManifestListItem.test.jsx
+++ b/__tests__/src/components/ManifestListItem.test.jsx
@@ -33,6 +33,16 @@ describe('ManifestListItem', () => {
 
     expect(screen.getByRole('listitem')).toHaveClass('active');
   });
+  it('shows the blue open-window indicator bar when active', () => {
+    createWrapper({ active: true });
+
+    expect(screen.getByRole('listitem')).toHaveStyle({ borderLeftColor: '#1967d2' });
+  });
+  it('does not show the indicator bar when not active', () => {
+    createWrapper({ active: false });
+
+    expect(screen.getByRole('listitem')).toHaveStyle({ borderLeftColor: 'transparent' });
+  });
   it('renders a placeholder element until real data is available', () => {
     const { container } = createWrapper({ ready: false });
 

--- a/src/components/ManifestListItem.jsx
+++ b/src/components/ManifestListItem.jsx
@@ -107,6 +107,7 @@ export function ManifestListItem({
 
   return (
     <Root
+      ownerState={ownerState}
       divider
       selected={active}
       className={active ? 'active' : ''}


### PR DESCRIPTION
Closes #4351

## Root cause

Bisected this to 9444d3bb \"Convert some class components to functions.\" (Nov 2024), which split `ManifestListItem`'s single `render()` into two early-return JSX branches (error vs. ready/not-ready). The error branch kept `ownerState={ownerState}` on `<Root>`, but the main branch lost it — `data-active={active}` was added there instead, which is just a DOM attribute and doesn't feed the styled-component's CSS.

`Root`'s `borderLeftColor` is `ownerState?.active ? theme.palette.primary.main : 'transparent'`. Since the main branch's `<Root>` receives no `ownerState` prop at all, that expression is always `undefined?.active` → always falsy, so the blue indicator bar for the currently-open-window's catalog entry never renders — regardless of the actual active state. This is a silent regression: `active` is still correctly computed and used elsewhere in the same render (the `selected`/`active` class, `data-active`), it just never reaches `ownerState` for the style function to read.

## Fix

Add `ownerState={ownerState}` to the main branch's `<Root>`, mirroring the error branch exactly. One line.

## Test

The existing "adds a class when the item is active" test only checked `data-active` and the `active` class name — both of which stayed correct even with the bug, which is exactly why this slipped through unnoticed for almost a year. Added a regression test that asserts the actual computed `borderLeftColor` instead.

Verified with `git stash` that the new test fails against the pre-fix code (expects `#1967d2`, the theme's primary color, gets nothing) and passes with the fix applied. Full `ManifestListItem.test.jsx`: 11/11 pass. `eslint` clean on both changed files.