### PR TITLE
Give CompanionWindow's <aside> an explicit region role

### DIFF
--- a/__tests__/integration/tests/annotations.test.js
+++ b/__tests__/integration/tests/annotations.test.js
@@ -44,7 +44,7 @@ describe('Annotations in Mirador', () => {
 
     // use safeFindByRole here. This specific test is consistently hard to interpret on failure,
     // since another async operation has happened after setupIntegrationTestViewer
-    const annotationPanel = await safeFindByRole('complementary', { name: /annotations/i });
+    const annotationPanel = await safeFindByRole('region', { name: /annotations/i });
     expect(annotationPanel).toBeInTheDocument();
 
     const listItems = await within(annotationPanel).findAllByRole('menuitem');

--- a/__tests__/integration/tests/companion-windows.test.js
+++ b/__tests__/integration/tests/companion-windows.test.js
@@ -11,19 +11,19 @@ describe('Basic end to end Mirador', () => {
     fireEvent.click(toggleButtons[0]);
 
     // Companion window is on the left
-    expect(await screen.findByRole('complementary', { name: /About this item/i })).toHaveClass('mirador-companion-window-left');
+    expect(await screen.findByRole('region', { name: /About this item/i })).toHaveClass('mirador-companion-window-left');
 
     const openButton = screen.getByRole('button', { name: /Open in separate panel/i });
     fireEvent.click(openButton);
 
     // Companion window is on the right
-    expect(await screen.findByRole('complementary', { name: /About this item/i })).toHaveClass('mirador-companion-window-right');
+    expect(await screen.findByRole('region', { name: /About this item/i })).toHaveClass('mirador-companion-window-right');
 
     // Close the panel
     const closeButton = screen.getByRole('button', { name: /Close panel/i });
     fireEvent.click(closeButton);
 
     // The companion window is removed
-    expect(screen.queryByRole('complementary', { name: /About this item/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /About this item/i })).not.toBeInTheDocument();
   });
 });

--- a/__tests__/src/components/CompanionArea.test.jsx
+++ b/__tests__/src/components/CompanionArea.test.jsx
@@ -27,7 +27,11 @@ describe('CompanionArea', () => {
   it('should render all <CompanionWindow>', () => {
     createWrapper();
 
-    expect(screen.getAllByRole('complementary')).toHaveLength(2);
+    // Scoped to <aside> specifically: MUI's Accordion also renders its own
+    // (unrelated) role="region" divs internally, so an unscoped role query
+    // would overcount -- CompanionWindow's own landmark is always an <aside>.
+    const regions = screen.getAllByRole('region').filter((el) => el.tagName === 'ASIDE');
+    expect(regions).toHaveLength(2);
   });
 
   it('should add the appropriate classes when the companion area fills the full width', () => {
@@ -56,7 +60,7 @@ describe('CompanionArea', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Expand sidebar' })).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Expand sidebar' }));
 

--- a/__tests__/src/components/CompanionWindow.test.jsx
+++ b/__tests__/src/components/CompanionWindow.test.jsx
@@ -15,12 +15,12 @@ describe('CompanionWindow', () => {
     it('has an aria-label for the landmark derived from the title', () => {
       createWrapper({ title: 'some title' });
 
-      expect(screen.getByRole('complementary')).toHaveAccessibleName('some title');
+      expect(screen.getByRole('region')).toHaveAccessibleName('some title');
     });
     it('can be overridden with an explicit ariaLabel prop', () => {
       createWrapper({ ariaLabel: 'some label', title: 'some title' });
 
-      expect(screen.getByRole('complementary')).toHaveAccessibleName('some label');
+      expect(screen.getByRole('region')).toHaveAccessibleName('some label');
     });
   });
 
@@ -89,7 +89,7 @@ describe('CompanionWindow', () => {
         updateCompanionWindow,
       });
 
-      expect(screen.getByRole('complementary')).toHaveClass('mirador-companion-window-right');
+      expect(screen.getByRole('region')).toHaveClass('mirador-companion-window-right');
 
       await user.click(screen.getByRole('button', { name: 'Move to bottom' }));
 
@@ -107,7 +107,7 @@ describe('CompanionWindow', () => {
         updateCompanionWindow,
       });
 
-      expect(screen.getByRole('complementary')).toHaveClass('mirador-companion-window-bottom ');
+      expect(screen.getByRole('region')).toHaveClass('mirador-companion-window-bottom ');
 
       await user.click(screen.getByRole('button', { name: 'Move to right' }));
 

--- a/__tests__/src/components/SearchPanel.test.jsx
+++ b/__tests__/src/components/SearchPanel.test.jsx
@@ -23,7 +23,7 @@ function createWrapper(props) {
 describe('SearchPanel', () => {
   it('renders a CompanionWindow', () => {
     createWrapper();
-    expect(screen.getByRole('complementary')).toBeInTheDocument();
+    expect(screen.getByRole('region')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Search' })).toBeInTheDocument();
   });
 

--- a/src/components/CompanionWindow.jsx
+++ b/src/components/CompanionWindow.jsx
@@ -126,6 +126,7 @@ export const CompanionWindow = forwardRef((props, innerRef) => {
       ].join(' ')}
       square
       component="aside"
+      role="region"
       aria-label={ariaLabel || title}
     >
       <LocaleContext.Provider value={locale}>


### PR DESCRIPTION
Closes #4225

## Problem

The sliding panels ("about this item", "rights", "index", search, annotations, etc.) render as `<aside>` (`src/components/CompanionWindow.jsx`), which has an implicit ARIA `complementary` landmark role. Per the WAI-ARIA APG, complementary landmarks are only valid as a **top-level** landmark (a sibling of `main`), not nested inside it — and `CompanionWindow` is always rendered inside `WorkspaceArea`'s `<main>` (`ViewerArea`), so every companion window panel was a landmark-nesting violation.

## Fix

Per the issue's own suggested options: kept the `<aside>` element, added `role="region"` to override its implicit landmark role. `region` is an ARIA-in-HTML-permitted role override for `<aside>`, is valid when nested inside `main` (unlike `complementary`), and `CompanionWindow` already provides an accessible name via `aria-label={ariaLabel || title}`, which is exactly what a region landmark needs to be meaningful to assistive tech.

## Test fallout

Updated 5 test files that queried for the old `'complementary'` role (11 assertions total, across `CompanionWindow.test.jsx`, `CompanionArea.test.jsx`, `SearchPanel.test.jsx`, `companion-windows.test.js`, `annotations.test.js`) to query `'region'` instead.

One of those (`CompanionArea.test.jsx`) needed more than a search-and-replace: MUI's `Accordion` component also renders its own unrelated `role="region"` divs internally (for its expandable content area), so an unscoped `getAllByRole('region')` now overcounts (found 4 instead of 2 when I ran it). Scoped that one assertion to `<aside>` elements specifically, since `CompanionWindow`'s own landmark is always an `<aside>` and MUI's Accordion regions aren't.

## Testing

Ran the full suite before and after (`git stash`): identical results except for this change — the same 7 pre-existing failures exist on unmodified `main` (unrelated integration tests, nothing to do with landmark roles or `CompanionWindow`). The files this PR actually touches are fully green: 34 tests, 0 failures. `eslint` clean.