### PR TITLE
Fix silent authentication for the IIIF external auth profile

### DIFF
--- a/__tests__/src/components/IIIFAuthentication.test.jsx
+++ b/__tests__/src/components/IIIFAuthentication.test.jsx
@@ -127,5 +127,13 @@ describe('IIIFAuthentication', () => {
         }),
       );
     });
+    it('renders a logout button for a non-interactive service with a logout service', () => {
+      createWrapper({ isInteractive: false, logoutConfirm: 'exit', status: 'ok' });
+      expect(screen.getByRole('button', { name: 'exit' })).toBeInTheDocument();
+    });
+    it('renders nothing for a non-interactive service without a logout service', () => {
+      createWrapper({ isInteractive: false, logoutServiceId: null, status: 'ok' });
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
   });
 });

--- a/__tests__/src/sagas/auth.test.js
+++ b/__tests__/src/sagas/auth.test.js
@@ -196,6 +196,13 @@ describe('IIIF Authentication sagas', () => {
         ])
         .put({
           id: 'https://authentication.example.com/external',
+          profile: 'http://iiif.io/api/auth/1/external',
+          type: ActionTypes.ADD_AUTHENTICATION_REQUEST,
+          windowId,
+        })
+        .put({
+          id: 'https://authentication.example.com/external',
+          ok: true,
           tokenServiceId: 'https://authentication.example.com/token',
           type: ActionTypes.RESOLVE_AUTHENTICATION_REQUEST,
         })

--- a/src/components/IIIFAuthentication.jsx
+++ b/src/components/IIIFAuthentication.jsx
@@ -52,7 +52,7 @@ export function IIIFAuthentication({
 
   /** Render the auth bar for logged in users */
   const renderLoggedIn = () => {
-    if (!isInteractive) return null;
+    if (!isInteractive && !logoutServiceId) return null;
 
     return (
       <WindowAuthenticationBar

--- a/src/state/sagas/auth.js
+++ b/src/state/sagas/auth.js
@@ -83,8 +83,10 @@ export function* doAuthWorkflow({ infoJson, windowId }) {
       Utils.getService(authService, 'http://iiif.io/api/auth/0/token');
 
     if (!tokenService) return;
+    // start the auth
+    yield put(addAuthenticationRequest(windowId, authService.id, authService.getProfile()));
     // resolve the auth
-    yield put(resolveAuthenticationRequest(authService.id, tokenService.id));
+    yield put(resolveAuthenticationRequest(authService.id, tokenService.id, { ok: true }));
     // start access tokens
     yield put(requestAccessToken(tokenService.id, authService.id));
   }


### PR DESCRIPTION
## Summary

The IIIF Auth 1.0 `external` (non-interactive) profile is currently non-functional: an `info.json` that advertises an `external` auth service never results in a token request, so a user who already holds a valid auth cookie is never silently authenticated. The interactive `login` profile is unaffected and works as before.

Three independent gates each stop the flow, and fixing any one or two of them produces no visible change — which is likely why this has gone unnoticed. Three lines of production code:

| # | File | Change |
|---|---|---|
| 1 | `src/state/sagas/auth.js` | record a `windowId` in the `external` branch |
| 2 | `src/state/sagas/auth.js` | pass `{ ok: true }` when resolving |
| 3 | `src/components/IIIFAuthentication.jsx` | don't suppress the auth bar when a logout service exists |

## The three gates

### 1. The `external` branch never records a `windowId`

`containers/IIIFAuthentication` only derives `status === 'token'` — the status that mounts `AccessTokenSender` and actually performs the token request — when the auth record carries a `windowId` matching the current window:

```js
} else if (accessTokenStatus && accessTokenStatus.isFetching) {
  if (authStatus.windowId === windowId) status = 'token';
}
```

The `kiosk` branch of `doAuthWorkflow` records one via `addAuthenticationRequest(windowId, …)`. The `external` branch goes straight to `resolveAuthenticationRequest`, so `authStatus.windowId` is `undefined`, the iframe never mounts, and `accessTokens[tokenId].isFetching` stays `true` indefinitely. No token request is ever issued.

### 2. `ok` is left `undefined`, so the service is dropped from selection

Fixing (1) alone changes nothing, because the service the container is looking at is chosen by `selectCurrentAuthServices`, which keeps a service only while it is untried, fetching, or `ok`:

```js
if (!auth[service.id] || auth[service.id].isFetching || auth[service.id].ok) return service;
```

`resolveAuthenticationRequest(id, tokenServiceId, props)` spreads its third argument, and the external branch omits it, so the reducer's `ok: action.ok` stores `undefined`. The external service fails all three conditions the moment it resolves; selection falls through to another service, and the `windowId` recorded in (1) belongs to a service nobody is reading.

Passing `{ ok: true }` keeps it selected. This mirrors `invalidateInvalidAuth`, which already uses the same third argument with `{ ok: false }` — so this is the existing mechanism, not a new one.

### 3. The auth bar is suppressed for non-interactive profiles

With (1) and (2) the token request fires and gated content loads, but **no auth bar renders at all** — neither Login nor Logout. `renderLoggedIn` begins:

```js
if (!isInteractive) return null;
```

`external` is non-interactive, so the `'ok'` state renders nothing, leaving an authenticated user with no way to log out.

The intent of that guard is reasonable — a non-interactive profile usually has no action for the user to take. But that isn't true when the service advertises a `logout` service, so the condition is widened:

```js
if (!isInteractive && !logoutServiceId) return null;
```

`logoutServiceId` is derived from the selected service, so this only takes effect for an `external` service that advertises its own logout service. Behavior for non-interactive services without one is unchanged.

## Testing

- `__tests__/src/sagas/auth.test.js` — the existing `kicks off the first external auth from the info.json` test asserts the exact `RESOLVE_AUTHENTICATION_REQUEST` action shape, so it required updating for `{ ok: true }`; the `ADD_AUTHENTICATION_REQUEST` assertion is added to the same test rather than duplicating it.
- `__tests__/src/components/IIIFAuthentication.test.jsx` — two cases: a non-interactive service **with** a logout service renders the logout button, and **without** one still renders nothing.

Each test was checked against a reverted fix to confirm it fails without the corresponding change. Full suite: 1203 passing, 12 skipped. `prettier --check` and `eslint` clean.

## Reproducing

Serve an `info.json` that returns `401` and advertises an `external` auth service carrying a `token` sub-service (and a `logout` sub-service, to observe gate 3):

```json
{
  "@context": "http://iiif.io/api/auth/1/context.json",
  "@id": "https://example.org/auth/token",
  "profile": "http://iiif.io/api/auth/1/external",
  "label": "Institutional access",
  "service": [
    { "@id": "https://example.org/auth/logout", "profile": "http://iiif.io/api/auth/1/logout", "label": "Log out" },
    { "@id": "https://example.org/auth/token", "profile": "http://iiif.io/api/auth/1/token" }
  ]
}
```

With a valid auth cookie, load a window on that resource. Before this change no request is made to the token service and `accessTokens[tokenId].isFetching` remains `true`. After, the token is fetched on load, the degraded info response is replaced, and the logout bar renders.

Screen share of the "before" behavior. A user logs in and the status bar refreshes to the "Logout button" state and the object refreshes to full resolution. However if the user refreshes the page the state is lost and the status bus goes back to the "Login" state:


https://github.com/user-attachments/assets/78c02620-775f-42f9-99eb-87a0a47be876



Screen share of the "after" behavior. A user logs in and the status bar refreshes to the "Logout button" state and the object refreshes to full resolution. If the user refreshes the page the token route is automatically called again so the "Logout Button" state stays. Additionally if the user visits a different object the same "Logout Button state remains, because token route is automatically called:


https://github.com/user-attachments/assets/0fd51cf9-1255-410e-8060-1e6b2a10c776



## Notes

Verified present in both Mirador 3 and Mirador 4 — the relevant logic is unchanged in `src/state/sagas/auth.js` since 2021 and in the authentication container since early 2025.

Gate 3 is the only change that affects rendering rather than saga behavior. If maintainers would prefer, it can be split into a separate PR, though gates 1 and 2 alone produce no user-visible result.
