### PR TITLE
guard against small thumbnails in right sidebar

### DIFF
--- a/src/components/ThumbnailNavigation.jsx
+++ b/src/components/ThumbnailNavigation.jsx
@@ -119,7 +119,8 @@ export function ThumbnailNavigation({
     const calc = Math.ceil((availableWidth * canvases.length * bounds[3]) / bounds[2]);
 
     if (!Number.isInteger(calc)) return thumbnailNavigation.height + spacing;
-    return calc + spacing;
+    // Guard against incredibly small thumbnails
+    return Math.max(calc, Math.round(thumbnailNavigation.height / 3)) + spacing;
   };
 
   /** */


### PR DESCRIPTION
Part of #3294. Design needed for when thumbnail is the super small

Before:
<img width="128" height="180" alt="Screenshot 2026-08-10 at 2 10 51 PM" src="https://github.com/user-attachments/assets/a74c51b7-3aa9-4bcf-89d4-7d3cb33b4c72" />

After:
<img width="134" height="252" alt="Screenshot 2026-08-10 at 2 11 02 PM" src="https://github.com/user-attachments/assets/9b40cd92-a97a-4c20-aaba-76098f402601" />

This does cause an issue where the thumbnail will scroll because in order to not have a horribly small height we do have to have a rather large width