### PR TITLE
Replace broken links in the auth demo page

### DIFF
--- a/__tests__/integration/mirador-configs/auth.js
+++ b/__tests__/integration/mirador-configs/auth.js
@@ -5,10 +5,18 @@ export default {
       manifestId: 'https://purl.stanford.edu/ds199xg9454/iiif/manifest',
     },
     {
-      manifestId: 'https://edsilv.github.io/test-manifests/auth1-degraded.json',
+      // Wellcome Collection exercises the same auth mechanism as a real login form,
+      // with a live clickthrough service instead of credentials-based auth.
+      // This works best for a public demo as it is institution agnostic.
+      manifestId: 'https://iiif.wellcomecollection.org/presentation/b19319174',
     },
+    // TODO: find a public replacement manifest for the degraded flow
+    // Wellcome Collections provides a manifest that can demo the standard auth flow (described above)
+    // but we need to search for a comparable public degraded image example.
+    // For now, use a Stanford image to at least demonstrate the degraded state,
+    // even if non-Stanford public can't complete the flow.
     {
-      manifestId: 'https://edsilv.github.io/test-manifests/auth1-standard.json',
+      manifestId: 'https://purl.stanford.edu/bb000cr7262/iiif/manifest',
     },
   ],
 };


### PR DESCRIPTION
This is causing https://mirador-dev.netlify.app/auth to immediately error
Here's this branch: https://deploy-preview-4429--mirador-dev.netlify.app/auth

Notes
- The Wellcome replacement uses a trigger-warning type consent model. This means we are placing possibly disturbing info into our Mirador demo. However, it is a model of auth that makes sense for a public demo. Otherwise real credentials are needed.
- I used a Stanford image for the degraded example. I can open a ticket for finding a better replacement -- but I don't know how to find one in the wild, and this seems better than an error for now.