### PR TITLE
add all svg shapes to display on annotations

### DIFF
--- a/__tests__/fixtures/version-3/0001-mvm-image.json
+++ b/__tests__/fixtures/version-3/0001-mvm-image.json
@@ -1,0 +1,43 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Single Image Example"
+    ]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+      "type": "Canvas",
+      "height": 1800,
+      "width": 1200,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                "type": "Image",
+                "format": "image/png",
+                "height": 1800,
+                "width": 1200
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"
+            }
+          ]
+        }
+      ],
+      "annotations": [{
+        "type": "AnnotationPage",
+        "id": "__tests__/fixtures/version-3/svg-annotations.json"
+      }]
+    }
+  ]
+}

--- a/__tests__/fixtures/version-3/svg-annotations.json
+++ b/__tests__/fixtures/version-3/svg-annotations.json
@@ -1,0 +1,136 @@
+{
+  "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1/page/p1",
+  "type": "AnnotationPage",
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1/058f22b4-f7d5-43e2-a9bb-12985338aae8",
+      "type": "Annotation",
+      "motivation": "commenting",
+      "body": [
+        {
+          "created": "2025-01-15T06:12:07.539Z",
+          "creator": "Rainer Simon",
+          "purpose": "commenting",
+          "type": "TextualBody",
+          "format": "text/html",
+          "value": "<p>Test (svg with 2 elements (polygon and red line))</p>"
+        }
+      ],
+      "target": {
+        "type": "SpecificResource",
+        "source": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g><line x1='242' y1='633' x2='400' y2='900' stroke='red' /><polygon points='242,633 340,552 948,1173 859,1249' /></g></svg>"
+        }
+      }
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1/0654ce3a-f0a1-4f01-9a6e-531bb62d1e3e",
+      "type": "Annotation",
+      "motivation": "commenting",
+      "body": [
+        {
+          "created": "2025-01-15T06:12:16.154Z",
+          "creator": "Rainer Simon",
+          "purpose": "commenting",
+          "type": "TextualBody",
+          "format": "text/html",
+          "value": "<p>Test (path)</p>"
+        }
+      ],
+      "target": {
+        "type": "SpecificResource",
+        "source": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g><path d='M270.000000,1900.000000 L1530.000000,1900.000000 L1530.000000,1610.000000 L1315.000000,1300.000000 L1200.000000,986.000000 L904.000000,661.000000 L600.000000,986.000000 L500.000000,1300.000000 L270,1630 L270.000000,1900.000000' /></g></svg>"
+        }
+      }
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1/anno-circle",
+      "type": "Annotation",
+      "motivation": "commenting",
+      "body": [
+        {
+          "type": "TextualBody",
+          "format": "text/html",
+          "purpose": "commenting",
+          "value": "<p>Test (circle)</p>"
+        }
+      ],
+      "target": {
+        "type": "SpecificResource",
+        "source": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg xmlns='http://www.w3.org/2000/svg'><circle cx='1050' cy='250' r='90'></circle></svg>"
+        }
+      }
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1/anno-ellipse",
+      "type": "Annotation",
+      "motivation": "commenting",
+      "body": [
+        {
+          "type": "TextualBody",
+          "format": "text/html",
+          "purpose": "commenting",
+          "value": "<p>Test (ellipse)</p>"
+        }
+      ],
+      "target": {
+        "type": "SpecificResource",
+        "source": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg xmlns='http://www.w3.org/2000/svg'><ellipse cx='1050' cy='1650' rx='130' ry='80'></ellipse></svg>"
+        }
+      }
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1/anno-rect",
+      "type": "Annotation",
+      "motivation": "commenting",
+      "body": [
+        {
+          "type": "TextualBody",
+          "format": "text/html",
+          "purpose": "commenting",
+          "value": "<p>Test (rect)</p>"
+        }
+      ],
+      "target": {
+        "type": "SpecificResource",
+        "source": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg xmlns='http://www.w3.org/2000/svg'><rect x='50' y='1500' width='180' height='120'></rect></svg>"
+        }
+      }
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1/anno-polyline",
+      "type": "Annotation",
+      "motivation": "commenting",
+      "body": [
+        {
+          "type": "TextualBody",
+          "format": "text/html",
+          "purpose": "commenting",
+          "value": "<p>Test (polyline, open path)</p>"
+        }
+      ],
+      "target": {
+        "type": "SpecificResource",
+        "source": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg xmlns='http://www.w3.org/2000/svg'><polyline points='60,300 200,220 340,340 480,260'></polyline></svg>"
+        }
+      }
+    }
+  ]
+}

--- a/__tests__/integration/mirador-configs/svg-annotations.js
+++ b/__tests__/integration/mirador-configs/svg-annotations.js
@@ -6,14 +6,11 @@ export default {
   },
   windows: [
     {
-      manifestId: 'https://collections.st-andrews.ac.uk/manifest-test/555859.json',
-    },
-    {
-      manifestId: 'https://collections.st-andrews.ac.uk/manifest-test/test-manifest.json',
-    },
-    {
       canvasIndex: 6,
       manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/748a9d50-5a3a-440e-ab9d-567dd68b6abb.json',
+    },
+    {
+      manifestId: '__tests__/fixtures/version-3/0001-mvm-image.json',
     },
   ],
 };

--- a/__tests__/src/lib/AnnotationItem.test.js
+++ b/__tests__/src/lib/AnnotationItem.test.js
@@ -1,4 +1,5 @@
 import AnnotationItem from '../../../src/lib/AnnotationItem';
+import svgAnnotations from '../../fixtures/version-3/svg-annotations.json';
 
 describe('AnnotationItem', () => {
   describe('id', () => {
@@ -139,6 +140,12 @@ describe('AnnotationItem', () => {
 
     it('specified SvgSelector', () => {
       expect(new AnnotationItem({ target: { selector: { type: 'SvgSelector' } } }).svgSelector).toEqual({ type: 'SvgSelector' });
+    });
+
+    it('svg shape SvgSelector', () => {
+      svgAnnotations.items.forEach((annotation) => {
+        expect(new AnnotationItem(annotation).svgSelector.value).toContain('<svg ');
+      });
     });
 
     it('without specified type', () => {

--- a/__tests__/src/lib/CanvasAnnotationDisplay.test.js
+++ b/__tests__/src/lib/CanvasAnnotationDisplay.test.js
@@ -34,6 +34,49 @@ describe('CanvasAnnotationDisplay', () => {
       expect(subject.svgContext).toHaveBeenCalled();
       expect(subject.fragmentContext).not.toHaveBeenCalled();
     });
+
+    it('draws every shape and sets all 6 svg shapes', () => {
+      const context = {
+        fill: vi.fn(),
+        restore: vi.fn(),
+        save: vi.fn(),
+        setLineDash: vi.fn(),
+        stroke: vi.fn(),
+        translate: vi.fn(),
+      };
+      const subject = createSubject({
+        resource: new AnnotationResource({
+          motivation: ['oa:commenting'],
+          on: {
+            selector: {
+              item: {
+                '@type': 'oa:SvgSelector',
+                value: `<svg xmlns='http://www.w3.org/2000/svg'>
+                <g>
+                  <line x1='0' y1='0' x2='300' y2='200' stroke='red' />
+                  <polygon points='242,633 340,552 948,1173 859,1249' />
+                </g>
+                <circle cx='1050' cy='250' r='90' />
+                <ellipse cx='1050' cy='1650' rx='130' ry='80' />
+                <rect x='50' y='1500' width='180' height='120' />
+                <polyline points='60,300 200,220 340,340 480,260' />
+              </svg>`,
+              },
+            },
+          },
+        }),
+      });
+      subject.context = context;
+
+      const tags = [...subject.svgPaths].map((el) => el.tagName.toLowerCase());
+      expect(tags).toEqual(['line', 'polygon', 'circle', 'ellipse', 'rect', 'polyline']);
+
+      subject.svgContext = vi.fn();
+      subject.fragmentContext = vi.fn();
+      subject.toContext(context);
+      expect(subject.svgContext).toHaveBeenCalled(6);
+      expect(subject.fragmentContext).not.toHaveBeenCalled();
+    });
     it('selects fragmentSelector if present and if no svg is present', () => {
       const context = {
         stroke: vi.fn(),

--- a/__tests__/src/lib/svgShapesToPath.test.js
+++ b/__tests__/src/lib/svgShapesToPath.test.js
@@ -1,0 +1,132 @@
+import { buildPath2D } from '../../../src/lib/svgShapesToPath';
+
+/** Creates an <svg> element and parses innerHTML into real SVG children. */
+function svgToElement(innerHTML) {
+  const el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  el.innerHTML = innerHTML;
+  return el.firstElementChild;
+}
+
+describe('svgShapesToPath', () => {
+  describe('buildPath2D', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    describe('path', () => {
+      it('builds a Path2D directly from the d attribute', () => {
+        const Path2DSpy = vi.spyOn(globalThis, 'Path2D');
+
+        const result = buildPath2D(svgToElement("<path d='M0,0 L10,10 Z' />"));
+
+        expect(Path2DSpy).toHaveBeenCalledWith('M0,0 L10,10 Z');
+        expect(result).toBeInstanceOf(Path2D);
+      });
+    });
+
+    describe('circle', () => {
+      it('draws an arc using cx, cy, and r', () => {
+        const arcSpy = vi.spyOn(Path2D.prototype, 'arc');
+
+        buildPath2D(svgToElement("<circle cx='10' cy='20' r='5' />"));
+
+        expect(arcSpy).toHaveBeenCalledWith(10, 20, 5, 0, 2 * Math.PI);
+      });
+    });
+
+    describe('circle with no attributes', () => {
+      it('defaults missing numeric attributes to 0', () => {
+        const arcSpy = vi.spyOn(Path2D.prototype, 'arc');
+
+        buildPath2D(svgToElement('<circle />'));
+
+        expect(arcSpy).toHaveBeenCalledWith(0, 0, 0, 0, 2 * Math.PI);
+      });
+    });
+
+    describe('ellipse', () => {
+      it('draws an ellipse using cx, cy, rx, and ry', () => {
+        const ellipseSpy = vi.spyOn(Path2D.prototype, 'ellipse');
+
+        buildPath2D(svgToElement("<ellipse cx='10' cy='20' rx='5' ry='8' />"));
+
+        expect(ellipseSpy).toHaveBeenCalledWith(10, 20, 5, 8, 0, 0, 2 * Math.PI);
+      });
+    });
+
+    describe('rect', () => {
+      it('draws a rect using x, y, width, and height', () => {
+        const rectSpy = vi.spyOn(Path2D.prototype, 'rect');
+
+        buildPath2D(svgToElement("<rect x='1' y='2' width='30' height='40' />"));
+
+        expect(rectSpy).toHaveBeenCalledWith(1, 2, 30, 40);
+      });
+    });
+
+    describe('line', () => {
+      it('moves to the start point and draws a line to the end point', () => {
+        const moveToSpy = vi.spyOn(Path2D.prototype, 'moveTo');
+        const lineToSpy = vi.spyOn(Path2D.prototype, 'lineTo');
+
+        buildPath2D(svgToElement("<line x1='0' y1='0' x2='100' y2='50' />"));
+
+        expect(moveToSpy).toHaveBeenCalledWith(0, 0);
+        expect(lineToSpy).toHaveBeenCalledWith(100, 50);
+      });
+    });
+
+    describe('polygon', () => {
+      it('moves to the first point, lines to the rest, and closes the path', () => {
+        const moveToSpy = vi.spyOn(Path2D.prototype, 'moveTo');
+        const lineToSpy = vi.spyOn(Path2D.prototype, 'lineTo');
+        const closePathSpy = vi.spyOn(Path2D.prototype, 'closePath');
+
+        buildPath2D(svgToElement("<polygon points='0,0 10,0 5,10' />"));
+
+        expect(moveToSpy).toHaveBeenCalledWith(0, 0);
+        expect(lineToSpy).toHaveBeenNthCalledWith(1, 10, 0);
+        expect(lineToSpy).toHaveBeenNthCalledWith(2, 5, 10);
+        expect(closePathSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('polygon with whitespace-separated points', () => {
+      it('parses points the same as comma-separated', () => {
+        const lineToSpy = vi.spyOn(Path2D.prototype, 'lineTo');
+
+        buildPath2D(svgToElement("<polygon points='0 0 10 0 5 10' />"));
+
+        expect(lineToSpy).toHaveBeenNthCalledWith(1, 10, 0);
+        expect(lineToSpy).toHaveBeenNthCalledWith(2, 5, 10);
+      });
+    });
+
+    describe('polyline', () => {
+      it('moves to the first point and lines to the rest, without closing', () => {
+        const moveToSpy = vi.spyOn(Path2D.prototype, 'moveTo');
+        const lineToSpy = vi.spyOn(Path2D.prototype, 'lineTo');
+        const closePathSpy = vi.spyOn(Path2D.prototype, 'closePath');
+
+        buildPath2D(svgToElement("<polyline points='0,0 10,0 5,10' />"));
+
+        expect(moveToSpy).toHaveBeenCalledWith(0, 0);
+        expect(lineToSpy).toHaveBeenNthCalledWith(1, 10, 0);
+        expect(lineToSpy).toHaveBeenNthCalledWith(2, 5, 10);
+        expect(closePathSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('polygon with no points attribute', () => {
+      it('throws, since points is required for a valid polygon', () => {
+        expect(() => buildPath2D(svgToElement('<polygon />'))).toThrow();
+      });
+    });
+
+    describe('polyline with no points attribute', () => {
+      it('throws, since points is required for a valid polyline', () => {
+        expect(() => buildPath2D(svgToElement('<polyline />'))).toThrow();
+      });
+    });
+  });
+});

--- a/setupTest.js
+++ b/setupTest.js
@@ -22,7 +22,25 @@ beforeEach((context) => {
 });
 
 /** */
-class Path2D {}
+class Path2D {
+  constructor(path) {
+    this.path = path;
+  }
+
+  arc() {}
+
+  ellipse() {}
+
+  rect() {}
+
+  moveTo() {}
+
+  lineTo() {}
+
+  closePath() {}
+
+  addPath() {}
+}
 
 global.Path2D = Path2D;
 

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -8,6 +8,7 @@ import xor from 'lodash/xor';
 import OpenSeadragonCanvasOverlay from '../lib/OpenSeadragonCanvasOverlay';
 import CanvasWorld from '../lib/CanvasWorld';
 import CanvasAnnotationDisplay from '../lib/CanvasAnnotationDisplay';
+import { buildPath2D } from '../lib/svgShapesToPath';
 
 /** @private */
 function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, point) {
@@ -18,7 +19,7 @@ function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, po
   if (resource.svgSelector) {
     const context = osdCanvasOverlay.context2d;
     const { svgPaths } = new CanvasAnnotationDisplay({ resource });
-    return [...svgPaths].some((path) => context.isPointInPath(new Path2D(path.attributes.d.nodeValue), relativeX, relativeY));
+    return [...svgPaths].some((path) => context.isPointInPath(buildPath2D(path), relativeX, relativeY));
   }
 
   if (resource.fragmentSelector) {

--- a/src/lib/CanvasAnnotationDisplay.js
+++ b/src/lib/CanvasAnnotationDisplay.js
@@ -2,6 +2,8 @@
  * CanvasAnnotationDisplay - class used to display a SVG and fragment based
  * annotations.
  */
+import { buildPath2D } from '../lib/svgShapesToPath';
+
 export default class CanvasAnnotationDisplay {
   /** */
   constructor({ resource, palette, zoomRatio, offset, selected, hovered }) {
@@ -49,7 +51,7 @@ export default class CanvasAnnotationDisplay {
        */
       this.context.save();
       this.context.translate(this.offset.x, this.offset.y);
-      const p = new Path2D(element.attributes.d.nodeValue);
+      const p = buildPath2D(element);
 
       // Setup styling from SVG -> Canvas
       this.context.strokeStyle = this.color;
@@ -136,6 +138,6 @@ export default class CanvasAnnotationDisplay {
   get svgPaths() {
     const parser = new DOMParser();
     const xmlDoc = parser.parseFromString(this.svgString, 'text/xml');
-    return xmlDoc.getElementsByTagName('path');
+    return Array.from(xmlDoc.querySelectorAll('circle, ellipse, rect, line, polygon, polyline, path'));
   }
 }

--- a/src/lib/svgShapesToPath.js
+++ b/src/lib/svgShapesToPath.js
@@ -1,0 +1,49 @@
+export function buildPath2D(element) {
+  const tag = element.tagName.toLowerCase();
+  const num = (attr) => parseFloat(element.getAttribute(attr)) || 0;
+
+  if (tag === 'path') return new Path2D(element.getAttribute('d'));
+
+  const path = new Path2D();
+  SHAPE_BUILDERS[tag]?.(path, element, num);
+  return path;
+}
+
+const SHAPE_BUILDERS = {
+  circle: (path, el, num) => {
+    path.arc(num('cx'), num('cy'), num('r'), 0, 2 * Math.PI);
+  },
+  ellipse: (path, el, num) => {
+    path.ellipse(num('cx'), num('cy'), num('rx'), num('ry'), 0, 0, 2 * Math.PI);
+  },
+  rect: (path, el, num) => {
+    path.rect(num('x'), num('y'), num('width'), num('height'));
+  },
+  line: (path, el, num) => {
+    path.moveTo(num('x1'), num('y1'));
+    path.lineTo(num('x2'), num('y2'));
+  },
+  polygon: (path, el) => pointElementPath(path, el, true),
+  polyline: (path, el) => pointElementPath(path, el, false),
+};
+
+function pointElementPath(path, element, closed) {
+  const points = parsePoints(element.getAttribute('points'));
+  points.forEach(([x, y], i) => {
+    if (i === 0) path.moveTo(x, y);
+    else path.lineTo(x, y);
+  });
+  if (closed) path.closePath();
+}
+
+function parsePoints(points) {
+  const nums = points
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number);
+  const pointsList = [];
+  for (let i = 0; i < nums.length - 1; i += 2) {
+    pointsList.push([nums[i], nums[i + 1]]);
+  }
+  return pointsList;
+}


### PR DESCRIPTION
Closes #3875 

I used this manifest to test other shapes: https://dnoneill.github.io/annonatate/manifests/iiif.lib.harvard.edu/manifest.json .

In regards to https://github.com/ProjectMirador/mirador/issues/3875#issuecomment-2767578620. There is a bigger problem where it is being set properly but it is never not hovered on or selected. I am not sure how to address.
