### PR TITLE
Remove `button` prop on MenuItem

### DIFF
--- a/src/components/WindowSideBarCollectionPanel.jsx
+++ b/src/components/WindowSideBarCollectionPanel.jsx
@@ -19,7 +19,6 @@ function Item({ manifest, canvasNavigation, variant, ...otherProps }) {
   return (
     <MenuItem
       alignItems="flex-start"
-      button
       divider
       component="li"
       variant="multiline"


### PR DESCRIPTION
This was required in MUI 4.x, but became the default in MUI 5.

Fixes this console warning:
> Received `true` for a non-boolean attribute `button`.