### PR TITLE
use OpenSeadragon built in function to calculate zoom levels

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.jsx
+++ b/__tests__/src/components/AnnotationsOverlay.test.jsx
@@ -114,7 +114,9 @@ describe('AnnotationsOverlay', () => {
         viewer: null,
       });
 
-      vi.spyOn(viewer.viewport, 'getMaxZoom').mockImplementation(() => 1);
+      const getItemAt = vi
+        .spyOn(viewer.world, 'getItemAt')
+        .mockImplementation((index) => (index === 0 ? { viewportToImageZoom: vi.fn(() => 0.05) } : undefined));
       vi.spyOn(viewer.viewport, 'getZoom').mockImplementation(() => 0.05);
 
       rerender(

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -70,11 +70,14 @@ export function AnnotationsOverlay({
   const annotationsToContext = useCallback(
     (renderedAnnotations, currentPalette) => {
       const context = osdCanvasOverlay.context2d;
-      const zoomRatio = viewer.viewport.getZoom(true) / viewer.viewport.getMaxZoom();
       renderedAnnotations.forEach((annotation) => {
         annotation.resources.forEach((resource) => {
-          if (!canvasWorld.canvasIds.includes(resource.targetId)) return;
+          const osdCanvasIndex = canvasWorld.canvases.findIndex((canvas) => canvas.id === resource.targetId);
+          if (osdCanvasIndex === -1) return;
+          const viewportCanvas = viewer.world.getItemAt(osdCanvasIndex);
+          if (!viewportCanvas) return;
           const offset = canvasWorld.offsetByCanvas(resource.targetId);
+          const zoomRatio = viewportCanvas.viewportToImageZoom(viewer.viewport.getZoom(true));
           const canvasAnnotationDisplay = new CanvasAnnotationDisplay({
             hovered: hoveredAnnotationIds.includes(resource.id),
             offset,


### PR DESCRIPTION
Closes #4246
[viewportToImageZoom](https://openseadragon.github.io/docs/OpenSeadragon.Viewport.html#viewportToImageZoom): `Convert a viewport zoom to an image zoom. Image zoom: ratio of the original image size to displayed image size. 1 means original image size, 0.5 half size... Viewport zoom: ratio of the displayed image's width to viewport's width. 1 means identical width, 2 means image's width is twice the viewport's width... Note: not accurate with multi-image`. Since we are using the data from the manifest in CanvasAnnotationDisplay is specific to the image.

I was worried this would cause an issue because of the note that it doesn't work with multi-image and it was causing a console error. The way around this is to find the correct canvas the image is on in the OSD viewer and do the calculation that way. This ended up working.

Also for historical reference

|maxZoomPixelRatio |Old calc | New calc |
|---|---|---|
| No | 0.07294561583071928 | 0.08156810121729129 |
| = 100 | 0.0008024017741379122 | 0.08024017741379122 |
