### PR TITLE
Define the thumbnail menu as a nav landmark

### DIFF
--- a/__tests__/src/components/ThumbnailNavigation.test.jsx
+++ b/__tests__/src/components/ThumbnailNavigation.test.jsx
@@ -44,6 +44,12 @@ describe('ThumbnailNavigation', () => {
 
     focusSpy.mockRestore();
   });
+
+  it('renders as a nav landmark with an accessible name', () => {
+    render(<Subject />);
+
+    expect(screen.getByRole('navigation')).toHaveAccessibleName('Thumbnails');
+  });
   it('renders containers based off of number of canvases', () => {
     render(<Subject />);
 

--- a/src/components/ThumbnailNavigation.jsx
+++ b/src/components/ThumbnailNavigation.jsx
@@ -176,6 +176,7 @@ export function ThumbnailNavigation({
         scrollbarGutter: 'stable',
       }}
       aria-label={t('thumbnailNavigation')}
+      component="nav"
       square
       elevation={0}
       style={style()}


### PR DESCRIPTION
## Summary
Closes #4185.

The thumbnail navigation strip renders its root `Paper` as a plain `div` with `aria-label="Thumbnails"` and `tabindex="0"`, but no landmark role. Screen readers expose it as a generic container: it has a name, but it never shows up in landmark navigation. This is the finding from the WCAG 2.2 AA audit behind #4185 (W3C technique H97 per the comment above).

## Change
`src/components/ThumbnailNavigation.jsx`: added `component="nav"` to the root `Paper` (1 line), following the in-codebase precedent @marlo-longley pointed to (`WorkspaceControlPanel.jsx`: `component="nav"` plus `aria-label` on its AppBar root). The existing `aria-label={t('thumbnailNavigation')}` ("Thumbnails") becomes the landmark's accessible name, so no new translation keys are needed. Keyboard handling (`tabindex`, arrow-key canvas switching), focus behavior, react-window layout, and all CSS classes are untouched; only the rendered tag changes from `div` to `nav`.

Added one test asserting the `navigation` role with its accessible name, in the style of #4392's role assertions.

## Landmark exposure before/after
Measured with axe-core 4.12.1 injected into the local dev demo (`/demo/index.html`), on current main (`a922434`):

- Before: the two-window demo exposes 14 landmarks; the thumbnail menu is not among them (the accessibility tree shows `generic "Thumbnails"`).
- After: `navigation "Thumbnails"` appears (nav landmarks go from 3 to 4).
- axe violations: 2 before, 2 after, identical nodes. Both are pre-existing and unrelated to this change (the duplicated "Window navigation" labels across the two windows, and `scrollable-region-focusable` on the react-window grid).

## One nuance worth flagging for review
With several windows open that all have thumbnails enabled, each window contributes a `nav` labeled "Thumbnails", so axe's `landmark-unique` reports the duplicate pair. Measured A/B on the demo: baseline has 1 `landmark-unique` node (the existing per-window "Window navigation" pair); with this change and two thumbnail strips visible it is 2 nodes. This is the same per-window static-label pattern the codebase already ships for "Window navigation"; disambiguating per-window landmark labels looks like #4354 territory rather than part of this one-line fix.

## How I tested this
- `npm install`, `npm test` (build, lint including i18n-lint and container-lint, size-limit, vitest): exit 0; 191 test files passed, 2 skipped; 1204 tests passed, 12 skipped
- `npx vitest run __tests__/src/components/ThumbnailNavigation.test.jsx`: 16/16
- Manual on the dev demo: keyboard focus lands on the `nav`, ArrowRight still advances the canvas ("1 of 84" to "2 of 84"); on the RTL demo (`viewingDirection: right-to-left` manifest) the grid keeps `direction: rtl` in both `far-bottom` and `far-right` positions
