### PR TITLE
only disable show all annotations if there are no annotations

### DIFF
--- a/src/containers/AnnotationSettings.js
+++ b/src/containers/AnnotationSettings.js
@@ -10,7 +10,7 @@ import { AnnotationSettings } from '../components/AnnotationSettings';
  */
 const mapStateToProps = (state, { windowId }) => ({
   displayAll: getWindow(state, { windowId }).highlightAllAnnotations,
-  displayAllDisabled: getAnnotationResourcesByMotivation(state, { windowId }).length < 2,
+  displayAllDisabled: getAnnotationResourcesByMotivation(state, { windowId }).length < 1,
 });
 
 /**


### PR DESCRIPTION
closes #4444 

I tracked this back. It is original to the codebase. I am guessing the idea was if there is only one annotation you should click on it but I think with the hover/selected state that isn't a good assumption. I went ahead and only disabled the button if there are 0 annotations which makes more sense.

<img width="873" height="742" alt="Screenshot 2026-08-13 at 3 39 38 PM" src="https://github.com/user-attachments/assets/bb102541-b0f1-4e5d-842d-e1efa0902e7f" />
