### PR TITLE
Fix thumbnail nav calculations

### DIFF
--- a/__tests__/src/components/ThumbnailCanvasGrouping.test.jsx
+++ b/__tests__/src/components/ThumbnailCanvasGrouping.test.jsx
@@ -59,7 +59,7 @@ describe('ThumbnailCanvasGrouping', () => {
   describe('attributes based off far-bottom position', () => {
     it('in button div', () => {
       expect(screen.getByRole('button', { name: 'Image 1' })).toHaveStyle({
-        height: '119px',
+        height: '90px',
         width: 'auto',
       });
     });

--- a/__tests__/src/components/ThumbnailNavigation.test.jsx
+++ b/__tests__/src/components/ThumbnailNavigation.test.jsx
@@ -65,45 +65,43 @@ describe('ThumbnailNavigation', () => {
 
   it('gives the grid a size', () => {
     const { rerender } = render(<Subject />);
-    expect(screen.getByLabelText('Thumbnails')).toHaveStyle({ height: '150px', width: '100%' });
+    expect(screen.getByLabelText('Thumbnails')).toHaveStyle({ width: '100%' });
 
     rerender(<Subject position="far-right" />);
     expect(screen.getByLabelText('Thumbnails')).toHaveStyle({
-      height: '100%',
-      minHeight: 0,
-      width: '127px',
+      width: '100px',
     });
   });
 
   it('roughly doubles the width of the grid in book view', () => {
     const { rerender } = render(<Subject position="far-right" />);
-    expect(screen.getByLabelText('Thumbnails')).toHaveStyle({ width: '127px' });
+    expect(screen.getByLabelText('Thumbnails')).toHaveStyle({ width: '100px' });
 
     rerender(<Subject position="far-right" view="book" />);
-    expect(screen.getByLabelText('Thumbnails')).toHaveStyle({ width: '227px' });
+    expect(screen.getByLabelText('Thumbnails')).toHaveStyle({ width: '200px' });
   });
 
   it('calculates the scaled width of each cell', () => {
     render(<Subject />);
 
-    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ width: '111px' });
+    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ width: '88px' });
   });
 
   it('calculates the scaled height of each cell when on the right', () => {
     render(<Subject position="far-right" />);
-    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ height: '150px' });
+    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ height: '123px' });
   });
 
   it('keeps a minimum size for each cell', () => {
     render(<Subject fixture={zeroWidthFixture} />);
 
-    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ width: '111px' });
+    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ width: '100px' });
   });
 
   it('keeps a minimum size for each cell when on the right', () => {
     render(<Subject fixture={zeroWidthFixture} position="far-right" />);
 
-    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ height: '100px' });
+    expect(screen.getAllByRole('gridcell')[0]).toHaveStyle({ height: '150px' });
   });
 
   describe('keyboard navigation', () => {

--- a/src/components/ThumbnailCanvasGrouping.jsx
+++ b/src/components/ThumbnailCanvasGrouping.jsx
@@ -38,21 +38,11 @@ export class ThumbnailCanvasGrouping extends PureComponent {
 
   /** */
   render() {
-    const { index, columnIndex, style, canvasGroupings, position, height, currentCanvasId, showThumbnailLabels } = this.props;
+    const { index, columnIndex, style, canvasGroupings, position, currentCanvasId, showThumbnailLabels } = this.props;
     // For Grid (horizontal), use columnIndex; for List (vertical), use index
     const itemIndex = columnIndex !== undefined ? columnIndex : index;
     const currentGroupings = canvasGroupings[itemIndex];
     const SPACING = 12;
-
-    // In react-window v2 Grid (horizontal layout), columnWidth is passed as style.height
-    // For List (vertical layout), rowHeight is passed as style.height
-    const isHorizontal = position === 'far-bottom';
-    let calculatedWidth = null;
-    if (isHorizontal && style.height) {
-      calculatedWidth = style.height - SPACING;
-    } else if (Number.isInteger(style.width)) {
-      calculatedWidth = style.width - SPACING;
-    }
 
     const isSelected = currentGroupings.map((canvas) => canvas.id).includes(currentCanvasId);
 
@@ -60,12 +50,12 @@ export class ThumbnailCanvasGrouping extends PureComponent {
       <div
         style={{
           ...style,
-          boxSizing: 'content-box',
+          boxSizing: 'border-box',
           height: Number.isInteger(style.height) ? style.height - SPACING : null,
           left: Number.isInteger(style.left) ? style.left + SPACING / 2 : null,
           padding: SPACING / 2,
           top: Number.isInteger(style.top) ? style.top + SPACING / 2 : null,
-          width: calculatedWidth,
+          width: Number.isInteger(style.width) ? style.width - SPACING : null,
         }}
         className={ns('thumbnail-nav-container')}
         role="gridcell"
@@ -89,7 +79,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
               outline: isSelected ? `2px solid ${theme.palette.primary.main}` : `2px solid ${theme.palette.action.hover}`,
               outlineOffset: isSelected ? '3px' : '-2px',
             },
-            height: position === 'far-right' ? 'auto' : `${height - SPACING}px`,
+            height: position === 'far-right' ? 'auto' : `${style.height}px`,
             width: position === 'far-bottom' ? 'auto' : `${style.width}px`,
           })}
           className={classNames(
@@ -105,7 +95,7 @@ export class ThumbnailCanvasGrouping extends PureComponent {
               key={canvas.id}
               resource={canvas}
               labelled={showThumbnailLabels}
-              maxHeight={position === 'far-right' ? style.height - 1.5 * SPACING : height - 1.5 * SPACING}
+              maxHeight={position === 'far-right' ? style.height - SPACING : style.height}
               variant="inside"
             />
           ))}
@@ -119,7 +109,6 @@ ThumbnailCanvasGrouping.propTypes = {
   canvasGroupings: PropTypes.array.isRequired,
   columnIndex: PropTypes.number,
   currentCanvasId: PropTypes.string.isRequired,
-  height: PropTypes.number.isRequired,
   index: PropTypes.number,
   position: PropTypes.string.isRequired,
   setCanvas: PropTypes.func.isRequired,

--- a/src/components/ThumbnailNavigation.jsx
+++ b/src/components/ThumbnailNavigation.jsx
@@ -23,8 +23,8 @@ export function ThumbnailNavigation({
   windowId,
 }) {
   const { t } = useTranslation();
-  const scrollbarSize = 15;
-  const spacing = 12; // 2 * (2px margin + 2px border + 2px padding + 2px padding)
+  const scrollbarSize = 6;
+  const spacing = 12; // 2 * (2px margin + 2px border + 2px padding)
   const gridRef = useRef();
   const previousView = useRef(view);
   const canvasWorlds = useCanvasWorldService();
@@ -88,36 +88,38 @@ export function ThumbnailNavigation({
   };
 
   /**
-   * When on right, row height
    * When on bottom, column width
    */
-  const calculateScaledSize = (index) => {
+  const calculateScaledWidth = (index) => {
     const canvases = canvasGroupings[index];
     if (!canvases) return thumbnailNavigation.width + spacing;
 
     const world = canvasWorlds.get(canvases);
     const bounds = world.worldBounds();
-    switch (position) {
-      case 'far-right': {
-        const calc = Math.floor((calculatingWidth(canvases.length) * bounds[3]) / bounds[2]);
-        if (!Number.isInteger(calc)) return thumbnailNavigation.width + spacing;
-        return calc + spacing;
-      }
-      // Default case bottom
-      default: {
-        if (bounds[3] === 0) return thumbnailNavigation.width + spacing;
-        const calc = Math.ceil(((thumbnailNavigation.height - scrollbarSize - spacing - 4) * bounds[2]) / bounds[3]);
-        return calc;
-      }
-    }
+    // calculate the correct canvas width based on the height + aspect ratio.
+    const availableHeight = thumbnailNavigation.height - spacing - scrollbarSize;
+    const calc = Math.ceil((availableHeight * bounds[2]) / bounds[3]);
+
+    if (!Number.isInteger(calc)) return thumbnailNavigation.width + spacing;
+    return calc + spacing;
   };
 
-  /** */
-  const calculatingWidth = (canvasesLength) => {
-    if (canvasesLength === 1) {
-      return thumbnailNavigation.width;
-    }
-    return thumbnailNavigation.width * 2;
+  /**
+   * When on right, row height
+   */
+  const calculateScaledHeight = (index) => {
+    const canvases = canvasGroupings[index];
+    if (!canvases) return thumbnailNavigation.height + spacing;
+
+    const world = canvasWorlds.get(canvases);
+    const bounds = world.worldBounds();
+
+    // calculate the correct canvas height based on the aspect ratio + width.
+    const availableWidth = thumbnailNavigation.width - spacing - scrollbarSize;
+    const calc = Math.ceil((availableWidth * canvases.length * bounds[3]) / bounds[2]);
+
+    if (!Number.isInteger(calc)) return thumbnailNavigation.height + spacing;
+    return calc + spacing;
   };
 
   /** */
@@ -127,14 +129,11 @@ export function ThumbnailNavigation({
     switch (position) {
       case 'far-right':
         return {
-          height: '100%',
-          minHeight: 0,
-          width: `${width + scrollbarSize + spacing}px`,
+          width: `${width}px`,
         };
       // Default case bottom
       default:
         return {
-          height: `${thumbnailNavigation.height}px`,
           width: '100%',
         };
     }
@@ -156,12 +155,12 @@ export function ThumbnailNavigation({
     return null;
   }
   const htmlDir = viewingDirection === 'right-to-left' ? 'rtl' : 'ltr';
-  const rowData = {
+  const itemData = {
     canvasGroupings,
-    height: thumbnailNavigation.height - spacing - scrollbarSize,
     position,
     windowId,
   };
+
   return (
     <Paper
       className={classNames(ns('thumb-navigation'))}
@@ -170,6 +169,7 @@ export function ThumbnailNavigation({
           boxShadow: 0,
           outline: 0,
         },
+        scrollbarGutter: 'stable',
       }}
       aria-label={t('thumbnailNavigation')}
       square
@@ -179,39 +179,35 @@ export function ThumbnailNavigation({
       onKeyDown={handleKeyDown}
       ref={paperRef}
     >
-      <div style={{ height: '100%', width: '100%' }}>
-        {canvasGroupings.length > 0 && position === 'far-bottom' && (
-          <Grid
-            columnCount={canvasGroupings.length}
-            columnWidth={calculateScaledSize}
-            rowCount={1}
-            rowHeight={() => thumbnailNavigation.height - spacing - scrollbarSize}
-            height={thumbnailNavigation.height}
-            width="100%"
-            style={{
-              direction: htmlDir === 'rtl' ? 'rtl' : 'ltr',
-            }}
-            cellProps={rowData}
-            gridRef={gridRef}
-            cellComponent={ThumbnailCanvasGrouping}
-          />
-        )}
-        {canvasGroupings.length > 0 && position === 'far-right' && (
-          <List
-            defaultHeight={100}
-            rowCount={canvasGroupings.length}
-            rowHeight={calculateScaledSize}
-            style={{
-              direction: htmlDir === 'rtl' ? 'rtl' : 'ltr',
-              height: '100%',
-              width: '100%',
-            }}
-            rowProps={rowData}
-            listRef={gridRef}
-            rowComponent={ThumbnailCanvasGrouping}
-          />
-        )}
-      </div>
+      {canvasGroupings.length > 0 && position === 'far-bottom' && (
+        <Grid
+          columnCount={canvasGroupings.length}
+          columnWidth={calculateScaledWidth}
+          rowCount={1}
+          rowHeight={thumbnailNavigation.height - spacing - scrollbarSize}
+          style={{
+            direction: htmlDir === 'rtl' ? 'rtl' : 'ltr',
+            height: thumbnailNavigation.height,
+          }}
+          cellProps={itemData}
+          gridRef={gridRef}
+          cellComponent={ThumbnailCanvasGrouping}
+        />
+      )}
+      {canvasGroupings.length > 0 && position === 'far-right' && (
+        <List
+          defaultHeight={100}
+          rowCount={canvasGroupings.length}
+          rowHeight={calculateScaledHeight}
+          style={{
+            paddingBottom: spacing,
+            direction: htmlDir === 'rtl' ? 'rtl' : 'ltr',
+          }}
+          rowProps={itemData}
+          listRef={gridRef}
+          rowComponent={ThumbnailCanvasGrouping}
+        />
+      )}
     </Paper>
   );
 }

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -291,7 +291,7 @@ export default {
             }),
             ...(ownerState?.variant === 'inside' && {
               background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
-              bottom: '5px',
+              bottom: '0px',
               boxSizing: 'border-box',
               left: '0px',
               padding: '4px',


### PR DESCRIPTION
This is mostly fixing a regression from updating to react-window v2, but also uses some of the (presumably more consistent?) calculations so we don't need to make as many adjustments on the actual canvas group (just tweaking the actual position to give us the spacing we want).

I'm not going to try to capture a before, but after:
- images take up the maximum available space with a consistent gutter between them
- the spacing saved for the scrollbar is sufficient to not obscure the content
- the active border around the images is the same on all sides
- scrollbars don't trigger cross-axis overflow
- etc

<img width="363" height="194" alt="Screenshot 2026-08-13 at 14 30 56" src="https://github.com/user-attachments/assets/4cede653-616d-4b04-9038-f9a779c25e99" />

