### PR TITLE
make sure fetch visible canvases when they are updated

### DIFF
--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -403,12 +403,14 @@ describe('window-level sagas', () => {
         .provide([
           [select(getWindow, { windowId }), { canvasId: 'y' }],
           [select(getCanvasGrouping, { canvasId: 'y', windowId }), [{ id: 'y' }, { id: 'z' }]],
+          [call(fetchInfoResponses, { visibleCanvases: ['y', 'z'], windowId })],
         ])
         .put({
           id: windowId,
           payload: { visibleCanvases: ['y', 'z'] },
           type: ActionTypes.UPDATE_WINDOW,
         })
+        .call(fetchInfoResponses, { visibleCanvases: ['y', 'z'], windowId })
         .run();
     });
   });

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -205,7 +205,9 @@ export function* panToFocusedWindow({ pan, windowId }) {
 export function* updateVisibleCanvases({ windowId }) {
   const { canvasId } = yield select(getWindow, { windowId });
   const visibleCanvases = yield select(getCanvasGrouping, { canvasId, windowId });
-  yield put(updateWindow(windowId, { visibleCanvases: (visibleCanvases || []).map((c) => c.id) }));
+  const visibleCanvasIds = (visibleCanvases || []).map((c) => c.id);
+  yield put(updateWindow(windowId, { visibleCanvases: visibleCanvasIds }));
+  yield call(fetchInfoResponses, { visibleCanvases: visibleCanvasIds, windowId });
 }
 
 /** @private */


### PR DESCRIPTION
closes #3276 

Honestly I thought the solution to this was fixing the reducers so that SET_WINDOW_VIEW_TYPE included a sequenceId which was causing this method to not run. https://github.com/ProjectMirador/mirador/blob/main/src/state/sagas/windows.js#L60. I was having a heck of a time with updating the payloads because they make no sense to me and weren't working. I was looking at updating it in line 209 but Claude said to add the code below. I have confirmed it looks right. I really don't understand the pattern at all in Mirador...

Also I added a note but this wasn't just broken in continuous. It was broken in book as well.