### PR TITLE
Revert "Merge pull request #4452 from ProjectMirador/4.2.2-release"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mirador",
-  "version": "4.2.2",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mirador",
-      "version": "4.2.2",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@custom-react-hooks/use-element-size": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirador",
-  "version": "4.2.2",
+  "version": "4.2.1",
   "description": "An open-source, web-based 'multi-up' viewer that supports zoom-pan-rotate functionality, ability to display/compare simple images, and images with annotations.",
   "type": "module",
   "main": "./dist/mirador.min.js",


### PR DESCRIPTION
Revert incorrect 4.2.2 version bump
PR #4452 was rebased onto main instead of tags/v4.2.0, so it accidentally shipped 4.2.1's content (including Vite 8) under the 4.2.2 label.