### PR TITLE
Bump version to 4.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mirador",
-  "version": "4.1.0",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mirador",
-      "version": "4.1.0",
+      "version": "4.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@custom-react-hooks/use-element-size": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirador",
-  "version": "4.2.1",
+  "version": "4.2.3",
   "description": "An open-source, web-based 'multi-up' viewer that supports zoom-pan-rotate functionality, ability to display/compare simple images, and images with annotations.",
   "type": "module",
   "main": "./dist/mirador.min.js",


### PR DESCRIPTION
Corrected republish of the intended 4.2.1 content (4.2.2 + the isolated Vite 8 migration)