### PR TITLE
Remove duplicate announcement of window titles by screen readers

### DIFF
--- a/__tests__/integration/tests/minimalist.test.js
+++ b/__tests__/integration/tests/minimalist.test.js
@@ -9,7 +9,14 @@ describe('Minimalist configuration to Mirador', () => {
   it('Loads a manifest and displays it without some of the default controls', async () => {
     expect(
       await screen.findByRole('region', {
-        name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+        name: /Item window 1/i,
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: /Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
       }),
     ).toBeInTheDocument();
 

--- a/__tests__/integration/tests/viewer-config.test.js
+++ b/__tests__/integration/tests/viewer-config.test.js
@@ -10,7 +10,7 @@ describe('initialViewerConfig', () => {
     it('allows initialViewerConfig to be passed', async (context) => {
       expect(
         await screen.findByRole('region', {
-          name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+          name: /Item window 1/i,
         }),
       ).toBeInTheDocument();
 

--- a/__tests__/integration/tests/window-actions.test.js
+++ b/__tests__/integration/tests/window-actions.test.js
@@ -9,7 +9,7 @@ describe('Window actions', () => {
   it('Closes a Mirador window', async () => {
     expect(
       await screen.findByRole('region', {
-        name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+        name: /Item window 1/i,
       }),
     ).toBeInTheDocument();
     const closeButton = screen.getByRole('button', { name: /Close window/i });
@@ -17,7 +17,7 @@ describe('Window actions', () => {
     await waitFor(() =>
       expect(
         screen.queryByRole('region', {
-          name: /Window: Cambridge, Corpus Christi College, MS 640: Antiphoner Leaf/i,
+          name: /Item window 1/i,
         }),
       ).not.toBeInTheDocument(),
     );

--- a/__tests__/src/components/Window.test.jsx
+++ b/__tests__/src/components/Window.test.jsx
@@ -6,7 +6,7 @@ import { Window } from '../../../src/components/Window';
 /** create wrapper */
 function createWrapper(props, state, renderOptions) {
   return render(
-    <Window windowId="xyz" manifestId="foo" classes={{}} {...props} />,
+    <Window windowId="xyz" manifestId="foo" classes={{}} windowPosition={1} {...props} />,
     {
       preloadedState: {
         windows: {
@@ -15,6 +15,9 @@ function createWrapper(props, state, renderOptions) {
             companionWindowIds: [],
           },
         },
+        workspace: {
+          windowIds: ['xyz'],
+        },
       },
     },
     { renderOptions },
@@ -22,9 +25,9 @@ function createWrapper(props, state, renderOptions) {
 }
 
 describe('Window', () => {
-  it('should render outer element', () => {
+  it('should render outer element with a numbered, non-duplicative accessible name', () => {
     createWrapper();
-    expect(screen.getByLabelText('Window:')).toHaveClass('mirador-window');
+    expect(screen.getByLabelText('Item window 1')).toHaveClass('mirador-window');
   });
   it('should render <WindowTopBar>', () => {
     createWrapper();

--- a/__tests__/src/components/Workspace.test.jsx
+++ b/__tests__/src/components/Workspace.test.jsx
@@ -30,6 +30,7 @@ function createWrapper(props) {
             x: 0,
             y: 0,
           },
+          windowIds: ['1', '2'],
         },
       },
     },
@@ -62,7 +63,7 @@ describe('Workspace', () => {
       createWrapper({ workspaceType: 'bubu' });
 
       expect(screen.getByRole('heading', { name: 'Mirador viewer' })).toBeInTheDocument();
-      expect(screen.getAllByLabelText('Window:')).toHaveLength(2);
+      expect(screen.getAllByRole('region', { name: /Item window/i })).toHaveLength(2);
     });
   });
   describe('if any windows are maximized', () => {
@@ -70,7 +71,7 @@ describe('Workspace', () => {
       createWrapper({ maximizedWindowIds: ['1'] });
 
       expect(screen.getByRole('heading', { name: 'Mirador viewer' })).toBeInTheDocument();
-      expect(screen.getByLabelText('Window:')).toHaveAttribute('id', '1');
+      expect(screen.getByRole('region', { name: 'Item window 1' })).toHaveAttribute('id', '1');
     });
   });
 

--- a/__tests__/src/components/WorkspaceElastic.test.jsx
+++ b/__tests__/src/components/WorkspaceElastic.test.jsx
@@ -29,7 +29,7 @@ function createWrapper({ elasticLayout = {}, ...props }) {
         companionWindows: {},
         elasticLayout,
         windows: { 1: { companionWindowIds: [] }, 2: { companionWindowIds: [] } },
-        workspace: { draggingEnabled: true },
+        workspace: { draggingEnabled: true, windowIds: ['1', '2'] },
       },
     },
   );
@@ -56,7 +56,7 @@ describe('WorkspaceElastic', () => {
 
   it('should render properly with an initialValue', () => {
     createWrapper({ elasticLayout });
-    expect(screen.getAllByLabelText('Window:')).toHaveLength(2);
+    expect(screen.getAllByRole('region', { name: /Item window/i })).toHaveLength(2);
   });
   describe('workspace behaviour', () => {
     it('when workspace itself is dragged', async () => {

--- a/__tests__/src/components/WorkspaceMosaic.test.jsx
+++ b/__tests__/src/components/WorkspaceMosaic.test.jsx
@@ -5,9 +5,9 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import { WorkspaceMosaic } from '../../../src/components/WorkspaceMosaic';
 
 /** create wrapper */
-function createWrapper(props) {
+function createWrapper({ windowIds = [], ...props } = {}) {
   return render(
-    <WorkspaceMosaic classes={{}} windowIds={[]} workspaceId="foo" updateWorkspaceMosaicLayout={() => {}} {...props} />,
+    <WorkspaceMosaic classes={{}} windowIds={windowIds} workspaceId="foo" updateWorkspaceMosaicLayout={() => {}} {...props} />,
     {
       preloadedState: {
         windows: {
@@ -15,6 +15,7 @@ function createWrapper(props) {
           2: { companionWindowIds: [] },
           3: { companionWindowIds: [] },
         },
+        workspace: { windowIds },
       },
     },
   );
@@ -120,8 +121,8 @@ describe('WorkspaceMosaic', () => {
     it('when window is available', () => {
       wrapper = createWrapper({ windowIds });
 
-      expect(screen.getAllByLabelText('Window:', { container: 'section' })[0]).toHaveAttribute('id', '1');
-      expect(screen.getAllByLabelText('Window:', { container: 'section' })[1]).toHaveAttribute('id', '2');
+      expect(screen.getByRole('region', { name: 'Item window 1' })).toHaveAttribute('id', '1');
+      expect(screen.getByRole('region', { name: 'Item window 2' })).toHaveAttribute('id', '2');
 
       expect(wrapper.container.querySelector('.mosaic-window-title')).toBeEmptyDOMElement();
       expect(wrapper.container.querySelector('.mosaic-window-controls')).toBeEmptyDOMElement();

--- a/__tests__/src/selectors/windows.test.js
+++ b/__tests__/src/selectors/windows.test.js
@@ -4,6 +4,7 @@ import manifestFixture015 from '../../fixtures/version-2/015.json';
 import manifestFixture019 from '../../fixtures/version-2/019.json';
 import {
   getWindowConfig,
+  getWindowPosition,
   getWindowTitles,
   getWindowViewType,
   getWindowDraggability,
@@ -35,6 +36,21 @@ describe('getWindowConfig', () => {
     };
 
     expect(getWindowConfig(state, { windowId: 'c' })).toEqual({ a: '1', b: '2' });
+  });
+});
+
+describe('getWindowPosition', () => {
+  it('returns the 1-based position of a window among all open windows', () => {
+    const state = { workspace: { windowIds: ['a', 'b', 'c'] } };
+
+    expect(getWindowPosition(state, { windowId: 'a' })).toEqual(1);
+    expect(getWindowPosition(state, { windowId: 'b' })).toEqual(2);
+    expect(getWindowPosition(state, { windowId: 'c' })).toEqual(3);
+  });
+  it('returns 0 for a window that is not currently open', () => {
+    const state = { workspace: { windowIds: ['a'] } };
+
+    expect(getWindowPosition(state, { windowId: 'nope' })).toEqual(0);
   });
 });
 

--- a/__tests__/utils/test-utils.jsx
+++ b/__tests__/utils/test-utils.jsx
@@ -95,7 +95,7 @@ export const setupIntegrationTestViewer = (config, plugins) => {
     await failIfErrorDialogPresent({ waitForRole: 'main' });
 
     if ((config.windows || []).length > 0) {
-      await safeFindAllByRole('region', { name: /Window:/i });
+      await safeFindAllByRole('region', { name: /Item window/i });
     }
   });
 };

--- a/src/components/Window.jsx
+++ b/src/components/Window.jsx
@@ -86,6 +86,7 @@ export function Window({
   view = undefined,
   windowDraggable = null,
   windowId,
+  windowPosition = null,
   workspaceType = null,
   manifestError = null,
 }) {
@@ -110,7 +111,7 @@ export function Window({
         elevation={1}
         id={windowId}
         className={ns('window')}
-        aria-label={t('window', { label })}
+        aria-label={t('windowRegion', { position: windowPosition })}
       >
         <WindowTopBar
           component={workspaceType === 'mosaic' && windowDraggable ? DraggableNavBar : undefined}
@@ -146,5 +147,6 @@ Window.propTypes = {
   view: PropTypes.string,
   windowDraggable: PropTypes.bool,
   windowId: PropTypes.string.isRequired,
+  windowPosition: PropTypes.number,
   workspaceType: PropTypes.string,
 };

--- a/src/containers/Window.js
+++ b/src/containers/Window.js
@@ -10,6 +10,7 @@ import {
   getWindow,
   getWorkspaceType,
   getWindowDraggability,
+  getWindowPosition,
   getWindowViewType,
   getManifestError,
 } from '../state/selectors';
@@ -28,6 +29,7 @@ const mapStateToProps = (state, { windowId }) => ({
   thumbnailNavigationPosition: getThumbnailNavigationPosition(state, { windowId }),
   view: getWindowViewType(state, { windowId }),
   windowDraggable: getWindowDraggability(state, { windowId }),
+  windowPosition: getWindowPosition(state, { windowId }),
   workspaceType: getWorkspaceType(state),
 });
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -157,6 +157,7 @@
     "windowNavigation": "Window navigation",
     "windowPluginButtons": "Options",
     "windowPluginMenu": "Window options",
+    "windowRegion": "Item window {{position}}",
     "workspace": "Workspace",
     "workspaceFullScreen": "Full screen",
     "workspaceMenu": "Workspace settings",

--- a/src/state/selectors/windows.js
+++ b/src/state/selectors/windows.js
@@ -17,6 +17,19 @@ export const getWindowConfig = createSelector([getConfig, getWindow], ({ window:
 }));
 
 /**
+ * Returns the 1-based position of a window among all currently open windows,
+ * for use in an accessible name that doesn't just repeat the manifest title
+ * (e.g. "Item window 2")
+ * @param {object} state
+ * @param {string} windowId
+ * @returns {number}
+ */
+export const getWindowPosition = createSelector(
+  [getWindowIds, (state, { windowId }) => windowId],
+  (windowIds, windowId) => windowIds.indexOf(windowId) + 1,
+);
+
+/**
  * Returns the manifest titles for all open windows.
  * @param {object} state
  * @returns {object}


### PR DESCRIPTION
This PR uses a generic `Item Window <windowNum>` for the aria-label of each window
The visible title in the UI still displays the manifest title
Closes #3904

@mferrarini -- are you able to review this? I followed your suggestion about using `Item window`. Thank you.