### PR TITLE
Replace react-image with our own ImageWithFallback

### DIFF
--- a/__tests__/src/components/AttributionPanel.test.jsx
+++ b/__tests__/src/components/AttributionPanel.test.jsx
@@ -37,7 +37,7 @@ describe('AttributionPanel', () => {
   });
 
   // Requires canvas to handle img loading.
-  it.skip('renders the manifest logo', async () => {
+  it('renders the manifest logo', async () => {
     const manifestLogo =
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mMMDQmtBwADgwF/Op8FmAAAAABJRU5ErkJggg==';
 
@@ -47,7 +47,6 @@ describe('AttributionPanel', () => {
       expect(container.querySelector('img')).toBeInTheDocument();
     });
 
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('img')).toHaveAttribute('src', manifestLogo);
+    expect(container.querySelector('img')).toHaveAttribute('src', manifestLogo); // eslint-disable-line testing-library/no-container, testing-library/no-node-access
   });
 });

--- a/__tests__/src/components/ImageWithFallback.test.jsx
+++ b/__tests__/src/components/ImageWithFallback.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@tests/utils/test-utils';
+import { ImageWithFallback } from '../../../src/components/ImageWithFallback';
+import FailedImageContext from '../../../src/contexts/FailedImageContext';
+
+describe('ImageWithFallback', () => {
+  it('renders the image', () => {
+    render(<ImageWithFallback src="http://example.org/image.jpg" alt="" fallback={<div data-testid="fallback" />} />);
+
+    expect(screen.getByRole('presentation')).toHaveAttribute('src', 'http://example.org/image.jpg');
+  });
+
+  it('renders the fallback when the image fails to load', () => {
+    render(<ImageWithFallback src="http://example.org/image.jpg" alt="" fallback={<div data-testid="fallback" />} />);
+
+    fireEvent.error(screen.getByRole('presentation'));
+
+    expect(screen.getByTestId('fallback')).toBeInTheDocument();
+  });
+
+  it('notifies FailedImageContext when the image fails to load', () => {
+    const notifyFailure = vi.fn();
+    render(
+      <FailedImageContext.Provider value={{ fallbackImage: '', notifyFailure }}>
+        <ImageWithFallback src="http://example.org/image.jpg" alt="" fallback={<div data-testid="fallback" />} />
+      </FailedImageContext.Provider>,
+    );
+
+    fireEvent.error(screen.getByRole('presentation'));
+
+    expect(notifyFailure).toHaveBeenCalledWith('http://example.org/image.jpg');
+  });
+
+  it('recovers if a later src succeeds after an earlier one failed', () => {
+    const { rerender } = render(
+      <ImageWithFallback src="http://example.org/bad.jpg" alt="" fallback={<div data-testid="fallback" />} />,
+    );
+
+    fireEvent.error(screen.getByRole('presentation'));
+    expect(screen.getByTestId('fallback')).toBeInTheDocument();
+
+    rerender(<ImageWithFallback src="http://example.org/good.jpg" alt="" fallback={<div data-testid="fallback" />} />);
+
+    expect(screen.getByRole('presentation')).toHaveAttribute('src', 'http://example.org/good.jpg');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react-dnd-multi-backend": "^9.0.0",
     "react-dnd-touch-backend": "^16.0.0",
     "react-error-boundary": "^5.0.0",
-    "react-image": "^4.0.1",
     "react-intersection-observer": "^10.0.0",
     "react-mosaic-component": "^7.0.0",
     "react-redux": "^8.0.0 || ^9.0.0",

--- a/src/components/AttributionPanel.jsx
+++ b/src/components/AttributionPanel.jsx
@@ -4,14 +4,14 @@ import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import Skeleton from '@mui/material/Skeleton';
 import { useTranslation } from 'react-i18next';
-import { Img } from 'react-image';
 import CompanionWindow from '../containers/CompanionWindow';
 import { CompanionWindowSection } from './CompanionWindowSection';
 import LabelValueMetadata from '../containers/LabelValueMetadata';
 import ns from '../config/css-ns';
 import { PluginHook } from './PluginHook';
+import { ImageWithFallback } from './ImageWithFallback';
 
-const StyledLogo = styled(Img)(() => ({
+const StyledLogo = styled(ImageWithFallback)(() => ({
   maxWidth: '100%',
 }));
 
@@ -51,10 +51,10 @@ export function AttributionPanel({ manifestLogo = null, requiredStatement = null
       {manifestLogo && (
         <CompanionWindowSection>
           <StyledLogo
-            src={[manifestLogo]}
+            src={manifestLogo}
             alt=""
             role="presentation"
-            unloader={<StyledPlaceholder variant="rectangular" height={60} width={60} />}
+            fallback={<StyledPlaceholder variant="rectangular" height={60} width={60} />}
           />
         </CompanionWindowSection>
       )}

--- a/src/components/ImageWithFallback.jsx
+++ b/src/components/ImageWithFallback.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * A plain img element that renders a fallback node when the image fails to load.
+ */
+export function ImageWithFallback({ alt, fallback, src, ...props }) {
+  const [hasError, setHasError] = useState(false);
+
+  if (hasError) return fallback;
+
+  return <img alt={alt} src={src} onError={() => setHasError(true)} {...props} />;
+}
+
+ImageWithFallback.propTypes = {
+  /** Alt text for the underlying img element. */
+  alt: PropTypes.string.isRequired,
+  /** Node rendered in place of the image when it fails to load. */
+  fallback: PropTypes.node.isRequired,
+  /** URL of the image to display. */
+  src: PropTypes.string.isRequired,
+};

--- a/src/components/ImageWithFallback.jsx
+++ b/src/components/ImageWithFallback.jsx
@@ -1,15 +1,43 @@
-import { useState } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
+import FailedImageContext from '../contexts/FailedImageContext';
 
 /**
  * A plain img element that renders a fallback node when the image fails to load.
+ *
+ * Reports failures through FailedImageContext like IIIFThumbnail/OpenSeadragonTileSource
  */
 export function ImageWithFallback({ alt, fallback, src, ...props }) {
   const [hasError, setHasError] = useState(false);
+  const { notifyFailure } = useContext(FailedImageContext);
+
+  // A later src may succeed even if an earlier one failed.
+  useEffect(() => {
+    setHasError(false);
+  }, [src]);
+
+  useEffect(() => {
+    const img = new Image();
+    img.src = src;
+    if (typeof img.decode === 'function') {
+      // .decode prevents image being added to DOM before it is decoded
+      img.decode().catch(() => {});
+    }
+  }, [src]);
 
   if (hasError) return fallback;
 
-  return <img alt={alt} src={src} onError={() => setHasError(true)} {...props} />;
+  return (
+    <img
+      alt={alt}
+      src={src}
+      onError={() => {
+        setHasError(true);
+        notifyFailure(src);
+      }}
+      {...props}
+    />
+  );
 }
 
 ImageWithFallback.propTypes = {

--- a/src/components/ManifestListItem.jsx
+++ b/src/components/ManifestListItem.jsx
@@ -7,8 +7,8 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 import { useTranslation } from 'react-i18next';
-import { Img } from 'react-image';
 import ManifestListItemError from '../containers/ManifestListItemError';
+import { ImageWithFallback } from './ImageWithFallback';
 import ns from '../config/css-ns';
 
 const Root = styled(ListItem, { name: 'ManifestListItem', slot: 'root' })(({ ownerState, theme }) => ({
@@ -26,15 +26,18 @@ const Root = styled(ListItem, { name: 'ManifestListItem', slot: 'root' })(({ own
   },
 }));
 
-const StyledThumbnail = styled(Img, {
+const StyledThumbnail = styled(ImageWithFallback, {
   name: 'ManifestListItem',
   slot: 'thumbnail',
-})(({ theme }) => ({
+})(() => ({
   maxWidth: '100%',
   objectFit: 'contain',
 }));
 
-const StyledLogo = styled(Img, { name: 'ManifestListItem', slot: 'logo' })(({ theme }) => ({
+const StyledLogo = styled(ImageWithFallback, {
+  name: 'ManifestListItem',
+  slot: 'logo',
+})(() => ({
   height: '2.5rem',
   maxWidth: '100%',
   objectFit: 'contain',
@@ -128,17 +131,28 @@ export function ManifestListItem({
               ref={buttonRef}
               className={ns('manifest-list-item-title')}
               onClick={handleOpenButtonClick}
-              sx={{ alignItems: 'center', justifyContent: 'flex-start', width: '100%' }}
+              sx={{
+                alignItems: 'center',
+                justifyContent: 'flex-start',
+                width: '100%',
+              }}
             >
               <Grid container component="div" sx={{ width: '100%' }}>
-                <Grid size={3} sx={{ alignItems: 'center', display: 'flex', justifyContent: 'flex-start' }}>
+                <Grid
+                  size={3}
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'flex-start',
+                  }}
+                >
                   {thumbnail ? (
                     <StyledThumbnail
-                      className={[ns('manifest-list-item-thumb')]}
-                      src={[thumbnail]}
+                      className={ns('manifest-list-item-thumb')}
+                      src={thumbnail}
                       alt=""
                       height="80"
-                      unloader={
+                      fallback={
                         <Skeleton variant="rectangular" animation={false} sx={{ bgcolor: 'grey[300]' }} height={80} width={120} />
                       }
                     />
@@ -168,10 +182,10 @@ export function ManifestListItem({
           <Grid size={{ sm: 3, xs: 4 }}>
             {manifestLogo && (
               <StyledLogo
-                src={[manifestLogo]}
+                src={manifestLogo}
                 alt=""
                 role="presentation"
-                unloader={
+                fallback={
                   <Skeleton variant="rectangular" animation={false} sx={{ bgcolor: 'grey[300]' }} height={60} width={60} />
                 }
               />


### PR DESCRIPTION
- **Replace react-image with our own ImageWithFallback**
- **Report to failedImageContext and use Img.decode**

Replaces / rebases / adds to @jcoyne 's https://github.com/ProjectMirador/mirador/pull/4267

Closes https://github.com/ProjectMirador/mirador/issues/4378 
Closes https://github.com/ProjectMirador/mirador/issues/4266

Looks like
<img width="1447" height="143" alt="Screenshot 2026-08-18 at 3 35 02 PM" src="https://github.com/user-attachments/assets/d420d7d3-be00-4298-89e3-5a94478653e9" />
