### PR TITLE
Ignore non-quick touch/pen gestures over annotations in onCanvasClick

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.jsx
+++ b/__tests__/src/components/AnnotationsOverlay.test.jsx
@@ -240,6 +240,52 @@ describe('AnnotationsOverlay', () => {
 
       expect(selectAnnotation).toHaveBeenCalledWith('base', 'http://example.org/identifier/annotation/anno-line');
     });
+
+    /** Raises canvas-click over the single test annotation with the given gesture shape */
+    const clickAnnotationWithGesture = (pointerType, quick) => {
+      const selectAnnotation = vi.fn();
+
+      const { viewer } = createWrapper({
+        annotations: [
+          new AnnotationList({
+            '@id': 'foo',
+            resources: [
+              {
+                '@id': 'http://example.org/identifier/annotation/anno-line',
+                '@type': 'oa:Annotation',
+                motivation: 'sc:painting',
+                on: 'http://iiif.io/api/presentation/2.0/example/fixtures/canvas/24/c1.json#xywh=100,100,250,20',
+              },
+            ],
+          }),
+        ],
+        selectAnnotation,
+      });
+
+      viewer.raiseEvent('canvas-click', {
+        eventSource: { viewport: viewer.viewport },
+        originalEvent: { pointerType },
+        position: new OpenSeadragon.Point(101, 101),
+        quick,
+      });
+
+      return selectAnnotation;
+    };
+
+    it('ignores a non-quick touch gesture (pinch/pan) over an annotation', () => {
+      expect(clickAnnotationWithGesture('touch', false)).not.toHaveBeenCalled();
+    });
+
+    it('ignores a non-quick pen gesture over an annotation', () => {
+      expect(clickAnnotationWithGesture('pen', false)).not.toHaveBeenCalled();
+    });
+
+    it('still selects on a quick touch tap over an annotation', () => {
+      expect(clickAnnotationWithGesture('touch', true)).toHaveBeenCalledWith(
+        'base',
+        'http://example.org/identifier/annotation/anno-line',
+      );
+    });
   });
 
   describe('onCanvasMouseMove', () => {

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -29,6 +29,19 @@ function isAnnotationAtPoint(canvasWorld, osdCanvasOverlay, resource, canvas, po
 }
 
 /**
+ * See: https://openseadragon.github.io/docs/OpenSeadragon.Viewer.html#.event:canvas-click
+ * Gestures returned from this method are likely viewer interactions such as pan and zoom,
+ * not taps and clicks targeted to an annotation.
+ * In deciding whether to change the display of the annotation overlay,
+ * we want to ignore these irrelevant gestures.
+ * @private
+ */
+function isIgnoredGesture(event) {
+  const pointerType = event.originalEvent?.pointerType;
+  return (pointerType === 'touch' || pointerType === 'pen') && event.quick === false;
+}
+
+/**
  * Represents a OpenSeadragonViewer in the mirador workspace. Responsible for mounting
  * and rendering OSD.
  */
@@ -131,6 +144,8 @@ export function AnnotationsOverlay({
 
   const onCanvasClick = useCallback(
     (event) => {
+      if (isIgnoredGesture(event)) return;
+
       const {
         position: webPosition,
         eventSource: { viewport },


### PR DESCRIPTION
This rebases and takes over https://github.com/ProjectMirador/mirador/pull/4396/changes which was abandoned 
Closes #4184 
