### PR TITLE
Update tests to ensure we wrap contents in a menulist

### DIFF
--- a/__tests__/src/components/LanguageSettings.test.jsx
+++ b/__tests__/src/components/LanguageSettings.test.jsx
@@ -1,12 +1,17 @@
 import { render, screen } from '@tests/utils/test-utils';
 import userEvent from '@testing-library/user-event';
+import MenuList from '@mui/material/MenuList';
 import { LanguageSettings } from '../../../src/components/LanguageSettings';
 
 /**
  * Helper function to create a shallow wrapper around LanguageSettings
  */
 function createWrapper(props) {
-  return render(<LanguageSettings handleClick={() => {}} languages={{}} {...props} />);
+  return render(
+    <MenuList>
+      <LanguageSettings handleClick={() => {}} languages={{}} {...props} />
+    </MenuList>,
+  );
 }
 
 describe('LanguageSettings', () => {

--- a/__tests__/src/components/NestedMenu.test.jsx
+++ b/__tests__/src/components/NestedMenu.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@tests/utils/test-utils';
 import userEvent from '@testing-library/user-event';
+import MenuList from '@mui/material/MenuList';
 import { NestedMenu } from '../../../src/components/NestedMenu';
 
 /**
@@ -7,9 +8,11 @@ import { NestedMenu } from '../../../src/components/NestedMenu';
  */
 function createWrapper(props) {
   return render(
-    <NestedMenu icon="GivenIcon" label="GivenLabel" {...props}>
-      GivenChildren
-    </NestedMenu>,
+    <MenuList>
+      <NestedMenu icon="GivenIcon" label="GivenLabel" {...props}>
+        GivenChildren
+      </NestedMenu>
+    </MenuList>,
   );
 }
 


### PR DESCRIPTION
This is required for MUI 9.x, but presumable a good idea now too.