### PR TITLE
Guard against missing companion windows ids.

### DIFF
--- a/src/state/selectors/companionWindows.js
+++ b/src/state/selectors/companionWindows.js
@@ -76,7 +76,7 @@ const getCompanionWindowsByWindowAndPosition = createSelector([getWindows, getCo
     (obj, id) => ({
       ...obj,
       [id]: groupBy(
-        windows[id].companionWindowIds.map((cwid) => companionWindows[cwid]),
+        (windows[id].companionWindowIds || []).map((cwid) => companionWindows[cwid]),
         (cw) => cw.position,
       ),
     }),


### PR DESCRIPTION
I don't think this is a real case (outside of tests) but seems like a harmless enough fallback to introduce 🤷 