### PR TITLE
Use setCanvas instead of updateWindow to change visible canvases.

### DIFF
--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -403,12 +403,9 @@ describe('window-level sagas', () => {
         .provide([
           [select(getWindow, { windowId }), { canvasId: 'y' }],
           [select(getCanvasGrouping, { canvasId: 'y', windowId }), [{ id: 'y' }, { id: 'z' }]],
+          [call(setCanvas, windowId, 'y', ['y', 'z']), { type: 'expectedThunk' }],
         ])
-        .put({
-          id: windowId,
-          payload: { visibleCanvases: ['y', 'z'] },
-          type: ActionTypes.UPDATE_WINDOW,
-        })
+        .put({ type: 'expectedThunk' })
         .run();
     });
   });

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -205,7 +205,14 @@ export function* panToFocusedWindow({ pan, windowId }) {
 export function* updateVisibleCanvases({ windowId }) {
   const { canvasId } = yield select(getWindow, { windowId });
   const visibleCanvases = yield select(getCanvasGrouping, { canvasId, windowId });
-  yield put(updateWindow(windowId, { visibleCanvases: (visibleCanvases || []).map((c) => c.id) }));
+
+  const thunk = yield call(
+    setCanvas,
+    windowId,
+    canvasId,
+    (visibleCanvases || []).map((c) => c.id),
+  );
+  yield put(thunk);
 }
 
 /** @private */


### PR DESCRIPTION
An alternative to #4449, with the added benefit that we'll fetch annotations (or anything else that is normally triggered by SET_CANVAS)

closes https://github.com/ProjectMirador/mirador/issues/3276
closes #4393