### PR TITLE
boundsChanged is not the only case we need to re-fit the viewer

### DIFF
--- a/__tests__/fixtures/version-2/fg165hz3589.json
+++ b/__tests__/fixtures/version-2/fg165hz3589.json
@@ -200,7 +200,7 @@
           "@type": "sc:Canvas",
           "label": "Page 5",
           "height": 3281,
-          "width": 2536,
+          "width": 2527,
           "images": [
             {
               "@id": "https://purl.stanford.edu/fg165hz3589/iiif/annotation/fg165hz3589_5",
@@ -211,7 +211,7 @@
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 3281,
-                "width": 2536,
+                "width": 2527,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://stacks.stanford.edu/image/iiif/fg165hz3589%2Ffg165hz3589_5",

--- a/__tests__/src/components/OpenSeadragonComponent.test.jsx
+++ b/__tests__/src/components/OpenSeadragonComponent.test.jsx
@@ -52,10 +52,11 @@ describe('OpenSeadragonComponent', () => {
   /**
    * Render component and complete initial tile loading
    * @param {Array} bounds - Initial bounds
+   * @param {Array} canvasIds - Initial canvas ids
    * @returns {object} Render result
    */
-  function renderAndInitialize(bounds = [0, 0, 5000, 3000]) {
-    const result = render(<OpenSeadragonComponent viewerConfig={{ bounds }} />);
+  function renderAndInitialize(bounds = [0, 0, 5000, 3000], canvasIds = undefined) {
+    const result = render(<OpenSeadragonComponent viewerConfig={{ bounds }} canvasIds={canvasIds} />);
 
     // Component registers a 'tile-loaded' handler during mount to set initial viewport
     invokeTileLoadedHandler();
@@ -101,17 +102,15 @@ describe('OpenSeadragonComponent', () => {
     expect(fitBoundsWithConstraints).not.toHaveBeenCalled();
   });
 
-  // Regression test: `boundsChanged` compares the pixel bounds, not
-  // which canvases are being viewed. Two different canvas pairs can round to
-  // the exact same worldBounds() via Math.floor() — see
-  // __tests__/fixtures/version-2/fg165hz3589.json canvases 2-3 vs 4-5
-  // This currently fails, since `OpenSeadragonComponent` has no way to
-  // tell "still the same canvases" apart from "coincidentally the same shape".
+  // Regression test: `boundsChanged` compares the pixel bounds, not which
+  // canvases are being viewed. Two different canvas pairs can round to the
+  // exact same worldBounds() via Math.floor()
+  // see __tests__/fixtures/version-2/fg165hz3589.json canvases 2-3 vs 4-5
   it('still re-fits when navigating to a different canvas pair whose bounds coincidentally match', () => {
-    const { rerender } = renderAndInitialize([0, 0, 5059, 3279]);
+    const { rerender } = renderAndInitialize([0, 0, 5059, 3279], ['canvas-2', 'canvas-3']);
 
     // Navigate to a different canvas pair with numerically identical worldBounds
-    rerender(<OpenSeadragonComponent viewerConfig={{ bounds: [0, 0, 5059, 3279] }} />);
+    rerender(<OpenSeadragonComponent viewerConfig={{ bounds: [0, 0, 5059, 3279] }} canvasIds={['canvas-4', 'canvas-5']} />);
     invokeTileLoadedHandler();
 
     expect(fitBoundsWithConstraints).toHaveBeenCalledWith(
@@ -123,5 +122,14 @@ describe('OpenSeadragonComponent', () => {
       }),
       true,
     );
+  });
+
+  it('does not reset zoom when neither bounds nor canvas selection change', () => {
+    const { rerender } = renderAndInitialize([0, 0, 5000, 3000], ['canvas-1']);
+
+    rerender(<OpenSeadragonComponent viewerConfig={{ bounds: [0, 0, 5000, 3000] }} canvasIds={['canvas-1']} />);
+
+    expect(addOnceHandler).not.toHaveBeenCalled();
+    expect(fitBoundsWithConstraints).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/src/components/OpenSeadragonComponent.test.jsx
+++ b/__tests__/src/components/OpenSeadragonComponent.test.jsx
@@ -100,4 +100,28 @@ describe('OpenSeadragonComponent', () => {
     // Should not call fitBoundsWithConstraints
     expect(fitBoundsWithConstraints).not.toHaveBeenCalled();
   });
+
+  // Regression test: `boundsChanged` compares the pixel bounds, not
+  // which canvases are being viewed. Two different canvas pairs can round to
+  // the exact same worldBounds() via Math.floor() — see
+  // __tests__/fixtures/version-2/fg165hz3589.json canvases 2-3 vs 4-5
+  // This currently fails, since `OpenSeadragonComponent` has no way to
+  // tell "still the same canvases" apart from "coincidentally the same shape".
+  it('still re-fits when navigating to a different canvas pair whose bounds coincidentally match', () => {
+    const { rerender } = renderAndInitialize([0, 0, 5059, 3279]);
+
+    // Navigate to a different canvas pair with numerically identical worldBounds
+    rerender(<OpenSeadragonComponent viewerConfig={{ bounds: [0, 0, 5059, 3279] }} />);
+    invokeTileLoadedHandler();
+
+    expect(fitBoundsWithConstraints).toHaveBeenCalledWith(
+      expect.objectContaining({
+        height: 3279,
+        width: 5059,
+        x: 0,
+        y: 0,
+      }),
+      true,
+    );
+  });
 });

--- a/src/components/OpenSeadragonComponent.jsx
+++ b/src/components/OpenSeadragonComponent.jsx
@@ -11,6 +11,7 @@ function OpenSeadragonComponent({
   Container = 'div',
   osdConfig = {},
   viewerConfig = {},
+  canvasIds = undefined,
   onUpdateViewport = () => {},
   setViewer = () => {},
   style = {},
@@ -22,6 +23,7 @@ function OpenSeadragonComponent({
   const viewerRef = useRef(undefined);
   const initialViewportSet = useRef(false);
   const lastAppliedBounds = useRef(null);
+  const lastCanvasIds = useRef(null);
   const isResettingViewport = useRef(false);
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
@@ -82,12 +84,13 @@ function OpenSeadragonComponent({
         if (viewerConfig.bounds) {
           viewport.fitBounds(new Openseadragon.Rect(...viewerConfig.bounds), true);
           lastAppliedBounds.current = viewerConfig.bounds;
+          lastCanvasIds.current = canvasIds;
         } else {
           viewport.goHome(true);
         }
       }
     },
-    [initialViewportSet, viewerConfig],
+    [initialViewportSet, viewerConfig, canvasIds],
   );
 
   useEffect(() => {
@@ -108,10 +111,19 @@ function OpenSeadragonComponent({
         viewerConfig.bounds.length !== lastAppliedBounds.current.length ||
         viewerConfig.bounds.some((val, idx) => val !== lastAppliedBounds.current[idx]);
 
-      // Bounds changed - recenter regardless of whether x/y/zoom exist
-      if (boundsChanged) {
+      // Different canvases can coincidentally round to identical bounds,
+      // so also recenter whenever the canvas selection itself changed
+      const canvasIdsChanged =
+        canvasIds !== undefined &&
+        (!lastCanvasIds.current ||
+          canvasIds.length !== lastCanvasIds.current.length ||
+          canvasIds.some((canvasId, idx) => canvasId !== lastCanvasIds.current[idx]));
+
+      // Bounds (or canvas selection) changed - recenter regardless of whether x/y/zoom exist
+      if (boundsChanged || canvasIdsChanged) {
         isResettingViewport.current = true;
         lastAppliedBounds.current = viewerConfig.bounds;
+        lastCanvasIds.current = canvasIds;
 
         // Wait for the tiles to be fully loaded before recentering
         const handleTilesLoaded = () => {
@@ -154,7 +166,7 @@ function OpenSeadragonComponent({
     if (viewerConfig.flip != null && (viewerConfig.flip || false) !== viewport.getFlip()) {
       viewport.setFlip(viewerConfig.flip);
     }
-  }, [initialViewportSet, setInitialBounds, viewerConfig, viewerRef]);
+  }, [initialViewportSet, setInitialBounds, viewerConfig, viewerRef, canvasIds]);
 
   // initialize OSD stuff when this component is mounted
   useEffect(() => {
@@ -239,6 +251,7 @@ function OpenSeadragonComponent({
 }
 
 OpenSeadragonComponent.propTypes = {
+  canvasIds: PropTypes.arrayOf(PropTypes.string),
   children: PropTypes.node,
   Container: PropTypes.elementType,
   onUpdateViewport: PropTypes.func,

--- a/src/components/OpenSeadragonViewer.jsx
+++ b/src/components/OpenSeadragonViewer.jsx
@@ -101,6 +101,7 @@ export function OpenSeadragonViewer({
       Container={StyledSection}
       osdConfig={osdConfig}
       viewerConfig={viewerConfig || (canvasWorld.hasDimensions() ? { bounds: canvasWorld.worldBounds() } : undefined)}
+      canvasIds={canvasWorld.canvasIds}
       onUpdateViewport={onViewportChange}
       setViewer={setViewer}
       aria-label={t('item', { label })}


### PR DESCRIPTION
- **Test that we refit viewer between canvases, even if bounds are the same**
- **Also check for changed canvasIds when refitting the viewer**

@dnoneill tracked down a strangely consistent bug where on page 8 of the Durham University demo (go to https://mirador-dev.netlify.app/ and scroll to the bottom of the available manifests) -- the canvas was not recentering the facing pages.

<img width="1445" height="777" alt="Screenshot 2026-08-20 at 3 02 17 PM" src="https://github.com/user-attachments/assets/4710845e-2649-4735-bf35-9b02611582a0" />

<img width="1437" height="772" alt="Screenshot 2026-08-20 at 3 01 29 PM" src="https://github.com/user-attachments/assets/11724e39-8e36-408c-aee2-875d7d0ea3cf" />


I was confused why this was so consistent, when other facing page centering issues seemed to have been fixed by past PRs. And it only happened on page 8.

I asked AI to tell me if there was anything strange or unique about page 8 -- it came back to say that unlike the preceding canvases, `canvasDimensions` were coincidently identical for pages 6-7 and 8-9:
```
(canvases "6-7") → bounds (0, 0, 12596, 7048)
(canvases "8-9") → bounds (0, 0, 12596, 7048)   ← IDENTICAL
```
So, this led me to see that we calculate all our re-fitting based on `boundsChanged`. I changed one of our fixtures to replicate this random coincidence and tested for it. 