### PR TITLE
Bugfix: prevent thumbnail focus from scrolling outer page

### DIFF
--- a/__tests__/src/components/ThumbnailNavigation.test.jsx
+++ b/__tests__/src/components/ThumbnailNavigation.test.jsx
@@ -34,6 +34,16 @@ describe('ThumbnailNavigation', () => {
 
     expect(screen.getByRole('grid')).toBeInTheDocument();
   });
+
+  it('restores focus without scrolling the page into view', () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
+
+    render(<Subject />);
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+
+    focusSpy.mockRestore();
+  });
   it('renders containers based off of number of canvases', () => {
     render(<Subject />);
 

--- a/src/components/ThumbnailNavigation.jsx
+++ b/src/components/ThumbnailNavigation.jsx
@@ -63,7 +63,10 @@ export function ThumbnailNavigation({
 
   useEffect(() => {
     if (paperRef.current && document.activeElement !== paperRef.current) {
-      paperRef.current.focus();
+      // This effect runs on mount too (not just keyboard navigation)
+      // Without preventScroll, the browser scrolls this element into view
+      // Inside an iframe embed, that scrolls the whole outer page down to the viewer
+      paperRef.current.focus({ preventScroll: true });
     }
   }, [canvasIndex]);
 


### PR DESCRIPTION
This can currently be seen on projectmirador.org :(
You can confirm the behavior on the /iframe demo page