### PR TITLE
Stop using deprecated getDescription from Manifesto.js

### DIFF
--- a/__tests__/src/components/ManifestInfo.test.jsx
+++ b/__tests__/src/components/ManifestInfo.test.jsx
@@ -7,12 +7,7 @@ describe('ManifestInfo', () => {
   describe('when metadata is present', () => {
     beforeEach(() => {
       render(
-        <ManifestInfo
-          manifestLabel="The Manifest Label"
-          manifestDescription="The Manifest Description"
-          manifestMetadata={metadata}
-          manifestSummary="The Manifest Summary"
-        />,
+        <ManifestInfo manifestLabel="The Manifest Label" manifestMetadata={metadata} manifestSummary="The Manifest Summary" />,
       );
     });
 
@@ -22,10 +17,6 @@ describe('ManifestInfo', () => {
 
     it('renders manifest label', () => {
       expect(screen.getByRole('heading', { level: 5 })).toHaveTextContent('The Manifest Label');
-    });
-
-    it('renders manifest description in SanitizedHtml component', () => {
-      expect(screen.getByText('The Manifest Description')).toBeInTheDocument();
     });
 
     it('renders manifest summary in SanitizedHtml component', () => {

--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -16,7 +16,6 @@ import {
   getDestructuredMetadata,
   getManifestStatus,
   getManifestLogo,
-  getManifestDescription,
   getManifestHomepage,
   getProviderLogo,
   getManifestProviderName,
@@ -132,22 +131,15 @@ describe('getManifestTitle', () => {
   });
 });
 
-describe('getManifestDescription', () => {
-  it('should return manifest description', () => {
-    const state = { manifests: { x: { json: manifestFixture001 } } };
-    const received = getManifestDescription(state, { manifestId: 'x' });
-    expect(received).toBe('[Handbill of Mr. Becket, [1787] ]');
-  });
-
-  it('should return undefined if manifest undefined', () => {
-    const received = getManifestDescription({ manifests: {} }, { manifestId: 'x' });
-    expect(received).toBeUndefined();
-  });
-});
-
 describe('getManifestSummary', () => {
   it('should return manifest summary', () => {
     const state = { manifests: { x: { json: manifestFixturev3001 } } };
+    const received = getManifestSummary(state, { manifestId: 'x' });
+    expect(received).toBe('[Handbill of Mr. Becket, [1787] ]');
+  });
+
+  it('should fall back to the v2 description when summary is absent', () => {
+    const state = { manifests: { x: { json: manifestFixture001 } } };
     const received = getManifestSummary(state, { manifestId: 'x' });
     expect(received).toBe('[Handbill of Mr. Becket, [1787] ]');
   });

--- a/src/components/ManifestInfo.jsx
+++ b/src/components/ManifestInfo.jsx
@@ -10,17 +10,10 @@ import { PluginHook } from './PluginHook';
 /**
  * ManifestInfo
  */
-export function ManifestInfo({
-  manifestDescription = null,
-  manifestLabel = null,
-  manifestMetadata = [],
-  manifestSummary = null,
-  ...rest
-}) {
+export function ManifestInfo({ manifestLabel = null, manifestMetadata = [], manifestSummary = null, ...rest }) {
   const { t } = useTranslation();
   const id = useId();
   const pluginProps = {
-    manifestDescription,
     manifestLabel,
     manifestMetadata,
     manifestSummary,
@@ -40,12 +33,6 @@ export function ManifestInfo({
         </Typography>
       )}
 
-      {manifestDescription && (
-        <Typography variant="body1">
-          <SanitizedHtml htmlString={manifestDescription} ruleSet="iiif" />
-        </Typography>
-      )}
-
       {manifestSummary && (
         <Typography variant="body1">
           <SanitizedHtml htmlString={manifestSummary} ruleSet="iiif" />
@@ -60,7 +47,6 @@ export function ManifestInfo({
 }
 
 ManifestInfo.propTypes = {
-  manifestDescription: PropTypes.string,
   manifestLabel: PropTypes.string,
   manifestMetadata: PropTypes.array,
   manifestSummary: PropTypes.string,

--- a/src/containers/ManifestInfo.js
+++ b/src/containers/ManifestInfo.js
@@ -1,7 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withPlugins } from '../extend/withPlugins';
-import { getManifestDescription, getManifestSummary, getManifestTitle, getManifestMetadata } from '../state/selectors';
+import { getManifestSummary, getManifestTitle, getManifestMetadata } from '../state/selectors';
 import { ManifestInfo } from '../components/ManifestInfo';
 
 /**
@@ -10,11 +10,6 @@ import { ManifestInfo } from '../components/ManifestInfo';
  * @private
  */
 const mapStateToProps = (state, { companionWindowId, manifestId, windowId }) => ({
-  manifestDescription: getManifestDescription(state, {
-    companionWindowId,
-    manifestId,
-    windowId,
-  }),
   manifestLabel: getManifestTitle(state, { companionWindowId, manifestId, windowId }),
   manifestMetadata: getManifestMetadata(state, { companionWindowId, manifestId, windowId }),
   manifestSummary: getManifestSummary(state, {

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -291,10 +291,17 @@ export const getManifestTitle = createSelector(
  * @param {string} props.windowId
  * @return {string|null}
  */
-export const getManifestSummary = createSelector(
+const getManifestSummary = createSelector(
   [getLocale, getManifestoInstance],
   (locale, manifest) => manifest && manifest.getSummary().getValue(locale),
 );
+
+export { getManifestSummary };
+
+/**
+ * @deprecated Use `getManifestSummary` instead
+ */
+export const getManifestDescription = getManifestSummary;
 
 /**
  * Return manifest title.

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -284,20 +284,7 @@ export const getManifestTitle = createSelector(
 );
 
 /**
- * Return manifest description (IIIF v2) -- distinct from any description field nested under metadata.
- * @param {object} state
- * @param {object} props
- * @param {string} props.manifestId
- * @param {string} props.windowId
- * @returns {string|null}
- */
-export const getManifestDescription = createSelector(
-  [getLocale, getManifestoInstance],
-  (locale, manifest) => manifest && manifest.getDescription().getValue(locale),
-);
-
-/**
- * Return manifest summary (IIIF v3).
+ * manifesto.js getSummary method handles fallback for presentation 3 and 2
  * @param {object} state
  * @param {object} props
  * @param {string} props.manifestId
@@ -305,8 +292,8 @@ export const getManifestDescription = createSelector(
  * @return {string|null}
  */
 export const getManifestSummary = createSelector(
-  [getProperty('summary'), getManifestLocale],
-  (summary, locale) => summary && PropertyValue.parse(summary).getValue(locale),
+  [getLocale, getManifestoInstance],
+  (locale, manifest) => manifest && manifest.getSummary().getValue(locale),
 );
 
 /**


### PR DESCRIPTION
Manifesto's getSummary handles the Presentation 3 to 2 fallback
We were printing both getSummary and the old getDescription, which led to the bug reported by a user on the Mirador Slack channel