### PR TITLE
Rename for clarity internal saga functions that share name with action creators

### DIFF
--- a/__tests__/src/sagas/app.test.js
+++ b/__tests__/src/sagas/app.test.js
@@ -1,7 +1,7 @@
 import { call } from 'redux-saga/effects';
 import { expectSaga, testSaga } from 'redux-saga-test-plan';
 
-import { fetchCollectionManifests, importConfig, importState } from '../../../src/state/sagas/app';
+import { fetchCollectionManifestsForDialog, importConfigSaga, importState } from '../../../src/state/sagas/app';
 import { fetchManifests } from '../../../src/state/sagas/iiif';
 import { fetchWindowManifest } from '../../../src/state/sagas/windows';
 import { addWindow } from '../../../src/state/actions';
@@ -50,7 +50,7 @@ describe('app-level sagas', () => {
     });
   });
 
-  describe('importConfig', () => {
+  describe('importConfigSaga', () => {
     it('adds windows from the provided config', () => {
       const action = {
         config: {
@@ -62,7 +62,7 @@ describe('app-level sagas', () => {
         },
       };
 
-      return expectSaga(importConfig, action)
+      return expectSaga(importConfigSaga, action)
         .provide([
           [
             call(addWindow, {
@@ -87,14 +87,14 @@ describe('app-level sagas', () => {
     });
   });
 
-  describe('fetchCollectionManifests', () => {
+  describe('fetchCollectionManifestsForDialog', () => {
     it('fetches ressources for manifestId and all collection path ids', () => {
       const action = {
         dialogCollectionPath: ['a', 'b'],
         manifestId: 'c',
         windowId: 'w',
       };
-      testSaga(fetchCollectionManifests, action).next().call(fetchManifests, 'c', 'a', 'b');
+      testSaga(fetchCollectionManifestsForDialog, action).next().call(fetchManifests, 'c', 'a', 'b');
     });
   });
 });

--- a/__tests__/src/sagas/auth.test.js
+++ b/__tests__/src/sagas/auth.test.js
@@ -11,7 +11,7 @@ import {
   rerequestOnAccessTokenFailure,
   invalidateInvalidAuth,
 } from '../../../src/state/sagas/auth';
-import { fetchInfoResponse } from '../../../src/state/sagas/iiif';
+import { fetchInfoResponseSaga } from '../../../src/state/sagas/iiif';
 import {
   getAccessTokens,
   getWindows,
@@ -165,9 +165,9 @@ describe('IIIF Authentication sagas', () => {
           [select(getWindows), { window }],
           [select(getVisibleCanvases, { windowId: 'window' }), canvases],
           [select(selectInfoResponses), { [iiifInfoId]: infoResponse }],
-          [call(fetchInfoResponse, { infoId: iiifInfoId }), {}],
+          [call(fetchInfoResponseSaga, { infoId: iiifInfoId }), {}],
         ])
-        .call(fetchInfoResponse, { infoId: iiifInfoId })
+        .call(fetchInfoResponseSaga, { infoId: iiifInfoId })
         .run();
     });
   });

--- a/__tests__/src/sagas/iiif.test.js
+++ b/__tests__/src/sagas/iiif.test.js
@@ -2,22 +2,22 @@ import { select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import {
   fetchAnnotation,
-  fetchManifest,
+  fetchManifestSaga,
   fetchSearchResponse,
-  fetchInfoResponse,
+  fetchInfoResponseSaga,
   fetchResourceManifest,
 } from '../../../src/state/sagas/iiif';
 import { getConfig, getManifests, selectInfoResponse, getAccessTokens, getRequestsConfig } from '../../../src/state/selectors';
 
 describe('IIIF sagas', () => {
-  describe('fetchManifest', () => {
+  describe('fetchManifestSaga', () => {
     it('fetches a IIIF manifest', () => {
       fetch.mockResponseOnce(JSON.stringify({ data: '12345' }));
       const action = {
         manifestId: 'manifestId',
       };
 
-      return expectSaga(fetchManifest, action)
+      return expectSaga(fetchManifestSaga, action)
         .provide([[select(getConfig), {}]])
         .put({
           manifestId: 'manifestId',
@@ -33,7 +33,7 @@ describe('IIIF sagas', () => {
         manifestId: 'manifestId',
       };
 
-      return expectSaga(fetchManifest, action)
+      return expectSaga(fetchManifestSaga, action)
         .provide([[select(getConfig), {}]])
         .put.actionType('mirador/RECEIVE_MANIFEST_FAILURE')
         .run();
@@ -49,7 +49,7 @@ describe('IIIF sagas', () => {
         manifestId: 'https://example.org/manifestId',
       };
 
-      return expectSaga(fetchManifest, action)
+      return expectSaga(fetchManifestSaga, action)
         .provide([[select(getConfig), {}]])
         .put({
           error: '404 Not Found: https://example.org/manifestId',
@@ -65,7 +65,7 @@ describe('IIIF sagas', () => {
         manifestId: 'manifestId',
       };
 
-      return expectSaga(fetchManifest, action)
+      return expectSaga(fetchManifestSaga, action)
         .provide([
           [
             select(getRequestsConfig),
@@ -88,7 +88,7 @@ describe('IIIF sagas', () => {
         manifestId: 'manifestId',
       };
 
-      return expectSaga(fetchManifest, action)
+      return expectSaga(fetchManifestSaga, action)
         .provide([
           [
             select(getRequestsConfig),
@@ -111,7 +111,7 @@ describe('IIIF sagas', () => {
     });
   });
 
-  describe('fetchInfoResponse', () => {
+  describe('fetchInfoResponseSaga', () => {
     it('fetches a IIIF info response', () => {
       fetch.mockResponseOnce(JSON.stringify({ id: 'http://server/prefix/infoId' }));
       const action = {
@@ -119,7 +119,7 @@ describe('IIIF sagas', () => {
         infoId: 'http://server/prefix/infoId',
       };
 
-      return expectSaga(fetchInfoResponse, action)
+      return expectSaga(fetchInfoResponseSaga, action)
         .put({
           infoId: 'http://server/prefix/infoId',
           infoJson: { id: 'http://server/prefix/infoId' },
@@ -152,7 +152,7 @@ describe('IIIF sagas', () => {
         ],
       };
 
-      return expectSaga(fetchInfoResponse, action)
+      return expectSaga(fetchInfoResponseSaga, action)
         .provide([
           [select(selectInfoResponse, { infoId: 'infoId' }), infoResponse],
           [
@@ -179,7 +179,7 @@ describe('IIIF sagas', () => {
         infoId: 'infoId',
       };
 
-      return expectSaga(fetchInfoResponse, action).put.actionType('mirador/RECEIVE_INFO_RESPONSE_FAILURE').run();
+      return expectSaga(fetchInfoResponseSaga, action).put.actionType('mirador/RECEIVE_INFO_RESPONSE_FAILURE').run();
     });
     it('handles degraded requests', () => {
       fetch.mockResponseOnce(JSON.stringify({ id: 'otherInfoId' }));
@@ -189,7 +189,7 @@ describe('IIIF sagas', () => {
         windowId: 'window',
       };
 
-      return expectSaga(fetchInfoResponse, action)
+      return expectSaga(fetchInfoResponseSaga, action)
         .put({
           infoId: 'infoId',
           infoJson: { id: 'otherInfoId' },
@@ -224,7 +224,7 @@ describe('IIIF sagas', () => {
         infoId: 'infoId',
       };
 
-      return expectSaga(fetchInfoResponse, action)
+      return expectSaga(fetchInfoResponseSaga, action)
         .provide([
           [select(selectInfoResponse, { infoId: 'infoId' }), undefined],
           [

--- a/src/state/sagas/app.js
+++ b/src/state/sagas/app.js
@@ -18,7 +18,7 @@ export function* importState(action) {
 }
 
 /** Add windows from the imported config */
-export function* importConfig({ config: { thumbnailNavigation, windows } }) {
+export function* importConfigSaga({ config: { thumbnailNavigation, windows } }) {
   if (!windows || windows.length === 0) return;
 
   const thunks = yield all(
@@ -41,7 +41,7 @@ export function* importConfig({ config: { thumbnailNavigation, windows } }) {
 }
 
 /** */
-export function* fetchCollectionManifests(action) {
+export function* fetchCollectionManifestsForDialog(action) {
   const { dialogCollectionPath, manifestId } = action;
   yield call(fetchManifests, manifestId, ...dialogCollectionPath);
 }
@@ -50,7 +50,7 @@ export function* fetchCollectionManifests(action) {
 export default function* appSaga() {
   yield all([
     takeEvery(ActionTypes.IMPORT_MIRADOR_STATE, importState),
-    takeEvery(ActionTypes.IMPORT_CONFIG, importConfig),
-    takeEvery(ActionTypes.SHOW_COLLECTION_DIALOG, fetchCollectionManifests),
+    takeEvery(ActionTypes.IMPORT_CONFIG, importConfigSaga),
+    takeEvery(ActionTypes.SHOW_COLLECTION_DIALOG, fetchCollectionManifestsForDialog),
   ]);
 }

--- a/src/state/sagas/auth.js
+++ b/src/state/sagas/auth.js
@@ -11,7 +11,7 @@ import {
   getAccessTokens,
   getMiradorCanvasWrapper,
 } from '../selectors';
-import { fetchInfoResponse } from './iiif';
+import { fetchInfoResponseSaga } from './iiif';
 
 /** */
 export function* refetchInfoResponsesOnLogout({ tokenServiceId }) {
@@ -52,7 +52,7 @@ export function* refetchInfoResponses({ serviceId }) {
   yield all(
     obsoleteInfoResponses.map(({ id: infoId }) => {
       if (visibleImageApiIds.includes(infoId)) {
-        return call(fetchInfoResponse, { infoId });
+        return call(fetchInfoResponseSaga, { infoId });
       }
       return put({ infoId, type: ActionTypes.REMOVE_INFO_RESPONSE });
     }),

--- a/src/state/sagas/iiif.js
+++ b/src/state/sagas/iiif.js
@@ -129,7 +129,7 @@ function* fetchIiifResourceWithAuth(url, iiifResource, options, { degraded, fail
 }
 
 /** */
-export function* fetchManifest({ manifestId }) {
+export function* fetchManifestSaga({ manifestId }) {
   const callbacks = {
     failure: ({ error, json, response }) => receiveManifestFailure(manifestId, typeof error === 'object' ? String(error) : error),
     success: ({ json, response }) => receiveManifest(manifestId, json),
@@ -162,7 +162,7 @@ function* getAccessTokenService(resource) {
 }
 
 /** @private */
-export function* fetchInfoResponse({ imageResource, infoId, windowId }) {
+export function* fetchInfoResponseSaga({ imageResource, infoId, windowId }) {
   let iiifResource = imageResource;
   if (!iiifResource) {
     iiifResource = yield select(selectInfoResponse, { infoId });
@@ -208,7 +208,7 @@ export function* fetchResourceManifest({ manifestId, manifestJson }) {
   if (!manifestId) return;
 
   const manifests = yield select(getManifests) || {};
-  if (!manifests[manifestId]) yield* fetchManifest({ manifestId });
+  if (!manifests[manifestId]) yield* fetchManifestSaga({ manifestId });
 }
 
 /** */
@@ -217,15 +217,15 @@ export function* fetchManifests(...manifestIds) {
 
   for (let i = 0; i < manifestIds.length; i += 1) {
     const manifestId = manifestIds[i];
-    if (!manifests[manifestId]) yield call(fetchManifest, { manifestId });
+    if (!manifests[manifestId]) yield call(fetchManifestSaga, { manifestId });
   }
 }
 
 /** */
 export default function* iiifSaga() {
   yield all([
-    takeEvery(ActionTypes.REQUEST_MANIFEST, fetchManifest),
-    takeEvery(ActionTypes.REQUEST_INFO_RESPONSE, fetchInfoResponse),
+    takeEvery(ActionTypes.REQUEST_MANIFEST, fetchManifestSaga),
+    takeEvery(ActionTypes.REQUEST_INFO_RESPONSE, fetchInfoResponseSaga),
     takeEvery(ActionTypes.REQUEST_SEARCH, fetchSearchResponse),
     takeEvery(ActionTypes.REQUEST_ANNOTATION, fetchAnnotation),
     takeEvery(ActionTypes.ADD_RESOURCE, fetchResourceManifest),

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -81,7 +81,7 @@ export function* setCollectionPath({ manifestId, windowId }) {
 }
 
 /** */
-export function* fetchCollectionManifests(action) {
+export function* fetchCollectionManifestsOnWindowUpdate(action) {
   const { collectionPath } = action.payload;
   if (!collectionPath) return;
 
@@ -281,10 +281,10 @@ export default function* windowsSaga() {
     takeEvery(ActionTypes.ADD_WINDOW, fetchWindowManifest),
     takeEvery(ActionTypes.UPDATE_WINDOW, fetchWindowManifest),
     takeEvery(ActionTypes.UPDATE_WINDOW, setCanvasOnNewSequence),
-    takeEvery(ActionTypes.UPDATE_WINDOW, fetchCollectionManifests),
+    takeEvery(ActionTypes.UPDATE_WINDOW, fetchCollectionManifestsOnWindowUpdate),
     takeEvery(ActionTypes.SET_CANVAS, setCurrentAnnotationsOnCurrentCanvas),
     takeEvery(ActionTypes.SET_CANVAS, fetchInfoResponses),
-    takeEvery(ActionTypes.UPDATE_COMPANION_WINDOW, fetchCollectionManifests),
+    takeEvery(ActionTypes.UPDATE_COMPANION_WINDOW, fetchCollectionManifestsOnWindowUpdate),
     takeEvery(ActionTypes.SET_WINDOW_VIEW_TYPE, updateVisibleCanvases),
     takeEvery(ActionTypes.RECEIVE_SEARCH, setCanvasOfFirstSearchResult),
     takeEvery(ActionTypes.SELECT_ANNOTATION, setCanvasforSelectedAnnotation),


### PR DESCRIPTION
This is prep work for RTK saga migration
These saga generators shared exact names with unrelated action creators or with each other. This made it confusing to trace different action calls. These methods are not publicly exported so it should not impact plugins.