### PR TITLE
allow for empty tags, string body fields

### DIFF
--- a/__tests__/src/components/CanvasAnnotations.test.jsx
+++ b/__tests__/src/components/CanvasAnnotations.test.jsx
@@ -44,6 +44,23 @@ describe('CanvasAnnotations', () => {
     expect(screen.getByText('Item: [A Canvas Label]')).toBeInTheDocument();
   });
 
+  it('renders without crashing when a tag is undefined', () => {
+    expect(() =>
+      createWrapper({
+        annotations: [
+          {
+            content: 'First Annotation',
+            id: 'abc123',
+            tags: ['abc123', undefined],
+            targetId: 'example.com/iiif/12345',
+          },
+        ],
+      }),
+    ).not.toThrow();
+
+    expect(screen.getByText('abc123', { container: 'span.MuiChip-label' })).toBeInTheDocument();
+  });
+
   it('renders a heading with the appropriate context based on index and totalSize', () => {
     wrapper = createWrapper({ annotations, index: 1, totalSize: 2 });
     expect(screen.getByText('Right: [A Canvas Label]')).toBeInTheDocument();

--- a/__tests__/src/lib/AnnotationItem.test.js
+++ b/__tests__/src/lib/AnnotationItem.test.js
@@ -44,6 +44,14 @@ describe('AnnotationItem', () => {
         }).tags,
       ).toEqual(['lo']);
     });
+    it('has mixed body types', () => {
+      expect(
+        new AnnotationItem({
+          body: [{ purpose: 'tagging', value: 'yo' }, 'String body value'],
+          motivation: 'tagging',
+        }).tags,
+      ).toEqual(['yo', 'String body value']);
+    });
   });
 
   describe('targetId', () => {
@@ -113,6 +121,9 @@ describe('AnnotationItem', () => {
     });
     it('with a single body', () => {
       expect(new AnnotationItem({ body: { value: 'foo' } }).chars).toEqual('foo');
+    });
+    it('with a string body', () => {
+      expect(new AnnotationItem({ body: 'foo' }).chars).toEqual('foo');
     });
     it('with multiple bodies', () => {
       expect(new AnnotationItem({ body: [{ value: 'foo' }, { value: 'bar' }] }).chars).toEqual('foo bar');

--- a/src/components/CanvasAnnotations.jsx
+++ b/src/components/CanvasAnnotations.jsx
@@ -89,7 +89,7 @@ export function CanvasAnnotations({
               <ListItemText
                 primary={<SanitizedHtml ruleSet={htmlSanitizationRuleSet} htmlString={annotation.content} />}
                 secondary={annotation.tags.map((tag) => (
-                  <Chip component="span" size="small" variant="outlined" label={tag} id={tag} key={tag.toString()} />
+                  <Chip component="span" size="small" variant="outlined" label={tag} id={tag} key={tag?.toString()} />
                 ))}
                 slotProps={{
                   primary: { variant: 'body2' },

--- a/src/lib/AnnotationItem.js
+++ b/src/lib/AnnotationItem.js
@@ -34,6 +34,12 @@ export default class AnnotationItem {
     }
   }
 
+  /** */
+  bodyValue(body) {
+    if (typeof body === 'string') return body;
+    return body.value;
+  }
+
   /**
    * @return {[Array]}
    */
@@ -54,9 +60,9 @@ export default class AnnotationItem {
   /** */
   get tags() {
     if (this.isOnlyTag()) {
-      return this.body.map((r) => r.value);
+      return this.body.map((r) => this.bodyValue(r));
     }
-    return this.body.filter((r) => r.purpose === 'tagging').map((r) => r.value);
+    return this.body.filter((r) => r.purpose === 'tagging').map((r) => this.bodyValue(r));
   }
 
   /** */
@@ -69,7 +75,7 @@ export default class AnnotationItem {
     if (this.isOnlyTag()) return null;
     return this.body
       .filter((r) => r.purpose !== 'tagging')
-      .map((r) => r.value)
+      .map((r) => this.bodyValue(r))
       .join(' ');
   }
 


### PR DESCRIPTION
closes #4495 

We still don't full support https://iiif.io/api/cookbook/recipe/0139-geolocate-canvas-fragment/manifest.json but nothing really does right now. I think it requires further thought to fully implement