### PR TITLE
Don't run CI twice on PRs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,10 @@
 
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
We want to run CI on PRs to not-main (PRs into PR branches)
We want to run CI on PRs to main
We want to run CI on merge/pushes to main itself

But we don't want to run CI twice! That's what is happening now on PR branches since https://github.com/ProjectMirador/mirador/pull/4482

```
[Node.js CI / build (22.x) (pull_request)](https://github.com/ProjectMirador/mirador/actions/runs/33664333030/job/100362230040?pr=4506)
Node.js CI / build (22.x) (pull_request)Successful in 2m
[Node.js CI / build (22.x) (push)](https://github.com/ProjectMirador/mirador/actions/runs/33664329984/job/100364549983?pr=4506)
Node.js CI / build (22.x) (push)Successful in 3m
[Node.js CI / build (24.x) (pull_request)](https://github.com/ProjectMirador/mirador/actions/runs/33664333030/job/100362229475?pr=4506)
Node.js CI / build (24.x) (pull_request)Successful in 3m
[Node.js CI / build (24.x) (push)](https://github.com/ProjectMirador/mirador/actions/runs/33664329984/job/100364599898?pr=4506)
Node.js CI / build (24.x) (push)Successful in 3m
[Node.js CI / build (26.x) (pull_request)](https://github.com/ProjectMirador/mirador/actions/runs/33664333030/job/100362229726?pr=4506)
Node.js CI / build (26.x) (pull_request)Successful in 3m
[Node.js CI / build (26.x) (push)](https://github.com/ProjectMirador/mirador/actions/runs/33664329984/job/100364551612?pr=4506)
Node.js CI / build (26.x) (push)Successful in 2m
```

I think this workflow accomplishes what we want...