### PR TITLE
Remove unused __mocks__ directory

### DIFF
--- a/__mocks__/css.js
+++ b/__mocks__/css.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/vite-umd.config.js
+++ b/vite-umd.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
       name: 'Mirador',
     },
     rolldownOptions: {
-      external: ['__tests__/*', '__mocks__/*'],
+      external: ['__tests__/*'],
       output: {
         assetFileNames: 'mirador.[ext]',
         exports: 'named',

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
     ? {
         build: {
           rolldownOptions: {
-            external: ['__tests__/*', '__mocks__/*'],
+            external: ['__tests__/*'],
             input: Object.fromEntries(
               globSync('./demo/*.html').map((file) => [
                 // This remove `src/` as well as the file extension from each
@@ -41,7 +41,7 @@ export default defineConfig({
             name: 'Mirador',
           },
           rolldownOptions: {
-            external: (id) => id.startsWith('__tests__/') || id.startsWith('__mocks__/'),
+            external: (id) => id.startsWith('__tests__/'),
             output: {
               assetFileNames: 'mirador.[ext]',
               exports: 'named',


### PR DESCRIPTION
I am 99% sure this is a holdover from past styling systems. In our current world of MUI and styled components, this is not doing anything. Aside from the Vite configs there is no reference to `__mocks__` In the codebase.