### PR TITLE
Reset the selected search annotation when a new query is submitted

### DIFF
--- a/__tests__/src/reducers/search.test.js
+++ b/__tests__/src/reducers/search.test.js
@@ -23,7 +23,7 @@ describe('search reducer', () => {
             },
           },
           query: 'search terms',
-          selectedContentSearchAnnotation: [],
+          selectedContentSearchAnnotationIds: [],
         },
       },
     });
@@ -60,10 +60,62 @@ describe('search reducer', () => {
             },
           },
           query: 'search terms',
-          selectedContentSearchAnnotation: [],
+          selectedContentSearchAnnotationIds: [],
         },
       },
     });
+  });
+  it('should clear the selected annotation for a new query with REQUEST_SEARCH', () => {
+    expect(
+      searchesReducer(
+        {
+          foo: {
+            abc123: {
+              data: {
+                'search?page=xyz': {
+                  json: {},
+                },
+              },
+              query: 'initial search terms',
+              selectedContentSearchAnnotationIds: ['annotationFromThePreviousQuery'],
+            },
+          },
+        },
+        {
+          companionWindowId: 'abc123',
+          query: 'search terms',
+          searchId: 'search?page=1',
+          type: ActionTypes.REQUEST_SEARCH,
+          windowId: 'foo',
+        },
+      ).foo.abc123.selectedContentSearchAnnotationIds,
+    ).toEqual([]);
+  });
+  it('should preserve the selected annotation when paginating through a query with REQUEST_SEARCH', () => {
+    expect(
+      searchesReducer(
+        {
+          foo: {
+            abc123: {
+              data: {
+                'search?page=1': {
+                  json: {},
+                },
+              },
+              query: 'search terms',
+              selectedContentSearchAnnotationIds: ['annotationFromPageOne'],
+            },
+          },
+        },
+        {
+          companionWindowId: 'abc123',
+          query: 'search terms',
+          searchId: 'search?page=2',
+          type: ActionTypes.REQUEST_SEARCH,
+          windowId: 'foo',
+        },
+      ).foo.abc123.selectedContentSearchAnnotationIds,
+    ).toEqual(['annotationFromPageOne']);
   });
   it('should handle RECEIVE_SEARCH', () => {
     expect(

--- a/src/state/reducers/search.js
+++ b/src/state/reducers/search.js
@@ -22,7 +22,7 @@ export const searchesReducer = (state = {}, action) => {
                 },
               },
               query: action.query,
-              selectedContentSearchAnnotation: [],
+              selectedContentSearchAnnotationIds: [],
             },
           },
         };


### PR DESCRIPTION
## Summary

The `REQUEST_SEARCH` "new query" branch of `searchesReducer` resets the previously selected search annotation so incoming results start from a clean slate. It writes `selectedContentSearchAnnotation`, but that has not been the key anything reads since 3491972 ("Rename ActionTypes.SELECT_CONTENT_SEARCH_ANNOTATION to SET_CONTENT_SEARCH_CURRENT_ANNOTATIONS", June 2020), which renamed the state key to `selectedContentSearchAnnotationIds` in the `SET_CONTENT_SEARCH_CURRENT_ANNOTATIONS` case and in `getSelectedContentSearchAnnotationIds` but left this reset on the old spelling.

The reset has been writing a key no selector reads ever since, so the previous query's selected annotation id survives into the next query. Every other write of this state — `SET_CONTENT_SEARCH_CURRENT_ANNOTATIONS` and `SELECT_ANNOTATION` — uses the plural key, and the selector reads the plural key, so the singular one here is the outlier.

This changes the reset to write `selectedContentSearchAnnotationIds`.

## User-visible effects of the stale id

**A window stops switching to the first hit after its first search.** `setCanvasOfFirstSearchResult` returns early when `getSelectedContentSearchAnnotationIds` is non-empty. With the stale id in place that is always true after the first search, so the second and subsequent searches don't navigate — even with the default `switchCanvasOnSearch: true`.

**The search pagination status reads `0 of n`.** `SearchPanelNavigation` computes `currentHitIndex` by finding the selected id among the current hits. The stale id isn't among them, so `findIndex` returns `-1`, the status renders `currentHitIndex + 1` as `0`, and the previous/next buttons take their disabled state from that index.

### Reproduction

Using a manifest with a content search service (`https://purl.stanford.edu/bd323hy3111/iiif3/manifest`, 44 canvases):

1. Search `"Net assets"` — 71 hits. The window moves to canvas 3, status reads `1 of 71`. Correct.
2. Search `President` — 4 hits, the first on canvas 9.

| | canvas | status |
|---|---|---|
| before | stays on 3 | `0 of 4` |
| after | moves to 9 | `1 of 4` |

## Tests

- Added a regression test: a new query clears a pre-existing `selectedContentSearchAnnotationIds`. It fails on `main` with `expected [ 'annotationFromThePreviousQuery' ] to deeply equal []`.
- Added a companion test that paginating within the *same* query preserves the selection, since that branch intentionally leaves it alone and nothing covered it.
- The two existing `REQUEST_SEARCH` tests asserted the unread singular key, so they move to the plural spelling.

Full suite passes locally (1238 passed, 10 skipped); `eslint` and `prettier --check` are clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)