### PR TITLE
add listener for removed canvases

### DIFF
--- a/src/components/OpenSeadragonComponent.jsx
+++ b/src/components/OpenSeadragonComponent.jsx
@@ -191,6 +191,11 @@ function OpenSeadragonComponent({
       setInitialBounds(viewer);
     });
 
+    viewer.world.addHandler('remove-item', () => {
+      initialViewportSet.current = false;
+      setInitialBounds(viewer);
+    });
+
     forceUpdate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref]);


### PR DESCRIPTION
closes #4516 

https://github.com/ProjectMirador/mirador/blob/3e6fc4cc6dcefaaed1b6f182a49c42933b67da77/src/components/OpenSeadragonComponent.jsx#L112-L126 is working properly but the listener for `tile-loaded` is never going to trip because the tile is already loaded and the thing that is happening is the other images are getting removed. This just does the work. I could use some more information on how the viewportChange listener is supposed to work. It seems like we could rip out a ton of unncessary code with the bounds changed but I am not sure when else that might trip.