### PR TITLE
Fix provider logo image requests when the logo has an image service

### DIFF
--- a/__tests__/src/selectors/manifests.test.js
+++ b/__tests__/src/selectors/manifests.test.js
@@ -157,6 +157,35 @@ describe('getProviderLogo', () => {
     expect(received).toBe('https://example.org/images/logo.png');
   });
 
+  it('should return a valid image request when the logo has a IIIF image service', () => {
+    // use the fixture but overwrite the logo with the one from the IIIF Presentation 3 spec,
+    // which offers an image service rather than a plain image
+    const provider = [
+      {
+        ...manifestFixtureWithAProvider.provider[0],
+        logo: [
+          {
+            format: 'image/png',
+            height: 100,
+            id: 'https://example.org/images/logo.png/full/max/0/default.png',
+            service: [
+              {
+                id: 'https://example.org/images/logo.png',
+                profile: 'level2',
+                type: 'ImageService3',
+              },
+            ],
+            type: 'Image',
+            width: 120,
+          },
+        ],
+      },
+    ];
+    const state = { manifests: { x: { json: { ...manifestFixtureWithAProvider, provider } } } };
+    const received = getProviderLogo(state, { manifestId: 'x' });
+    expect(received).toBe('https://example.org/images/logo.png/full/,120/0/default.jpg');
+  });
+
   it('should return null if no logo', () => {
     // use the fixture but overwrite the 'provider' property to be empty/not include logo
     const state = { manifests: { x: { json: { ...manifestFixtureWithAProvider, provider: [] } } } };

--- a/src/state/selectors/manifests.js
+++ b/src/state/selectors/manifests.js
@@ -90,8 +90,6 @@ export const getManifestProviderName = createSelector(
   (provider, locale) => provider && provider[0].label && PropertyValue.parse(provider[0].label).getValue(locale),
 );
 
-const EMPTY_LOGO_OPTS = Object.freeze({});
-
 /**
  * Return the IIIF v3 provider logo.
  * @param {object} state
@@ -99,7 +97,9 @@ const EMPTY_LOGO_OPTS = Object.freeze({});
  * @returns {string|null}
  */
 export const getProviderLogo = createSelector(
-  [getProperty('provider'), (state) => getThumbnailFactory(state, EMPTY_LOGO_OPTS)],
+  // getThumbnailFactory takes (state, maxHeight, maxWidth); the provider logo is
+  // rendered at its natural size, so no dimensions are requested here.
+  [getProperty('provider'), (state) => getThumbnailFactory(state)],
   (provider, thumbnailFactory) => {
     const logo = provider && provider[0] && provider[0].logo && provider[0].logo[0];
     if (!logo) return null;


### PR DESCRIPTION
A provider logo served by a IIIF Image API service currently resolves to an image request no server will answer. `getProviderLogo` in `src/state/selectors/manifests.js:102` builds its thumbnail with `getThumbnailFactory(state, EMPTY_LOGO_OPTS)`, but `getThumbnailFactory` takes `(state, maxHeight, maxWidth)` (`src/state/selectors/thumbnails.js:9-10`), so the frozen empty object arrives as `maxHeight`. `ThumbnailFactory#iiifThumbnailUrl` then evaluates `Math.max({}, 120)` at `src/lib/ThumbnailFactory.js:131` as `NaN` and takes the `requestedMaxHeight && !requestedMaxWidth` branch at line 170, so the size becomes `,NaN`.

For the provider logo in the Presentation 3 spec's own example that yields `https://example.org/images/logo.png/full/,NaN/0/default.jpg`, and the logo silently fails to render in AttributionPanel and in ManifestListItem in the load window. Logos that are plain images with no image service are unaffected, since they return early through `staticImageUrl`.

The stray argument is left over from 82dc6c0, which moved ThumbnailFactory behind a selector; the call before that commit was `getThumbnail(new Resource(logo))` with no options at all. Dropping it restores that, so the factory applies its own 120px minimum dimension and produces `https://example.org/images/logo.png/full/,120/0/default.jpg`. The frozen constant is no longer needed to keep memoization stable: reselect 5 keys `getThumbnailFactory(state)` separately from `getThumbnailFactory(state, 80, 120)` and returns the same factory instance on repeated calls, so `getProviderLogo` stays referentially stable.

The regression test sits with the existing `getProviderLogo` cases. On main it fails with `Received: "https://example.org/images/logo.png/full/,NaN/0/default.jpg"`. Verified on Node 22.23: `npx vitest run __tests__/src/selectors/manifests.test.js` passes 49 tests, `npx vitest run` passes 192 files and 1237 tests with 2 files and 10 tests skipped, and `npm run build`, `npm run size` (568.78 kB gzipped against a 732 kB limit), `npm run lint` and `npx prettier --check` on both changed files are all clean.
