### PR TITLE
Add handler for remove-item with current refs

### DIFF
--- a/src/components/OpenSeadragonComponent.jsx
+++ b/src/components/OpenSeadragonComponent.jsx
@@ -197,6 +197,11 @@ function OpenSeadragonComponent({
       setInitialBoundsRef.current(viewer);
     });
 
+    viewer.world.addHandler('remove-item', () => {
+      initialViewportSet.current = false;
+      setInitialBoundsRef.current(viewer);
+    });
+
     forceUpdate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref]);


### PR DESCRIPTION
closes https://github.com/ProjectMirador/mirador/issues/4516

Same as [4516-remove ](https://github.com/ProjectMirador/mirador/pull/4518) but rebased and with current ref