### PR TITLE
Add setting preserveInitialCanvasOnSearch to resolve conflict between switchCanvasOnSearch and initial canvasId

### DIFF
--- a/__tests__/src/reducers/windows.test.js
+++ b/__tests__/src/reducers/windows.test.js
@@ -13,6 +13,24 @@ describe('windows reducer', () => {
       ),
     ).toEqual({
       abc123: {
+        explicitInitialCanvasId: false,
+        id: 'abc123',
+      },
+    });
+  });
+  it('should handle ADD_WINDOW with an explicit canvasId', () => {
+    expect(
+      windowsReducer(
+        {},
+        {
+          type: ActionTypes.ADD_WINDOW,
+          window: { canvasId: 'canvas-1', id: 'abc123' },
+        },
+      ),
+    ).toEqual({
+      abc123: {
+        canvasId: 'canvas-1',
+        explicitInitialCanvasId: true,
         id: 'abc123',
       },
     });

--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -423,6 +423,7 @@ describe('window-level sagas', () => {
       return expectSaga(setCanvasOfFirstSearchResult, action)
         .provide([
           [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: true }],
+          [select(getWindow, { windowId }), { explicitInitialCanvasId: false }],
           [select(getSelectedContentSearchAnnotationIds, { companionWindowId, windowId }), []],
           [select(getSortedSearchAnnotationsForCompanionWindow, { companionWindowId, windowId }), [{ id: 'a' }, { id: 'b' }]],
         ])
@@ -446,6 +447,7 @@ describe('window-level sagas', () => {
       return expectSaga(setCanvasOfFirstSearchResult, action)
         .provide([
           [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: true }],
+          [select(getWindow, { windowId }), { explicitInitialCanvasId: false }],
           [select(getSelectedContentSearchAnnotationIds, { companionWindowId, windowId }), ['y']],
         ])
         .run()
@@ -465,6 +467,82 @@ describe('window-level sagas', () => {
         .provide([[select(getWindowConfig, { windowId }), { switchCanvasOnSearch: false }]])
         .run()
         .then(({ allEffects }) => allEffects.length === 0);
+    });
+
+    it('consumes explicitInitialCanvasId but still switches when preserveInitialCanvasOnSearch is off (default)', () => {
+      const companionWindowId = 'x';
+      const windowId = 'y';
+      const action = {
+        companionWindowId,
+        type: ActionTypes.RECEIVE_SEARCH,
+        windowId,
+      };
+
+      return expectSaga(setCanvasOfFirstSearchResult, action)
+        .provide([
+          [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: true, preserveInitialCanvasOnSearch: false }],
+          [select(getWindow, { windowId }), { explicitInitialCanvasId: true }],
+          [select(getSelectedContentSearchAnnotationIds, { companionWindowId, windowId }), []],
+          [select(getSortedSearchAnnotationsForCompanionWindow, { companionWindowId, windowId }), [{ id: 'a' }]],
+        ])
+        .put({
+          payload: { explicitInitialCanvasId: false },
+          id: 'y',
+          type: 'mirador/UPDATE_WINDOW',
+        })
+        .put({
+          annotationId: 'a',
+          type: 'mirador/SELECT_ANNOTATION',
+          windowId: 'y',
+        })
+        .run();
+    });
+
+    it('consumes explicitInitialCanvasId and skips switching when preserveInitialCanvasOnSearch is on', () => {
+      const companionWindowId = 'x';
+      const windowId = 'y';
+      const action = {
+        companionWindowId,
+        type: ActionTypes.RECEIVE_SEARCH,
+        windowId,
+      };
+
+      return expectSaga(setCanvasOfFirstSearchResult, action)
+        .provide([
+          [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: true, preserveInitialCanvasOnSearch: true }],
+          [select(getWindow, { windowId }), { explicitInitialCanvasId: true }],
+        ])
+        .put({
+          payload: { explicitInitialCanvasId: false },
+          id: 'y',
+          type: 'mirador/UPDATE_WINDOW',
+        })
+        .run()
+        .then(({ allEffects }) => expect(allEffects.length).toBe(3)); // 2 selects + the one put, nothing else
+    });
+
+    it('a subsequent search still switches normally once explicitInitialCanvasId has been consumed', () => {
+      const companionWindowId = 'x';
+      const windowId = 'y';
+      const action = {
+        companionWindowId,
+        type: ActionTypes.RECEIVE_SEARCH,
+        windowId,
+      };
+
+      return expectSaga(setCanvasOfFirstSearchResult, action)
+        .provide([
+          [select(getWindowConfig, { windowId }), { switchCanvasOnSearch: true, preserveInitialCanvasOnSearch: true }],
+          [select(getWindow, { windowId }), { explicitInitialCanvasId: false }],
+          [select(getSelectedContentSearchAnnotationIds, { companionWindowId, windowId }), []],
+          [select(getSortedSearchAnnotationsForCompanionWindow, { companionWindowId, windowId }), [{ id: 'b' }]],
+        ])
+        .put({
+          annotationId: 'b',
+          type: 'mirador/SELECT_ANNOTATION',
+          windowId: 'y',
+        })
+        .run();
     });
   });
 

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -496,6 +496,7 @@ export default {
     showLocalePicker: false, // Configure locale picker for multi-lingual metadata
     sideBarOpen: false, // Configure if the sidebar (and its content panel) is open by default
     switchCanvasOnSearch: true, // Configure if Mirador should automatically switch to the canvas of the first search result
+    preserveInitialCanvasOnSearch: false, // Configure if an explicitly-requested starting canvasId should survive the window's first search (e.g. one fired by defaultSearchQuery) instead of being overridden by switchCanvasOnSearch
     panels: {
       // Configure which panels are visible in WindowSideBarButtons
       info: true,

--- a/src/state/reducers/windows.js
+++ b/src/state/reducers/windows.js
@@ -9,7 +9,17 @@ import ActionTypes from '../actions/action-types';
 export const windowsReducer = (state = {}, action) => {
   switch (action.type) {
     case ActionTypes.ADD_WINDOW:
-      return { ...state, [action.window.id]: action.window };
+      return {
+        ...state,
+        [action.window.id]: {
+          ...action.window,
+          // Tracks whether the caller explicitly requested a starting canvas
+          // (as opposed to one computed later, e.g. the manifest's first
+          // canvas) -- consumed once by setCanvasOfFirstSearchResult so a
+          // defaultSearchQuery can't silently override it on the first search.
+          explicitInitialCanvasId: action.window.canvasId !== undefined,
+        },
+      };
 
     case ActionTypes.MAXIMIZE_WINDOW:
       return {

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -217,10 +217,21 @@ export function* updateVisibleCanvases({ windowId }) {
 
 /** @private */
 export function* setCanvasOfFirstSearchResult({ companionWindowId, windowId }) {
-  const { switchCanvasOnSearch } = yield select(getWindowConfig, { windowId });
+  const { switchCanvasOnSearch, preserveInitialCanvasOnSearch } = yield select(getWindowConfig, { windowId });
   if (!switchCanvasOnSearch) {
     return;
   }
+
+  // Protect an explicitly-requested starting canvas from being overridden by
+  // the very first search (e.g. one fired automatically by defaultSearchQuery)
+  // -- but only once. Consuming the flag here means every later search (a
+  // new query the user actually typed) still jumps to its first hit normally.
+  const { explicitInitialCanvasId } = yield select(getWindow, { windowId });
+  if (explicitInitialCanvasId) {
+    yield put(updateWindow(windowId, { explicitInitialCanvasId: false }));
+    if (preserveInitialCanvasOnSearch) return;
+  }
+
   const selectedIds = yield select(getSelectedContentSearchAnnotationIds, {
     companionWindowId,
     windowId,


### PR DESCRIPTION
… switchCanvasOnSearch and initial canvasId

Idea for resolving https://github.com/ProjectMirador/mirador/issues/4226

Sort of a long/confusing setting name -- but we could document its existence.
@fitnycdigitalinitiatives would this help you? 