### PR TITLE
Defer initial viewport fit until the viewer element is visible

### DIFF
--- a/__tests__/src/components/OpenSeadragonComponent.test.jsx
+++ b/__tests__/src/components/OpenSeadragonComponent.test.jsx
@@ -9,12 +9,16 @@ describe('OpenSeadragonComponent', () => {
   let addHandler;
   let fitBoundsWithConstraints;
   let goHome;
+  let checkVisibility;
+  let element;
 
   beforeEach(() => {
     addOnceHandler = vi.fn();
     addHandler = vi.fn();
     fitBoundsWithConstraints = vi.fn();
     goHome = vi.fn();
+    checkVisibility = vi.fn(() => true);
+    element = { checkVisibility };
 
     // Mock methods used in the component
     OpenSeadragon.mockImplementation(function () {
@@ -23,6 +27,7 @@ describe('OpenSeadragonComponent', () => {
         addOnceHandler,
         canvas: {},
         destroy: vi.fn(),
+        element,
         innerTracker: {},
         removeAllHandlers: vi.fn(),
         viewport: {
@@ -54,10 +59,16 @@ describe('OpenSeadragonComponent', () => {
     if (tileLoadedHandler) tileLoadedHandler();
   }
 
+  /**
+   * Invoke the handler registered (via addHandler) for a specific event name.
+   */
+  function invokeHandlerFor(eventName) {
+    const call = addHandler.mock.calls.findLast(([name]) => name === eventName);
+    if (call) call[1]();
+  }
+
   function invokeItemAddedHandler() {
-    const { lastCall } = addHandler.mock;
-    const [_eventName, itemAddedHandler] = lastCall || [];
-    if (itemAddedHandler) itemAddedHandler();
+    invokeHandlerFor('add-item');
   }
 
   /**
@@ -68,7 +79,7 @@ describe('OpenSeadragonComponent', () => {
   function renderAndInitialize(viewerConfig = { bounds: [0, 0, 5000, 3000] }) {
     const result = render(<OpenSeadragonComponent viewerConfig={viewerConfig} />);
 
-    // Component registers a 'item-added' handler during mount to set initial viewport
+    // Component registers an 'add-item' handler during mount to set initial viewport
     invokeItemAddedHandler();
 
     // Clear mocks after initialization
@@ -126,5 +137,28 @@ describe('OpenSeadragonComponent', () => {
 
     // Should not call fitBoundsWithConstraints
     expect(fitBoundsWithConstraints).not.toHaveBeenCalled();
+  });
+
+  // Confirms OpenSeadragonComponent wires add-item/remove-item through IntersectionObserver
+  it('does not set bounds while hidden, and does once the element becomes visible (#3540)', () => {
+    let intersectionCallback;
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn(function IntersectionObserverMock(callback) {
+        intersectionCallback = callback;
+        return { disconnect: vi.fn(), observe: vi.fn() };
+      }),
+    );
+    checkVisibility.mockReturnValue(false);
+
+    render(<OpenSeadragonComponent viewerConfig={{}} />);
+    invokeItemAddedHandler();
+
+    expect(checkVisibility).toHaveBeenCalled();
+    expect(goHome).not.toHaveBeenCalled();
+
+    intersectionCallback([{ isIntersecting: true }]);
+
+    expect(goHome).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/src/hooks/useDeferUntilVisible.test.js
+++ b/__tests__/src/hooks/useDeferUntilVisible.test.js
@@ -1,0 +1,95 @@
+import { renderHook } from '@testing-library/react';
+import useDeferUntilVisible from '../../../src/hooks/useDeferUntilVisible';
+
+describe('useDeferUntilVisible', () => {
+  let disconnect;
+  let observe;
+  let intersectionCallback;
+
+  beforeEach(() => {
+    disconnect = vi.fn();
+    observe = vi.fn();
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn(function IntersectionObserverMock(callback) {
+        intersectionCallback = callback;
+        return { disconnect, observe };
+      }),
+    );
+  });
+
+  it('runs apply immediately when the element is already visible', () => {
+    const apply = vi.fn();
+    const element = { checkVisibility: vi.fn(() => true) };
+    const { result } = renderHook(() => useDeferUntilVisible());
+
+    result.current(element, apply);
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(observe).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing checkVisibility as visible rather than throwing', () => {
+    const apply = vi.fn();
+    const element = {};
+    const { result } = renderHook(() => useDeferUntilVisible());
+
+    expect(() => result.current(element, apply)).not.toThrow();
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(observe).not.toHaveBeenCalled();
+  });
+
+  it('waits for visibility before running apply when the element is hidden', () => {
+    const apply = vi.fn();
+    const element = { checkVisibility: vi.fn(() => false) };
+    const { result } = renderHook(() => useDeferUntilVisible());
+
+    result.current(element, apply);
+
+    expect(observe).toHaveBeenCalledWith(element);
+    expect(apply).not.toHaveBeenCalled();
+
+    intersectionCallback([{ isIntersecting: true }]);
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the intersection callback reports not-yet-intersecting', () => {
+    const apply = vi.fn();
+    const element = { checkVisibility: vi.fn(() => false) };
+    const { result } = renderHook(() => useDeferUntilVisible());
+
+    result.current(element, apply);
+    intersectionCallback([{ isIntersecting: false }]);
+
+    expect(apply).not.toHaveBeenCalled();
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('disconnects a still-pending observer instead of stacking a second one on a later call', () => {
+    const apply = vi.fn();
+    const element = { checkVisibility: vi.fn(() => false) };
+    const { result } = renderHook(() => useDeferUntilVisible());
+
+    result.current(element, apply);
+    expect(observe).toHaveBeenCalledTimes(1);
+
+    // called again while still hidden (e.g. another canvas change)
+    result.current(element, apply);
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(observe).toHaveBeenCalledTimes(2);
+  });
+
+  it('disconnects a pending observer on unmount', () => {
+    const apply = vi.fn();
+    const element = { checkVisibility: vi.fn(() => false) };
+    const { result, unmount } = renderHook(() => useDeferUntilVisible());
+
+    result.current(element, apply);
+    unmount();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/OpenSeadragonComponent.jsx
+++ b/src/components/OpenSeadragonComponent.jsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useReducer, useState, useCallback } from 'rea
 import { useDebouncedCallback } from 'use-debounce';
 import { useTranslation } from 'react-i18next';
 import OpenSeadragonViewerContext from '../contexts/OpenSeadragonViewerContext';
+import { useDeferUntilVisible } from '../hooks';
 
 /** Handle setting up OSD for use in mirador + react */
 function OpenSeadragonComponent({
@@ -95,6 +96,8 @@ function OpenSeadragonComponent({
   // current viewerConfig -- instead of whatever it was on the very first render.
   const setInitialBoundsRef = useRef(setInitialBounds);
   setInitialBoundsRef.current = setInitialBounds;
+
+  const runOnceVisible = useDeferUntilVisible();
 
   useEffect(() => {
     const viewer = viewerRef.current;
@@ -192,15 +195,17 @@ function OpenSeadragonComponent({
     viewerRef.current = viewer;
     setViewer(viewer);
 
-    viewer.world.addHandler('add-item', () => {
-      initialViewportSet.current = false;
-      setInitialBoundsRef.current(viewer);
-    });
-
-    viewer.world.addHandler('remove-item', () => {
-      initialViewportSet.current = false;
-      setInitialBoundsRef.current(viewer);
-    });
+    // add-item/remove-item can fire while the viewer's element has no
+    // rendered box at all (e.g. an inactive Bootstrap/tab panel, see #3540)
+    // Defer fit until it's visible.
+    const onWorldChanged = () => {
+      runOnceVisible(viewer.element, () => {
+        initialViewportSet.current = false;
+        setInitialBoundsRef.current(viewer);
+      });
+    };
+    viewer.world.addHandler('add-item', onWorldChanged);
+    viewer.world.addHandler('remove-item', onWorldChanged);
 
     forceUpdate();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,4 +1,5 @@
 import useCanvasWorldService from './useCanvasWorldService';
+import useDeferUntilVisible from './useDeferUntilVisible';
 import useThumbnailService from './useThumbnailService';
 
-export { useCanvasWorldService, useThumbnailService };
+export { useCanvasWorldService, useDeferUntilVisible, useThumbnailService };

--- a/src/hooks/useDeferUntilVisible.js
+++ b/src/hooks/useDeferUntilVisible.js
@@ -1,0 +1,36 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+/**
+ * Returns a function that runs `apply` immediately if `element` is visible,
+ * or waits (via IntersectionObserver) until it becomes visible and then runs
+ * it once. Cancels any earlier still-pending wait when a newer call
+ * supersedes it, and disconnects on unmount.
+ */
+export default function useDeferUntilVisible() {
+  const pending = useRef(null);
+
+  const runOnceVisible = useCallback((element, apply) => {
+    const isVisible = typeof element.checkVisibility !== 'function' || element.checkVisibility();
+
+    if (isVisible) {
+      apply();
+      return;
+    }
+
+    pending.current?.disconnect();
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) return;
+      observer.disconnect();
+      pending.current = null;
+      apply();
+    });
+
+    pending.current = observer;
+    observer.observe(element);
+  }, []);
+
+  useEffect(() => () => pending.current?.disconnect(), []);
+
+  return runOnceVisible;
+}


### PR DESCRIPTION
add-item/remove-item can fire while the viewer's element has no
rendered box at all (e.g. an inactive Bootstrap/tab panel), so
OpenSeadragon can't compute a fit. Extracted the wait-until-visible
logic into a reusable useDeferUntilVisible hook.

Fixes #3540
Supersedes #4506 -- needed a rebase / rewriting after #4526; extracted logic into a hook