### PR TITLE
Prefer useLayoutEffect to useEffect when removing OSD handlers

### DIFF
--- a/__tests__/src/components/AnnotationsOverlay.test.jsx
+++ b/__tests__/src/components/AnnotationsOverlay.test.jsx
@@ -86,6 +86,35 @@ describe('AnnotationsOverlay', () => {
       expect(canvasUpdate).toHaveBeenCalled();
       expect(forceRedraw).toHaveBeenCalled();
     });
+
+    // Regression test for https://github.com/ProjectMirador/mirador/issues/4525
+    it('stops responding to update-viewport once unmounted', () => {
+      const clear = vi.fn();
+      const resize = vi.fn();
+      const canvasUpdate = vi.fn();
+
+      OpenSeadragonCanvasOverlay.mockImplementation(function () {
+        return {
+          canvasUpdate,
+          clear,
+          resize,
+        };
+      });
+
+      const { component, rerender, viewer, unmount } = createWrapper({ viewer: null });
+
+      rerender(cloneElement(component, { viewer }));
+
+      unmount();
+
+      // OSD doesn't know the component unmounted -- simulate its animation
+      // loop still firing after the fact.
+      viewer.raiseEvent('update-viewport');
+
+      expect(clear).not.toHaveBeenCalled();
+      expect(resize).not.toHaveBeenCalled();
+      expect(canvasUpdate).not.toHaveBeenCalled();
+    });
   });
 
   describe('annotationsToContext', () => {

--- a/src/components/AnnotationsOverlay.jsx
+++ b/src/components/AnnotationsOverlay.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useMemo } from 'react';
+import { useRef, useEffect, useLayoutEffect, useCallback, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { useDebouncedCallback } from 'use-debounce';
@@ -252,7 +252,9 @@ export function AnnotationsOverlay({
     updateCanvas();
   }, [updateCanvas]);
 
-  useEffect(() => {
+  // useLayoutEffect lets us remove handlers at the same time that
+  // React tears down the ref to our own portaled canvas
+  useLayoutEffect(() => {
     if (!viewer) return undefined;
 
     viewer.addHandler('canvas-click', onCanvasClick);


### PR DESCRIPTION
Closes #4525

@morpheus-87 thanks for reporting and thanks also @jbaiter 

Are you able to test this and confirm it fixes your issue? I was able to reproduce your error with  https://api.digitale-sammlungen.de/iiif/presentation/v3/bsb11815183/manifest, and it was fixed with this change.