### PR TITLE
                                                                                                                                                                                                                                                                                                                                                                                                              Rename osdConfig.preserveViewport to window.preserveMiradorViewport

### DIFF
--- a/__tests__/src/actions/canvas.test.js
+++ b/__tests__/src/actions/canvas.test.js
@@ -3,13 +3,12 @@ import { thunk } from 'redux-thunk';
 
 import * as actions from '../../../src/state/actions';
 import ActionTypes from '../../../src/state/actions/action-types';
+import { getConfig, getWindowConfig } from '../../../src/state/selectors';
 
 vi.mock('../../../src/state/selectors', () => ({
   getCanvasGrouping: (state, { canvasId }) => [{ id: canvasId }],
-  getConfig: vi.fn((state) => {
-    const osdConfig = { osdConfig: { preserveViewport: true } };
-    return osdConfig;
-  }),
+  getConfig: vi.fn(() => ({ osdConfig: {} })),
+  getWindowConfig: vi.fn(() => ({ preserveMiradorViewport: true })),
   getNextCanvasGrouping: () => [{ id: 'canvasIndex-2' }],
   getPreviousCanvasGrouping: () => [{ id: 'canvasIndex-0' }],
 }));
@@ -42,7 +41,7 @@ describe('canvas actions', () => {
       const id = 'abc123';
       const expectedAction = {
         canvasId: 'a',
-        preserveViewport: true,
+        preserveMiradorViewport: true,
         type: ActionTypes.SET_CANVAS,
         visibleCanvases: ['a'],
         windowId: id,
@@ -61,7 +60,7 @@ describe('canvas actions', () => {
       const id = 'abc123';
       const expectedAction = {
         canvasId: 'canvasIndex-0',
-        preserveViewport: true,
+        preserveMiradorViewport: true,
         type: ActionTypes.SET_CANVAS,
         visibleCanvases: ['canvasIndex-0'],
         windowId: id,
@@ -80,7 +79,7 @@ describe('canvas actions', () => {
       const id = 'abc123';
       const expectedAction = {
         canvasId: 'canvasIndex-2',
-        preserveViewport: true,
+        preserveMiradorViewport: true,
         type: ActionTypes.SET_CANVAS,
         visibleCanvases: ['canvasIndex-2'],
         windowId: id,
@@ -89,6 +88,56 @@ describe('canvas actions', () => {
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
   });
+  describe('setCanvas legacy osdConfig.preserveViewport fallback (#4536)', () => {
+    let store = null;
+    let warnSpy = null;
+
+    beforeEach(() => {
+      store = createRecordingStore();
+      getWindowConfig.mockReturnValue({ preserveMiradorViewport: false });
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      getWindowConfig.mockReturnValue({ preserveMiradorViewport: true });
+      getConfig.mockReturnValue({ osdConfig: {} });
+      warnSpy.mockRestore();
+    });
+
+    it('falls back to the legacy osdConfig.preserveViewport when window.preserveMiradorViewport is unset, and warns', () => {
+      getConfig.mockReturnValue({ osdConfig: { preserveViewport: true } });
+
+      store.dispatch(actions.setCanvas('abc123', 'a'));
+
+      expect(store.getActions()[0]).toEqual(expect.objectContaining({ preserveMiradorViewport: true }));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('osdConfig.preserveViewport is deprecated'));
+    });
+
+    it('does not turn on preserveMiradorViewport just because the legacy option is present and false', () => {
+      getConfig.mockReturnValue({ osdConfig: { preserveViewport: false } });
+
+      store.dispatch(actions.setCanvas('abc123', 'a'));
+
+      expect(store.getActions()[0]).toEqual(expect.objectContaining({ preserveMiradorViewport: false }));
+    });
+
+    it('does not warn when the legacy option was never set', () => {
+      getConfig.mockReturnValue({ osdConfig: {} });
+
+      store.dispatch(actions.setCanvas('abc123', 'a'));
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('an explicit options.preserveMiradorViewport always wins over the legacy fallback', () => {
+      getConfig.mockReturnValue({ osdConfig: { preserveViewport: true } });
+
+      store.dispatch(actions.setCanvas('abc123', 'a', null, { preserveMiradorViewport: false }));
+
+      expect(store.getActions()[0]).toEqual(expect.objectContaining({ preserveMiradorViewport: false }));
+    });
+  });
+
   describe('updateViewport', () => {
     it('sets viewer state', () => {
       const id = 'abc123';

--- a/__tests__/src/reducers/viewers.test.js
+++ b/__tests__/src/reducers/viewers.test.js
@@ -77,7 +77,7 @@ describe('viewers reducer', () => {
       },
     });
   });
-  it('should handle SET_CANVAS and throwaway if !preserveViewport', () => {
+  it('should handle SET_CANVAS and throwaway if !preserveMiradorViewport', () => {
     expect(
       viewersReducer(
         {
@@ -100,7 +100,7 @@ describe('viewers reducer', () => {
       },
     });
   });
-  it('should handle SET_CANVAS and not throwaway viewports if preserveViewport', () => {
+  it('should handle SET_CANVAS and not throwaway viewports if preserveMiradorViewport', () => {
     expect(
       viewersReducer(
         {
@@ -112,7 +112,7 @@ describe('viewers reducer', () => {
           },
         },
         {
-          preserveViewport: true,
+          preserveMiradorViewport: true,
           type: ActionTypes.SET_CANVAS,
           windowId: 'abc123',
         },

--- a/__tests__/src/sagas/windows.test.js
+++ b/__tests__/src/sagas/windows.test.js
@@ -129,7 +129,7 @@ describe('window-level sagas', () => {
       return expectSaga(setWindowStartingCanvas, action)
         .provide([
           [select(getManifests), { 'manifest.json': {} }],
-          [call(setCanvas, 'x', '1', null, { preserveViewport: false }), { type: 'setCanvasThunk' }],
+          [call(setCanvas, 'x', '1', null, { preserveMiradorViewport: false }), { type: 'setCanvasThunk' }],
         ])
         .put({ type: 'setCanvasThunk' })
         .run();
@@ -147,13 +147,13 @@ describe('window-level sagas', () => {
       return expectSaga(setWindowStartingCanvas, action)
         .provide([
           [select(getManifests), { 'manifest.json': {} }],
-          [call(setCanvas, 'x', '1', null, { preserveViewport: true }), { type: 'setCanvasThunk' }],
+          [call(setCanvas, 'x', '1', null, { preserveMiradorViewport: true }), { type: 'setCanvasThunk' }],
         ])
         .put({ type: 'setCanvasThunk' })
         .run();
     });
 
-    it('overrides default preserveViewport: false when initialViewerConfig is set', () => {
+    it('overrides default preserveMiradorViewport: false when initialViewerConfig is set', () => {
       const action = {
         window: {
           canvasId: '1',
@@ -170,7 +170,7 @@ describe('window-level sagas', () => {
       return expectSaga(setWindowStartingCanvas, action)
         .provide([
           [select(getManifests), { 'manifest.json': {} }],
-          [call(setCanvas, 'x', '1', null, { preserveViewport: true }), { type: 'setCanvasThunk' }],
+          [call(setCanvas, 'x', '1', null, { preserveMiradorViewport: true }), { type: 'setCanvasThunk' }],
         ])
         .put({ type: 'setCanvasThunk' })
         .run();

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -494,6 +494,11 @@ export default {
     hideWindowTitle: false, // Configure if the window title is shown in the window title bar or not
     highlightAllAnnotations: false, // Configure whether to display annotations on the canvas by default
     showLocalePicker: false, // Configure locale picker for multi-lingual metadata
+    // Configure if Mirador should remember the pan/zoom position across page turns,
+    // instead of resetting to fit each new page. BREAKING CHANGE (#4536): replaces
+    // the old osdConfig.preserveViewport (deprecated -- still honored as a fallback,
+    // with a console warning, until removed in a future major version).
+    preserveMiradorViewport: false,
     sideBarOpen: false, // Configure if the sidebar (and its content panel) is open by default
     switchCanvasOnSearch: true, // Configure if Mirador should automatically switch to the canvas of the first search result
     panels: {
@@ -563,11 +568,14 @@ export default {
     width: null, // width of gallery view thumbnails (or null, to auto-calculate an aspect-ratio appropriate size)
   },
   osdConfig: {
-    // Default config used for OpenSeadragon
+    // Default config used for OpenSeadragon. Note that OpenSeadragon has its
+    // own, unrelated `preserveViewport` option (see its docs) -- Mirador's
+    // own "remember pan/zoom across page turns" feature previously
+    // (confusingly) shared this same field, but now lives at
+    // window.preserveMiradorViewport instead.
     alwaysBlend: false,
     blendTime: 0.1,
     preserveImageSizeOnResize: true,
-    preserveViewport: false,
     showNavigationControl: false,
     zoomPerClick: 1, // disable zoom-to-click
     zoomPerDoubleClick: 2.0,

--- a/src/state/actions/canvas.js
+++ b/src/state/actions/canvas.js
@@ -1,5 +1,29 @@
 import ActionTypes from './action-types';
-import { getNextCanvasGrouping, getPreviousCanvasGrouping, getCanvasGrouping, getConfig } from '../selectors';
+import { getNextCanvasGrouping, getPreviousCanvasGrouping, getCanvasGrouping, getWindowConfig, getConfig } from '../selectors';
+
+/**
+ * Pre-#4536, Mirador's "remember pan/zoom across page turns" feature lived at
+ * osdConfig.preserveViewport, entangled with OpenSeadragon's own same-named
+ * (and unrelated) option. Deployments that set osdConfig.preserveViewport
+ * explicitly would otherwise have that setting silently dropped by the
+ * window.preserveMiradorViewport rename. Warn and fall back to it until this
+ * legacy support is removed in a future major version.
+ * @param {object} state
+ * @param {boolean} preserveMiradorViewport
+ * @returns {boolean}
+ */
+function withLegacyPreserveViewportFallback(state, preserveMiradorViewport) {
+  const legacyPreserveViewport = getConfig(state).osdConfig?.preserveViewport;
+  if (legacyPreserveViewport === undefined) return preserveMiradorViewport;
+
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[Mirador] osdConfig.preserveViewport is deprecated and no longer controls OpenSeadragon directly. ' +
+      'Set window.preserveMiradorViewport instead -- this fallback will be removed in a future release.',
+  );
+
+  return preserveMiradorViewport || legacyPreserveViewport;
+}
 
 /**
  * setCanvas - action creator
@@ -11,7 +35,7 @@ import { getNextCanvasGrouping, getPreviousCanvasGrouping, getCanvasGrouping, ge
 export function setCanvas(windowId, canvasId, newGroup = undefined, options = {}) {
   return (dispatch, getState) => {
     const state = getState();
-    const { preserveViewport } = getConfig(state).osdConfig;
+    const { preserveMiradorViewport } = getWindowConfig(state, { windowId });
     let visibleCanvases = newGroup;
 
     if (!visibleCanvases) {
@@ -21,7 +45,8 @@ export function setCanvas(windowId, canvasId, newGroup = undefined, options = {}
 
     dispatch({
       canvasId,
-      preserveViewport: options?.preserveViewport ?? preserveViewport,
+      preserveMiradorViewport:
+        options?.preserveMiradorViewport ?? withLegacyPreserveViewportFallback(state, preserveMiradorViewport),
       type: ActionTypes.SET_CANVAS,
       visibleCanvases,
       windowId,

--- a/src/state/reducers/viewers.js
+++ b/src/state/reducers/viewers.js
@@ -30,7 +30,7 @@ export const viewersReducer = (state = {}, action) => {
     case ActionTypes.SET_WINDOW_VIEW_TYPE:
       return set([action.windowId], null, state);
     case ActionTypes.SET_CANVAS:
-      if (!action.preserveViewport) {
+      if (!action.preserveMiradorViewport) {
         return set([action.windowId], null, state);
       }
       return state;

--- a/src/state/sagas/windows.js
+++ b/src/state/sagas/windows.js
@@ -95,10 +95,10 @@ export function* setWindowStartingCanvas(action) {
   const windowId = action.id || action.window.id;
 
   if (canvasId) {
-    // Preserve viewport when initialViewerConfig exists, event if the preserveViewport OSD setting is set to false
-    const preserveViewport = !!action.payload || !!action.window?.initialViewerConfig;
-    // When canvasId is explicitly provided, always pass preserveViewport flag
-    const thunk = yield call(setCanvas, windowId, canvasId, null, { preserveViewport });
+    // Preserve viewport when initialViewerConfig exists, even if the preserveMiradorViewport setting is false
+    const preserveMiradorViewport = !!action.payload || !!action.window?.initialViewerConfig;
+    // When canvasId is explicitly provided, always pass preserveMiradorViewport flag
+    const thunk = yield call(setCanvas, windowId, canvasId, null, { preserveMiradorViewport });
     yield put(thunk);
   } else {
     const getMiradorManifest = yield select(getMiradorManifestWrapper);
@@ -109,10 +109,10 @@ export function* setWindowStartingCanvas(action) {
       const startCanvas =
         miradorManifest.startCanvas || miradorManifest.canvasAt(canvasIndex || 0) || miradorManifest.canvasAt(0);
       if (startCanvas) {
-        const preserveViewport = !!action.payload || !!action.window?.initialViewerConfig;
-        // When canvas is calculated, only pass preserveViewport when true
-        const thunk = preserveViewport
-          ? yield call(setCanvas, windowId, startCanvas.id, null, { preserveViewport })
+        const preserveMiradorViewport = !!action.payload || !!action.window?.initialViewerConfig;
+        // When canvas is calculated, only pass preserveMiradorViewport when true
+        const thunk = preserveMiradorViewport
+          ? yield call(setCanvas, windowId, startCanvas.id, null, { preserveMiradorViewport })
           : yield call(setCanvas, windowId, startCanvas.id);
         yield put(thunk);
       }


### PR DESCRIPTION
Mirador's logic for "remember pan/zoom across page turns" feature has lived at osdConfig.preserveViewport since #4220, which entangles it with OSD's functionality. I was debugging mysterious regressions and came across this in the OSD code:

```
if (world.getItemCount() === 1 && !preserveViewport) {
  viewport.goHome(true);
}
``` 
https://github.com/openseadragon/openseadragon/blob/807996ade9879d135642d36d6878705dc5520370/src/viewer.js#L1976

In the current architecture, Mirador's own add-item/remove-item handler refit the viewport on every tile event, which happened to overwrite OSD's goHome() a moment after it fired — masking the bug rather than preventing it.

However in the course of debugging a cluster of viewport bugs, I decided to try not waiting on `add-item` or `tile-loaded` -- but rather read the canvas size from the manifest. These OSD handler/listeners were a big focus over the last weeks and caused mysterious problems.
We shouldn't need to be waiting on async OSD events which are running on a different lifecycle clock than our React code. This change is coming in the next stacked PR.

I am proposing to set preserveViewport in OSD permanently to true, so that we never run into this internal `goHome` event for single items. Move the concept of keeping the zoom/pan consistent between pages into a Mirador setting and out of OSD.

Breaking change for deployments with osdConfig.preserveViewport is handled with a fallback that reads the legacy field with a console deprecation warning if the new field isn't set.

This PR is up for discussion; there may be a better approach than hardcoding OSD's `preserveViewport` but I think given the number of bugs that keep cropping up we need a new approach to preserveViewport and sizing the viewer. 

